### PR TITLE
Respect inline CSS setting in contact form

### DIFF
--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -73,12 +73,16 @@ class Enhanced_Internal_Contact_Form {
         $atts = shortcode_atts( [
             'template'     => 'default',
             'style'        => 'false',
-            'useinlinecss' => 'true',
+            'useinlinecss' => null,
         ], $atts );
 
-        $template            = sanitize_key( $atts['template'] );
-        $this->load_css      = filter_var( $atts['style'], FILTER_VALIDATE_BOOLEAN );
-        $this->use_inline_css = filter_var( $atts['useinlinecss'], FILTER_VALIDATE_BOOLEAN );
+        $template       = sanitize_key( $atts['template'] );
+        $this->load_css = filter_var( $atts['style'], FILTER_VALIDATE_BOOLEAN );
+
+        // Only override the inline CSS preference if explicitly provided
+        if ( null !== $atts['useinlinecss'] ) {
+            $this->use_inline_css = filter_var( $atts['useinlinecss'], FILTER_VALIDATE_BOOLEAN );
+        }
 
         return $this->render_form( $template );
     }


### PR DESCRIPTION
## Summary
- avoid overriding inline CSS preference unless `useinlinecss` attribute is supplied

## Testing
- `php -l includes/class-enhanced-icf.php`


------
https://chatgpt.com/codex/tasks/task_e_6890088e0f44832db99c44a045acc56b