### PR TITLE
Add configurable log rotation for forms.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This plugin includes logging for form activity. Log entries are written to
 `WP_CONTENT_DIR/uploads/logs/forms.log`, which is outside the plugin directory
 and typically not directly accessible via the web. The plugin will create this
 location if it does not exist and enforce restrictive permissions (`0640`) on
-the log file.
+the log file. When the log file exceeds 5MB it is rotated with a timestamped
+suffix and a new log is started. Administrators may adjust the limit by defining
+`EFORM_LOG_FILE_MAX_SIZE` (bytes) or using the `eform_log_file_max_size` filter.
 
 Each entry is stored as JSON and includes a `timestamp` field. An example
 entry looks like this:

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -18,6 +18,20 @@ class Logger {
             @chmod( $log_file, 0640 ); // Ensure restrictive permissions on creation
         }
 
+        // Allow administrators to adjust the max file size via constant or filter.
+        $max_size = defined( 'EFORM_LOG_FILE_MAX_SIZE' ) ? EFORM_LOG_FILE_MAX_SIZE : 5 * 1024 * 1024;
+        if ( function_exists( 'apply_filters' ) ) {
+            $max_size = apply_filters( 'eform_log_file_max_size', $max_size, $log_file );
+        }
+
+        if ( file_exists( $log_file ) && filesize( $log_file ) >= $max_size ) {
+            $timestamp    = date( 'YmdHis' );
+            $rotated_file = $log_dir . '/forms-' . $timestamp . '.log';
+            @rename( $log_file, $rotated_file );
+            touch( $log_file );
+            @chmod( $log_file, 0640 );
+        }
+
         if (defined('DEBUG_LEVEL') && DEBUG_LEVEL == 2 && $form_data !== null) {
             $safe_data         = array_intersect_key($form_data, array_flip(['name', 'zip']));
             $context['form_data'] = $safe_data;


### PR DESCRIPTION
## Summary
- rotate forms.log when it exceeds a size limit
- allow admins to adjust limit via `EFORM_LOG_FILE_MAX_SIZE` or `eform_log_file_max_size`
- document log rotation and size limit options

## Testing
- `php -l includes/logger.php`


------
https://chatgpt.com/codex/tasks/task_e_689156ef64c8832dbac656f795fb0732