### PR TITLE
refactor: migrate logging to Logger class

### DIFF
--- a/eform.php
+++ b/eform.php
@@ -19,11 +19,12 @@ add_action('wp_enqueue_scripts', function () {
 
 // Include supporting files
 require_once plugin_dir_path(__FILE__) . 'includes/logger.php';
+$logger = new Logger();
 require_once plugin_dir_path(__FILE__) . 'includes/mail-error-logger.php';
 require_once plugin_dir_path(__FILE__) . 'includes/class-enhanced-icf-processor.php';
 require_once plugin_dir_path(__FILE__) . 'includes/class-enhanced-icf.php';
 
 // Initialize plugin
-$processor = new Enhanced_ICF_Form_Processor( enhanced_icf_get_ip() );
+$processor = new Enhanced_ICF_Form_Processor( $logger );
 new Enhanced_Internal_Contact_Form( $processor );
 

--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -3,9 +3,11 @@
 
 class Enhanced_ICF_Form_Processor {
     private $ipaddress;
+    private $logger;
 
-    public function __construct($ipaddress) {
-        $this->ipaddress = $ipaddress;
+    public function __construct(Logger $logger) {
+        $this->logger    = $logger;
+        $this->ipaddress = $logger->get_ip();
     }
 
     public function process_form_submission($template) {
@@ -143,7 +145,7 @@ class Enhanced_ICF_Form_Processor {
         if (isset($details['form_data'])) {
             unset($details['form_data']);
         }
-        enhanced_icf_log($type, [
+        $this->logger->log($type, [
             'type'    => $type,
             'details' => $details,
         ], $form_data);

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -1,71 +1,73 @@
 <?php
 // includes/logger.php
 
-function enhanced_icf_log($message, $context = [], $form_data = null) {
-    $server = $_SERVER;
-    $log_file = WP_CONTENT_DIR . '/forms.log';
+class Logger {
+    public function log($message, $context = [], $form_data = null) {
+        $server   = $_SERVER;
+        $log_file = WP_CONTENT_DIR . '/forms.log';
 
-    if (defined('DEBUG_LEVEL') && DEBUG_LEVEL == 2 && $form_data !== null) {
-        $safe_data = array_intersect_key($form_data, array_flip(['name', 'zip']));
-        $context['form_data'] = $safe_data;
-    }
+        if (defined('DEBUG_LEVEL') && DEBUG_LEVEL == 2 && $form_data !== null) {
+            $safe_data         = array_intersect_key($form_data, array_flip(['name', 'zip']));
+            $context['form_data'] = $safe_data;
+        }
 
-    $context['ip'] = enhanced_icf_get_ip();
-    $context['source'] = 'Enhanced iContact Form';
-    $context['message'] = $message;
-    $context['user_agent'] = isset($server['HTTP_USER_AGENT']) ? sanitize_text_field($server['HTTP_USER_AGENT']) : '';
-    $context['referrer'] = isset($server['HTTP_REFERER']) ? sanitize_text_field($server['HTTP_REFERER']) : 'No referrer';
+        $context['ip']        = $this->get_ip();
+        $context['source']    = 'Enhanced iContact Form';
+        $context['message']   = $message;
+        $context['user_agent'] = isset($server['HTTP_USER_AGENT']) ? sanitize_text_field($server['HTTP_USER_AGENT']) : '';
+        $context['referrer']  = isset($server['HTTP_REFERER']) ? sanitize_text_field($server['HTTP_REFERER']) : 'No referrer';
 
-    $jsonLogEntry = json_encode($context, JSON_PRETTY_PRINT);
-    if (json_last_error() !== JSON_ERROR_NONE) {
-        $jsonLogEntry = 'Log encoding error: ' . json_last_error_msg();
-    }
+        $jsonLogEntry = json_encode($context, JSON_PRETTY_PRINT);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $jsonLogEntry = 'Log encoding error: ' . json_last_error_msg();
+        }
 
-    if (!empty($log_file) && is_writable(dirname($log_file))) {
-        error_log($jsonLogEntry . "\n", 3, $log_file);
-    } else {
-        error_log($jsonLogEntry);
-    }
-}
-
-function enhanced_icf_get_ip() {
-    $server = $_SERVER;
-    $candidates = [
-        'HTTP_X_FORWARDED_FOR',
-        'HTTP_CLIENT_IP',
-        'HTTP_CF_CONNECTING_IP', // Cloudflare
-        'REMOTE_ADDR'
-    ];
-
-    foreach ($candidates as $key) {
-        if (!empty($server[$key])) {
-            $ipList = explode(',', $server[$key]);
-            foreach ($ipList as $ip) {
-                $ip = trim($ip);
-
-                // Filter out local/private/reserved IPs
-                if (
-                    filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)
-                ) {
-                    return $ip;
-                }
-            }
+        if (!empty($log_file) && is_writable(dirname($log_file))) {
+            error_log($jsonLogEntry . "\n", 3, $log_file);
+        } else {
+            error_log($jsonLogEntry);
         }
     }
 
-    // Fallback (still return something, even if private)
-    foreach ($candidates as $key) {
-        if (!empty($server[$key])) {
-            $ipList = explode(',', $server[$key]);
-            foreach ($ipList as $ip) {
-                $ip = trim($ip);
-                if (filter_var($ip, FILTER_VALIDATE_IP)) {
-                    return $ip;
+    public function get_ip() {
+        $server = $_SERVER;
+        $candidates = [
+            'HTTP_X_FORWARDED_FOR',
+            'HTTP_CLIENT_IP',
+            'HTTP_CF_CONNECTING_IP', // Cloudflare
+            'REMOTE_ADDR'
+        ];
+
+        foreach ($candidates as $key) {
+            if (!empty($server[$key])) {
+                $ipList = explode(',', $server[$key]);
+                foreach ($ipList as $ip) {
+                    $ip = trim($ip);
+
+                    // Filter out local/private/reserved IPs
+                    if (
+                        filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)
+                    ) {
+                        return $ip;
+                    }
                 }
             }
         }
-    }
 
-    return 'UNKNOWN';
+        // Fallback (still return something, even if private)
+        foreach ($candidates as $key) {
+            if (!empty($server[$key])) {
+                $ipList = explode(',', $server[$key]);
+                foreach ($ipList as $ip) {
+                    $ip = trim($ip);
+                    if (filter_var($ip, FILTER_VALIDATE_IP)) {
+                        return $ip;
+                    }
+                }
+            }
+        }
+
+        return 'UNKNOWN';
+    }
 }
 

--- a/includes/mail-error-logger.php
+++ b/includes/mail-error-logger.php
@@ -5,21 +5,21 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-add_action('wp_mail_failed', function ($wp_error) {
+add_action('wp_mail_failed', function ($wp_error) use ($logger) {
     if (is_wp_error($wp_error)) {
         $data = $wp_error->get_error_data();
-        enhanced_icf_log('Mail send failure', [
+        $logger->log('Mail send failure', [
             'error'   => $wp_error->get_error_message(),
             'details' => is_array($data) ? $data : [],
         ]);
     }
 });
 
-add_action('phpmailer_init', function ($phpmailer) {
+add_action('phpmailer_init', function ($phpmailer) use ($logger) {
     if (defined('DEBUG_LEVEL') && DEBUG_LEVEL === 3) {
-        $phpmailer->SMTPDebug = 3;
-        $phpmailer->Debugoutput = function ($str, $level) {
-            enhanced_icf_log('PHPMailer Debug', ['debug' => $str, 'level' => $level]);
+        $phpmailer->SMTPDebug  = 3;
+        $phpmailer->Debugoutput = function ($str, $level) use ($logger) {
+            $logger->log('PHPMailer Debug', ['debug' => $str, 'level' => $level]);
         };
     }
 });


### PR DESCRIPTION
## Summary
- wrap logging helpers in a reusable `Logger` class with `log` and `get_ip` methods
- bootstrap plugin with a single `Logger` instance and inject into form processor and error hooks
- update form processor and mail error hooks to use the injected logger

## Testing
- `php -l includes/logger.php`
- `php -l includes/mail-error-logger.php`
- `php -l includes/class-enhanced-icf-processor.php`
- `php -l eform.php`


------
https://chatgpt.com/codex/tasks/task_e_689021763818832d9f1a7302012e8cee