### PR TITLE
Log successful submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ adjust this list you may either:
 
 Both approaches will replace the default values, ensuring that only explicitly
 approved fields are recorded.
+
+## Successful Submission Logging
+
+By default a successful form submission writes a "Form submission sent" entry to
+the log. The entry records only the safe fields configured via the
+`eform_log_safe_fields` option or filter. Administrators may disable this logging
+by setting `DEBUG_LEVEL` to `0` or filtering the behavior:
+
+```
+add_filter('eform_log_successful_submission', '__return_false');
+```

--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -50,6 +50,27 @@ class Enhanced_ICF_Form_Processor {
         }
 
         if ($this->send_email($data)) {
+            $should_log = true;
+            if (defined('DEBUG_LEVEL') && DEBUG_LEVEL < 1) {
+                $should_log = false;
+            }
+            if (function_exists('apply_filters')) {
+                $should_log = apply_filters('eform_log_successful_submission', $should_log, $data);
+            }
+            if ($should_log) {
+                $safe_fields = ['name', 'zip'];
+                if (function_exists('get_option')) {
+                    $option_fields = get_option('eform_log_safe_fields', []);
+                    if (!empty($option_fields) && is_array($option_fields)) {
+                        $safe_fields = $option_fields;
+                    }
+                }
+                if (function_exists('apply_filters')) {
+                    $safe_fields = apply_filters('eform_log_safe_fields', $safe_fields, $data);
+                }
+                $safe_data = array_intersect_key($data, array_flip($safe_fields));
+                $this->logger->log('Form submission sent', ['form_data' => $safe_data]);
+            }
             return [ 'success' => true ];
         }
 


### PR DESCRIPTION
## Summary
- log a "Form submission sent" message after successful email delivery
- allow administrators to disable this logging via DEBUG_LEVEL or `eform_log_successful_submission`

## Testing
- `php -l includes/class-enhanced-icf-processor.php`


------
https://chatgpt.com/codex/tasks/task_e_6891590837ac832d8ed2185c069d3eff