### PR TITLE
Inject logger into Enhanced_Internal_Contact_Form

### DIFF
--- a/eform.php
+++ b/eform.php
@@ -26,5 +26,5 @@ require_once plugin_dir_path(__FILE__) . 'includes/class-enhanced-icf.php';
 
 // Initialize plugin
 $processor = new Enhanced_ICF_Form_Processor( $logger );
-new Enhanced_Internal_Contact_Form( $processor );
+new Enhanced_Internal_Contact_Form( $processor, $logger );
 

--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -14,9 +14,11 @@ class Enhanced_Internal_Contact_Form {
     private $loaded_css_templates = []; // Track templates whose CSS is loaded
     private $css_printed = false; // Ensure CSS only printed once
     private $processor;
+    private $logger;
 
-    public function __construct( Enhanced_ICF_Form_Processor $processor ) {
+    public function __construct( Enhanced_ICF_Form_Processor $processor, Logger $logger ) {
         $this->processor = $processor;
+        $this->logger    = $logger;
 
         // Process submissions before rendering any template
         add_action('template_redirect', [$this, 'maybe_handle_form'], 1);
@@ -154,7 +156,7 @@ class Enhanced_Internal_Contact_Form {
             return ob_get_clean();
         }
 
-        error_log( sprintf( 'Enhanced ICF template missing: %s', $template_path ) );
+        $this->logger->log( sprintf( 'Enhanced ICF template missing: %s', $template_path ) );
 
         return '<p>Form template not found.</p>';
     }


### PR DESCRIPTION
## Summary
- Inject `Logger` into `Enhanced_Internal_Contact_Form` and store the instance
- Replace direct `error_log` usage with `$logger->log()` calls
- Pass the `Logger` from the plugin bootstrap when instantiating the form handler

## Testing
- `php -l includes/class-enhanced-icf.php`
- `php -l eform.php`


------
https://chatgpt.com/codex/tasks/task_e_68915c5a990c832d9a1aa29ebec7ec3a