### PR TITLE
Format phone number and retain form data

### DIFF
--- a/templates/form-custom.php
+++ b/templates/form-custom.php
@@ -3,7 +3,7 @@
 ?>
 <form method="post" action="">
     <?php Enhanced_Internal_Contact_Form::render_hidden_fields('default'); ?>
-    <div><textarea name="message_input" placeholder="Write your message..." rows="6" required></textarea></div>
-    <div><input type="email" name="email_input" placeholder="Enter Your Email*" required></div>
+    <div><textarea name="message_input" placeholder="Write your message..." rows="6" required><?php echo esc_textarea($this->form_data['message'] ?? ''); ?></textarea></div>
+    <div><input type="email" name="email_input" placeholder="Enter Your Email*" required value="<?php echo esc_attr($this->form_data['email'] ?? ''); ?>"></div>
     <div><button type="submit" name="enhanced_form_submit_custom">Click to Send</button></div>
 </form>

--- a/templates/form-default.php
+++ b/templates/form-default.php
@@ -7,17 +7,17 @@
     <form class="contactform" id="maincontactform" aria-label="Contact Form" method="post" action="">
         <?php Enhanced_Internal_Contact_Form::render_hidden_fields('default'); ?>
         <div class="inputwrap">
-            <input class="form_field" type="text" name="name_input" autocomplete="name" required aria-required="true" aria-label="Your Name" placeholder="Your Name" value="">
+            <input class="form_field" type="text" name="name_input" autocomplete="name" required aria-required="true" aria-label="Your Name" placeholder="Your Name" value="<?php echo esc_attr($this->form_data['name'] ?? ''); ?>">
         </div>
         <div class="inputwrap">
-            <input class="form_field" type="email" name="email_input" autocomplete="email" required aria-required="true" aria-label="Your Email" placeholder="Your eMail" value="">
+            <input class="form_field" type="email" name="email_input" autocomplete="email" required aria-required="true" aria-label="Your Email" placeholder="Your eMail" value="<?php echo esc_attr($this->form_data['email'] ?? ''); ?>">
         </div>
         <div class="columns_nomargins inputwrap">
-            <input class="form_field" type="tel" name="tel_input" autocomplete="tel" required aria-required="true" aria-label="Phone" placeholder="Phone" value="">
-            <input class="form_field" type="text" name="zip_input" autocomplete="postal-code" required aria-required="true" aria-label="Project Zip Code" placeholder="Project Zip Code" value="">
+            <input class="form_field" type="tel" name="tel_input" autocomplete="tel" required aria-required="true" aria-label="Phone" placeholder="Phone" value="<?php echo esc_attr($this->format_phone($this->form_data['phone'] ?? '')); ?>">
+            <input class="form_field" type="text" name="zip_input" autocomplete="postal-code" required aria-required="true" aria-label="Project Zip Code" placeholder="Project Zip Code" value="<?php echo esc_attr($this->form_data['zip'] ?? ''); ?>">
         </div>
         <div class="inputwrap">
-            <textarea cols="21" rows="5" name="message_input" required aria-required="true" aria-label="Message" placeholder="Please describe your project and let us know if there is any urgency"></textarea>
+            <textarea cols="21" rows="5" name="message_input" required aria-required="true" aria-label="Message" placeholder="Please describe your project and let us know if there is any urgency"><?php echo esc_textarea($this->form_data['message'] ?? ''); ?></textarea>
         </div>
 
         <input type="hidden" name="submitted" value="1" aria-hidden="true">


### PR DESCRIPTION
## Summary
- store phone numbers as digits-only and format as `xxx-xxx-xxxx` when emailing
- keep submitted form data to repopulate fields after validation errors

## Testing
- `php -l includes/class-enhanced-icf.php`
- `php -l templates/form-default.php`
- `php -l templates/form-custom.php`


------
https://chatgpt.com/codex/tasks/task_e_688ff23986ac832d8895e556274253a3