### PR TITLE
Add timestamp to log entries and document sample line

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@ This plugin includes logging for form activity. Log entries are written to
 and typically not directly accessible via the web. The plugin will create this
 location if it does not exist and enforce restrictive permissions (`0640`) on
 the log file.
+
+Each entry is stored as JSON and includes a `timestamp` field. An example
+entry looks like this:
+
+```
+{
+    "timestamp": "2024-01-01T12:00:00+00:00",
+    "ip": "203.0.113.5",
+    "source": "Enhanced iContact Form",
+    "message": "Submitted form",
+    "user_agent": "Mozilla/5.0",
+    "referrer": "No referrer"
+}
+```

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -23,6 +23,7 @@ class Logger {
             $context['form_data'] = $safe_data;
         }
 
+        $context['timestamp'] = date('c');
         $context['ip']        = $this->get_ip();
         $context['source']    = 'Enhanced iContact Form';
         $context['message']   = $message;


### PR DESCRIPTION
## Summary
- include an ISO 8601 `timestamp` on every log entry
- document a sample log entry with the new field

## Testing
- `php -l includes/logger.php`


------
https://chatgpt.com/codex/tasks/task_e_689151ed8398832da413f1fb85982cc9