### PR TITLE
Allow customizing logged form fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ entry looks like this:
     "referrer": "No referrer"
 }
 ```
+
+## Logged Form Fields
+
+When `DEBUG_LEVEL` is set to `2`, selected form fields may be included in the log
+for troubleshooting. By default only the `name` and `zip` fields are stored. To
+adjust this list you may either:
+
+1. Update the `eform_log_safe_fields` option in WordPress to contain an array of
+   allowed field keys.
+2. Use the `eform_log_safe_fields` filter to programmatically modify the array of
+   field keys prior to logging.
+
+Both approaches will replace the default values, ensuring that only explicitly
+approved fields are recorded.

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -33,7 +33,17 @@ class Logger {
         }
 
         if (defined('DEBUG_LEVEL') && DEBUG_LEVEL == 2 && $form_data !== null) {
-            $safe_data         = array_intersect_key($form_data, array_flip(['name', 'zip']));
+            $safe_fields = ['name', 'zip'];
+            if ( function_exists( 'get_option' ) ) {
+                $option_fields = get_option( 'eform_log_safe_fields', [] );
+                if ( ! empty( $option_fields ) && is_array( $option_fields ) ) {
+                    $safe_fields = $option_fields;
+                }
+            }
+            if ( function_exists( 'apply_filters' ) ) {
+                $safe_fields = apply_filters( 'eform_log_safe_fields', $safe_fields, $form_data );
+            }
+            $safe_data             = array_intersect_key( $form_data, array_flip( $safe_fields ) );
             $context['form_data'] = $safe_data;
         }
 


### PR DESCRIPTION
## Summary
- make logged form fields configurable via `eform_log_safe_fields` option/filter
- document `eform_log_safe_fields` for administrators

## Testing
- `php -l includes/logger.php`


------
https://chatgpt.com/codex/tasks/task_e_689158595784832d983f4a4e02241897