### PR TITLE
Refactor form handling into dedicated processor

### DIFF
--- a/eform.php
+++ b/eform.php
@@ -20,7 +20,10 @@ add_action('wp_enqueue_scripts', function () {
 // Include supporting files
 require_once plugin_dir_path(__FILE__) . 'includes/logger.php';
 require_once plugin_dir_path(__FILE__) . 'includes/mail-error-logger.php';
+require_once plugin_dir_path(__FILE__) . 'includes/class-enhanced-icf-processor.php';
 require_once plugin_dir_path(__FILE__) . 'includes/class-enhanced-icf.php';
 
 // Initialize plugin
-new Enhanced_Internal_Contact_Form();
+$processor = new Enhanced_ICF_Form_Processor( enhanced_icf_get_ip() );
+new Enhanced_Internal_Contact_Form( $processor );
+

--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -1,0 +1,153 @@
+<?php
+// includes/class-enhanced-icf-processor.php
+
+class Enhanced_ICF_Form_Processor {
+    private $ipaddress;
+
+    public function __construct($ipaddress) {
+        $this->ipaddress = $ipaddress;
+    }
+
+    public function process_form_submission($template) {
+        $error_type = '';
+        $details    = [];
+        $user_msg   = '';
+
+        if (empty($_POST)) {
+            $error_type = 'Form Left Empty';
+            $user_msg   = 'No data submitted.';
+        } elseif (!isset($_POST['enhanced_icf_form_nonce']) || !wp_verify_nonce($_POST['enhanced_icf_form_nonce'], 'enhanced_icf_form_action')) {
+            $error_type = 'Nonce Failed';
+            $user_msg   = 'Invalid submission detected.';
+        } elseif (!empty($_POST['enhanced_url'])) {
+            $error_type = 'Bot Alert: Honeypot Filled';
+            $user_msg   = 'Bot test failed.';
+        } else {
+            $submit_time = $_POST['enhanced_form_time'] ?? 0;
+            if (time() - intval($submit_time) < 5) {
+                $error_type = 'Bot Alert: Fast Submission';
+                $user_msg   = 'Submission too fast. Please try again.';
+            } elseif (empty($_POST['enhanced_js_check'])) {
+                $error_type = 'Bot Alert: JS Check Missing';
+                $user_msg   = 'JavaScript must be enabled.';
+            } else {
+                $data = [
+                    'name'    => sanitize_text_field($_POST['name_input'] ?? ''),
+                    'email'   => sanitize_email($_POST['email_input'] ?? ''),
+                    'phone'   => preg_replace('/\D/', '', $_POST['tel_input'] ?? ''),
+                    'zip'     => sanitize_text_field($_POST['zip_input'] ?? ''),
+                    'message' => sanitize_textarea_field($_POST['message_input'] ?? ''),
+                ];
+
+                $errors = $this->validate_form($data);
+                if ($errors) {
+                    $error_type = 'Validation errors';
+                    $details    = [
+                        'errors'    => $errors,
+                        'form_data' => $data,
+                    ];
+                    $user_msg = implode('<br>', $errors);
+                } else {
+                    $sent = $this->send_email($data);
+                    if ($sent) {
+                        return [ 'success' => true ];
+                    }
+                    $error_type = 'Email Sending Failure';
+                    $details    = [
+                        'form_data' => $data,
+                    ];
+                    $user_msg   = 'Something went wrong. Please try again later.';
+                }
+            }
+        }
+
+        $user_msg = $this->log_and_message($error_type, $details, $user_msg);
+
+        return [
+            'success'   => false,
+            'message'   => $user_msg,
+            'form_data' => $details['form_data'] ?? [],
+        ];
+    }
+
+    public function format_phone($digits) {
+        if (preg_match('/^(\d{3})(\d{3})(\d{4})$/', $digits, $matches)) {
+            return $matches[1] . '-' . $matches[2] . '-' . $matches[3];
+        }
+        return $digits;
+    }
+
+    private function validate_form($data) {
+        $errors = [];
+        if (strlen($data['name']) < 3) {
+            $errors[] = 'Name too short.';
+        }
+        if (!preg_match("/^[\\p{L}\\s.'-]+$/u", $data['name'])) {
+            $errors[] = 'Invalid characters in name.';
+        }
+        if (!filter_var($data['email'], FILTER_VALIDATE_EMAIL)) {
+            $errors[] = 'Invalid email.';
+        }
+        if (empty($data['phone'])) {
+            $errors[] = 'Phone is required.';
+        } elseif (!preg_match('/^\\d{10}$/', $data['phone'])) {
+            $errors[] = 'Invalid phone number.';
+        }
+        if (!preg_match('/^\\d{5}$/', $data['zip'])) {
+            $errors[] = 'Zip must be 5 digits.';
+        }
+        $plain = wp_strip_all_tags($data['message']);
+        if (strlen($plain) < 20) {
+            $errors[] = 'Message too short.';
+        }
+        return $errors;
+    }
+
+    private function build_email_body($data) {
+        $ip = esc_html($this->ipaddress);
+        $rows = [
+            ['label' => 'Name',    'value' => esc_html($data['name'])],
+            ['label' => 'Email',   'value' => esc_html($data['email'])],
+            ['label' => 'Phone',   'value' => esc_html($this->format_phone($data['phone']))],
+            ['label' => 'Zip',     'value' => esc_html($data['zip'])],
+            ['label' => 'Message', 'value' => nl2br(esc_html($data['message'])), 'valign' => 'top'],
+            ['label' => 'Sent from', 'value' => $ip],
+        ];
+
+        $message_rows = '';
+        foreach ($rows as $row) {
+            $valign = isset($row['valign']) ? " valign='{$row['valign']}'" : '';
+            $message_rows .= "<tr><td{$valign}><strong>{$row['label']}:</strong></td><td>{$row['value']}</td></tr>";
+        }
+
+        return '<table cellpadding="4" cellspacing="0" border="0">' . $message_rows . '</table>';
+    }
+
+    private function send_email($data) {
+        $to = get_option('admin_email');
+        $subject = 'Quote Request - ' . sanitize_text_field($data['name']);
+        $message = $this->build_email_body($data);
+
+        $noreply = 'noreply@flooringartists.com';
+        $headers = [];
+        $headers[] = "From: {$data['name']} <{$noreply}>";
+        $headers[] = 'Content-Type: text/html; charset=UTF-8';
+        $headers[] = 'Content-Transfer-Encoding: 8bit';
+        $headers[] = "Reply-To: {$data['name']} <{$data['email']}>";
+
+        return wp_mail($to, $subject, $message, $headers);
+    }
+
+    private function log_and_message($type, $details = [], $user_msg = '') {
+        $form_data = $details['form_data'] ?? null;
+        if (isset($details['form_data'])) {
+            unset($details['form_data']);
+        }
+        enhanced_icf_log($type, [
+            'type'    => $type,
+            'details' => $details,
+        ], $form_data);
+
+        return $user_msg;
+    }
+}

--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -2,8 +2,6 @@
 // includes/class-enhanced-icf.php
 
 class Enhanced_Internal_Contact_Form {
-    private $form_errors = [];
-    private $ipaddress;
     private $redirect_url='/?page_id=20'; // Set to empty string to disable redirect
     private $success_message = '<div class="form-message success">Thank you! Your message has been sent.</div>';
     private $error_message = '';
@@ -15,9 +13,10 @@ class Enhanced_Internal_Contact_Form {
     private $processed_template = ''; // Track which template was submitted
     private $loaded_css_templates = []; // Track templates whose CSS is loaded
     private $css_printed = false; // Ensure CSS only printed once
+    private $processor;
 
-    public function __construct() {
-        $this->ipaddress = enhanced_icf_get_ip();
+    public function __construct( Enhanced_ICF_Form_Processor $processor ) {
+        $this->processor = $processor;
 
         // Process form early
         add_action('init',              [$this, 'maybe_handle_form']);
@@ -26,6 +25,7 @@ class Enhanced_Internal_Contact_Form {
         // Register shortcode to render form
         add_shortcode('enhanced_icf_shortcode', [$this, 'handle_shortcode']);
     }
+
     public function maybe_handle_form() {
         if ('POST' !== $_SERVER['REQUEST_METHOD']) {
             return;
@@ -36,10 +36,16 @@ class Enhanced_Internal_Contact_Form {
 
         if (isset($_POST[$submit_key])) {
             $this->processed_template = $template;
-            // Process form; sets $this->form_submitted on success
-            $this->process_form_submission($template);
+            $result = $this->processor->process_form_submission($template);
+            if ($result['success']) {
+                $this->form_submitted = true;
+            } else {
+                $this->error_message = '<div class="form-message error">' . $result['message'] . '</div>';
+                $this->form_data     = $result['form_data'] ?? [];
+            }
         }
     }
+
     /**
      * Redirect after successful submission, before rendering template.
      */
@@ -147,152 +153,8 @@ class Enhanced_Internal_Contact_Form {
         return $form_html;
     }
 
-    /**
-     * Helper to standardize logging and user-facing error responses.
-     */
-    private function log_and_message($type, $details = [], $user_msg = '') {
-        $form_data = $details['form_data'] ?? null;
-        if (isset($details['form_data'])) {
-            unset($details['form_data']);
-        }
-        enhanced_icf_log($type, [
-            'type'    => $type,
-            'details' => $details,
-        ], $form_data);
-
-        $this->error_message = '<div class="form-message error">' . $user_msg . '</div>';
-    }
-
-    private function process_form_submission($template) {
-        $error_type = '';
-        $details    = [];
-        $user_msg   = '';
-
-        if (empty($_POST)) {
-            $error_type = 'Form Left Empty';
-            $user_msg   = 'No data submitted.';
-        } elseif (!isset($_POST['enhanced_icf_form_nonce']) || !wp_verify_nonce($_POST['enhanced_icf_form_nonce'], 'enhanced_icf_form_action')) {
-            $error_type = 'Nonce Failed';
-            $user_msg   = 'Invalid submission detected.';
-        } elseif (!empty($_POST['enhanced_url'])) {
-            $error_type = 'Bot Alert: Honeypot Filled';
-            $user_msg   = 'Bot test failed.';
-        } else {
-            $submit_time = $_POST['enhanced_form_time'] ?? 0;
-            if (time() - intval($submit_time) < 5) {
-                $error_type = 'Bot Alert: Fast Submission';
-                $user_msg   = 'Submission too fast. Please try again.';
-            } elseif (empty($_POST['enhanced_js_check'])) {
-                $error_type = 'Bot Alert: JS Check Missing';
-                $user_msg   = 'JavaScript must be enabled.';
-            } else {
-                $data = [
-                    'name'    => sanitize_text_field($_POST['name_input'] ?? ''),
-                    'email'   => sanitize_email($_POST['email_input'] ?? ''),
-                    // Store digits only for flexible formatting later
-                    'phone'   => preg_replace('/\D/', '', $_POST['tel_input'] ?? ''),
-                    'zip'     => sanitize_text_field($_POST['zip_input'] ?? ''),
-                    'message' => sanitize_textarea_field($_POST['message_input'] ?? '')
-                ];
-
-                // Preserve submitted data so the form can be repopulated after errors
-                $this->form_data = $data;
-
-                $errors = $this->validate_form($data);
-                if ($errors) {
-                    $error_type = 'Validation errors';
-                    $details    = [
-                        'errors'    => $errors,
-                        'form_data' => $data,
-                    ];
-                    $user_msg = implode('<br>', $errors);
-                } else {
-                    $sent = $this->send_email($data);
-                    if ($sent) {
-                        $this->form_submitted = true;
-                        return;
-                    }
-
-                    $error_type = 'Email Sending Failure';
-                    $details    = [
-                        'form_data' => $data,
-                    ];
-                    $user_msg   = 'Something went wrong. Please try again later.';
-                }
-            }
-        }
-
-        $this->log_and_message($error_type, $details, $user_msg);
-    }
-
-    private function validate_form($data) {
-        $this->form_errors = [];
-        if (strlen($data['name']) < 3) {
-            $this->form_errors[] = 'Name too short.';
-        }
-        if (!preg_match("/^[\\p{L}\\s.'-]+$/u", $data['name'])) {
-            $this->form_errors[] = 'Invalid characters in name.';
-        }
-        if (!filter_var($data['email'], FILTER_VALIDATE_EMAIL)) {
-            $this->form_errors[] = 'Invalid email.';
-        }
-        if (empty($data['phone'])) {
-            $this->form_errors[] = 'Phone is required.';
-        } elseif (!preg_match('/^\d{10}$/', $data['phone'])) {
-            $this->form_errors[] = 'Invalid phone number.';
-        }
-        if (!preg_match('/^\d{5}$/', $data['zip'])) {
-            $this->form_errors[] = 'Zip must be 5 digits.';
-        }
-        $plain = wp_strip_all_tags($data['message']);
-        if (strlen($plain) < 20) {
-            $this->form_errors[] = 'Message too short.';
-        }
-        return $this->form_errors;
-    }
-
-    // Format a 10 digit phone number as xxx-xxx-xxxx
-    private function format_phone($digits) {
-        if (preg_match('/^(\d{3})(\d{3})(\d{4})$/', $digits, $matches)) {
-            return $matches[1] . '-' . $matches[2] . '-' . $matches[3];
-        }
-        return $digits;
-    }
-
-    private function build_email_body($data, $ip) {
-    $rows = [
-        ['label' => 'Name',    'value' => esc_html($data['name'])],
-        ['label' => 'Email',   'value' => esc_html($data['email'])],
-        ['label' => 'Phone',   'value' => esc_html($this->format_phone($data['phone']))],
-        ['label' => 'Zip',     'value' => esc_html($data['zip'])],
-        ['label' => 'Message', 'value' => nl2br(esc_html($data['message'])), 'valign' => 'top'],
-        ['label' => 'Sent from', 'value' => esc_html($ip)],
-    ];
-
-    $message_rows = '';
-    foreach ($rows as $row) {
-        $valign = isset($row['valign']) ? " valign='{$row['valign']}'" : '';
-        $message_rows .= "<tr><td{$valign}><strong>{$row['label']}:</strong></td><td>{$row['value']}</td></tr>";
-    }
-
-    return '<table cellpadding="4" cellspacing="0" border="0">' . $message_rows . '</table>';
-    }
-
-    private function send_email($data) {
-        $to = get_option('admin_email');
-        $subject = 'Quote Request - ' . sanitize_text_field( $data['name'] );
-        $ip = esc_html($this->ipaddress);
-        $message = $this->build_email_body($data, $ip);
-
-        $noreply = 'noreply@flooringartists.com';
-        $headers = [];
-        $headers[] = "From: {$data['name']} <{$noreply}>";
-        $headers[] = 'Content-Type: text/html; charset=UTF-8';
-        $headers[] = 'Content-Transfer-Encoding: 8bit';
-        $headers[] = "Reply-To: {$data['name']} <{$data['email']}>";
-
-        $sent = wp_mail($to, $subject, $message, $headers);
-
-        return $sent;
+    // Expose phone formatting for templates
+    public function format_phone($digits) {
+        return $this->processor->format_phone($digits);
     }
 }


### PR DESCRIPTION
## Summary
- Move validation and email handling into new `Enhanced_ICF_Form_Processor` class
- Keep `Enhanced_Internal_Contact_Form` focused on rendering and delegate processing
- Bootstrap plugin by instantiating processor and passing it to the form

## Testing
- `php -l eform.php`
- `php -l includes/class-enhanced-icf.php`
- `php -l includes/class-enhanced-icf-processor.php`


------
https://chatgpt.com/codex/tasks/task_e_68900bfd0580832d90660bcdc98d4972