### PR TITLE
Ensure custom template identifies itself in hidden fields

### DIFF
--- a/templates/form-custom.php
+++ b/templates/form-custom.php
@@ -2,7 +2,7 @@
 // templates/form-custom.php
 ?>
 <form method="post" action="">
-    <?php Enhanced_Internal_Contact_Form::render_hidden_fields('default'); ?>
+    <?php Enhanced_Internal_Contact_Form::render_hidden_fields('custom'); ?>
     <div><textarea name="message_input" placeholder="Write your message..." rows="6" required><?php echo esc_textarea($this->form_data['message'] ?? ''); ?></textarea></div>
     <div><input type="email" name="email_input" placeholder="Enter Your Email*" required value="<?php echo esc_attr($this->form_data['email'] ?? ''); ?>"></div>
     <div><button type="submit" name="enhanced_form_submit_custom">Click to Send</button></div>


### PR DESCRIPTION
## Summary
- switch form-custom hidden field identifier from `default` to `custom`

## Testing
- `php -l templates/form-custom.php`
- `php /tmp/test_custom.php`


------
https://chatgpt.com/codex/tasks/task_e_689027db920c832db6dc9951e2cc816b