### PR TITLE
Cache server data in logging functions

### DIFF
--- a/includes/logger.php
+++ b/includes/logger.php
@@ -2,6 +2,7 @@
 // includes/logger.php
 
 function enhanced_icf_log($message, $context = [], $form_data = null) {
+    $server = $_SERVER;
     $log_file = WP_CONTENT_DIR . '/forms.log';
 
     if (defined('DEBUG_LEVEL') && DEBUG_LEVEL == 2 && $form_data !== null) {
@@ -12,8 +13,8 @@ function enhanced_icf_log($message, $context = [], $form_data = null) {
     $context['ip'] = enhanced_icf_get_ip();
     $context['source'] = 'Enhanced iContact Form';
     $context['message'] = $message;
-    $context['user_agent'] = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field($_SERVER['HTTP_USER_AGENT']) : '';
-    $context['referrer'] = isset($_SERVER['HTTP_REFERER']) ? sanitize_text_field($_SERVER['HTTP_REFERER']) : 'No referrer';
+    $context['user_agent'] = isset($server['HTTP_USER_AGENT']) ? sanitize_text_field($server['HTTP_USER_AGENT']) : '';
+    $context['referrer'] = isset($server['HTTP_REFERER']) ? sanitize_text_field($server['HTTP_REFERER']) : 'No referrer';
 
     $jsonLogEntry = json_encode($context, JSON_PRETTY_PRINT);
     if (json_last_error() !== JSON_ERROR_NONE) {
@@ -28,6 +29,7 @@ function enhanced_icf_log($message, $context = [], $form_data = null) {
 }
 
 function enhanced_icf_get_ip() {
+    $server = $_SERVER;
     $candidates = [
         'HTTP_X_FORWARDED_FOR',
         'HTTP_CLIENT_IP',
@@ -36,8 +38,8 @@ function enhanced_icf_get_ip() {
     ];
 
     foreach ($candidates as $key) {
-        if (!empty($_SERVER[$key])) {
-            $ipList = explode(',', $_SERVER[$key]);
+        if (!empty($server[$key])) {
+            $ipList = explode(',', $server[$key]);
             foreach ($ipList as $ip) {
                 $ip = trim($ip);
 
@@ -53,8 +55,8 @@ function enhanced_icf_get_ip() {
 
     // Fallback (still return something, even if private)
     foreach ($candidates as $key) {
-        if (!empty($_SERVER[$key])) {
-            $ipList = explode(',', $_SERVER[$key]);
+        if (!empty($server[$key])) {
+            $ipList = explode(',', $server[$key]);
             foreach ($ipList as $ip) {
                 $ip = trim($ip);
                 if (filter_var($ip, FILTER_VALIDATE_IP)) {


### PR DESCRIPTION
## Summary
- Avoid repeated superglobal lookups by caching `$_SERVER` in `enhanced_icf_log`
- Reuse cached `$_SERVER` in `enhanced_icf_get_ip` for cleaner IP detection

## Testing
- `php -l includes/logger.php`
- `php -r 'define("WP_CONTENT_DIR", sys_get_temp_dir()); function sanitize_text_field($str){return $str;} @unlink(WP_CONTENT_DIR."/forms.log"); $_SERVER["HTTP_USER_AGENT"]="TestAgent"; $_SERVER["HTTP_REFERER"]="http://example.com"; $_SERVER["REMOTE_ADDR"]="203.0.113.5"; include "includes/logger.php"; enhanced_icf_log("Test message"); $log=file_get_contents(WP_CONTENT_DIR."/forms.log"); echo $log; echo "\nIP: ".enhanced_icf_get_ip();'`

------
https://chatgpt.com/codex/tasks/task_e_688fee869464832dadcce837ac7d8ba9