### PR TITLE
Add hook-based mail error logging

### DIFF
--- a/eform.php
+++ b/eform.php
@@ -19,6 +19,7 @@ add_action('wp_enqueue_scripts', function () {
 
 // Include supporting files
 require_once plugin_dir_path(__FILE__) . 'includes/logger.php';
+require_once plugin_dir_path(__FILE__) . 'includes/mail-error-logger.php';
 require_once plugin_dir_path(__FILE__) . 'includes/class-enhanced-icf.php';
 
 // Initialize plugin

--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -173,13 +173,6 @@ class Enhanced_Internal_Contact_Form {
                         return;
                     }
 
-                    // Additional SMTP error logging (if available)
-                    global $phpmailer;
-                    if (defined('DEBUG_LEVEL') && DEBUG_LEVEL === 3 && isset($phpmailer)) {
-                        $smtpErrorMsg = $phpmailer->ErrorInfo ?? 'No detailed error';
-                        enhanced_icf_log('Detailed SMTP Error', ['error' => $smtpErrorMsg]);
-                    }
-
                     $error_type = 'Email Sending Failure';
                     $details    = [
                         'form_data' => $data,

--- a/includes/mail-error-logger.php
+++ b/includes/mail-error-logger.php
@@ -1,0 +1,25 @@
+<?php
+// includes/mail-error-logger.php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+add_action('wp_mail_failed', function ($wp_error) {
+    if (is_wp_error($wp_error)) {
+        $data = $wp_error->get_error_data();
+        enhanced_icf_log('Mail send failure', [
+            'error'   => $wp_error->get_error_message(),
+            'details' => is_array($data) ? $data : [],
+        ]);
+    }
+});
+
+add_action('phpmailer_init', function ($phpmailer) {
+    if (defined('DEBUG_LEVEL') && DEBUG_LEVEL === 3) {
+        $phpmailer->SMTPDebug = 3;
+        $phpmailer->Debugoutput = function ($str, $level) {
+            enhanced_icf_log('PHPMailer Debug', ['debug' => $str, 'level' => $level]);
+        };
+    }
+});


### PR DESCRIPTION
## Summary
- Add `wp_mail_failed` listener and `phpmailer_init` debug hook for centralized mail error logging
- Require new logger in main plugin bootstrap and remove direct PHPMailer debugging

## Testing
- `php -l eform.php`
- `php -l includes/mail-error-logger.php`
- `php -l includes/class-enhanced-icf.php`


------
https://chatgpt.com/codex/tasks/task_e_688fed202da0832db7efc1cdec8ed366