### PR TITLE
Refactor safe field logging into helper

### DIFF
--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -55,18 +55,9 @@ class Enhanced_ICF_Form_Processor {
                 $should_log = apply_filters('eform_log_successful_submission', $should_log, $data);
             }
             if ($should_log) {
-                $safe_fields = ['name', 'zip'];
-                if (function_exists('get_option')) {
-                    $option_fields = get_option('eform_log_safe_fields', []);
-                    if (!empty($option_fields) && is_array($option_fields)) {
-                        $safe_fields = $option_fields;
-                    }
-                }
-                if (function_exists('apply_filters')) {
-                    $safe_fields = apply_filters('eform_log_safe_fields', $safe_fields, $data);
-                }
-                $safe_data = array_intersect_key($data, array_flip($safe_fields));
-                $this->logger->log('Form submission sent', ['form_data' => $safe_data]);
+                $safe_fields = eform_get_safe_fields( $data );
+                $safe_data   = array_intersect_key( $data, array_flip( $safe_fields ) );
+                $this->logger->log( 'Form submission sent', [ 'form_data' => $safe_data ] );
             }
             return [ 'success' => true ];
         }


### PR DESCRIPTION
## Summary
- add `eform_get_safe_fields()` helper for central safe field retrieval
- use new helper in logger and form processor instead of duplicate logic

## Testing
- `php -l includes/logger.php`
- `php -l includes/class-enhanced-icf-processor.php`


------
https://chatgpt.com/codex/tasks/task_e_68916df76b68832db9f16856206a3538