### PR TITLE
Refactor form processor to accept submitted data array

### DIFF
--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -36,7 +36,7 @@ class Enhanced_Internal_Contact_Form {
 
         if (isset($_POST[$submit_key])) {
             $this->processed_template = $template;
-            $result = $this->processor->process_form_submission($template);
+            $result = $this->processor->process_form_submission($template, $_POST);
             if ($result['success']) {
                 $this->form_submitted = true;
                 if ( ! empty( $this->redirect_url ) ) {


### PR DESCRIPTION
## Summary
- Pass posted data from `Enhanced_Internal_Contact_Form::maybe_handle_form` to the processor
- Update `Enhanced_ICF_Form_Processor` to receive and validate submitted data arrays
- Adjust validation helpers to read from the provided array instead of `$_POST`

## Testing
- `php -l includes/class-enhanced-icf-processor.php`
- `php -l includes/class-enhanced-icf.php`


------
https://chatgpt.com/codex/tasks/task_e_6891720c57ec832d9a96f4618a76fd85