### PR TITLE
Strip tags before message length check

### DIFF
--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -195,7 +195,8 @@ class Enhanced_Internal_Contact_Form {
         if (!preg_match('/^\d{5}$/', $data['zip'])) {
             $this->form_errors[] = 'Zip must be 5 digits.';
         }
-        if (strlen($data['message']) < 10) {
+        $plain = wp_strip_all_tags($data['message']);
+        if (strlen($plain) < 20) {
             $this->form_errors[] = 'Message too short.';
         }
         return $this->form_errors;


### PR DESCRIPTION
## Summary
- sanitize message with `wp_strip_all_tags` before validating
- require at least 20 plain-text characters in message

## Testing
- `php -l includes/class-enhanced-icf.php`


------
https://chatgpt.com/codex/tasks/task_e_688fe29376f8832dac773fe7ebeda974