### PR TITLE
refactor: localize post data handling

### DIFF
--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -10,9 +10,9 @@ class Enhanced_ICF_Form_Processor {
         $this->ipaddress = $logger->get_ip();
     }
 
-    public function process_form_submission($template) {
-        if (empty($_POST)) {
-            return $this->error_response('Form Left Empty', [], 'No data submitted.');
+    public function process_form_submission( $template, $post_data ) {
+        if ( empty( $post_data ) ) {
+            return $this->error_response( 'Form Left Empty', [], 'No data submitted.' );
         }
 
         $validators = [
@@ -22,18 +22,18 @@ class Enhanced_ICF_Form_Processor {
             'check_js_enabled',
         ];
 
-        foreach ($validators as $validator) {
-            if ($error = $this->$validator()) {
-                return $this->error_response($error['type'], [], $error['message']);
+        foreach ( $validators as $validator ) {
+            if ( $error = $this->$validator( $post_data ) ) {
+                return $this->error_response( $error['type'], [], $error['message'] );
             }
         }
 
         $data = [
-            'name'    => sanitize_text_field($_POST['name_input'] ?? ''),
-            'email'   => sanitize_email($_POST['email_input'] ?? ''),
-            'phone'   => preg_replace('/\\D/', '', $_POST['tel_input'] ?? ''),
-            'zip'     => sanitize_text_field($_POST['zip_input'] ?? ''),
-            'message' => sanitize_textarea_field($_POST['message_input'] ?? ''),
+            'name'    => sanitize_text_field( $post_data['name_input'] ?? '' ),
+            'email'   => sanitize_email( $post_data['email_input'] ?? '' ),
+            'phone'   => preg_replace( '/\\D/', '', $post_data['tel_input'] ?? '' ),
+            'zip'     => sanitize_text_field( $post_data['zip_input'] ?? '' ),
+            'message' => sanitize_textarea_field( $post_data['message_input'] ?? '' ),
         ];
 
         $errors = $this->validate_form($data);
@@ -73,8 +73,8 @@ class Enhanced_ICF_Form_Processor {
         return $digits;
     }
 
-    private function check_nonce() {
-        if (!isset($_POST['enhanced_icf_form_nonce']) || !wp_verify_nonce($_POST['enhanced_icf_form_nonce'], 'enhanced_icf_form_action')) {
+    private function check_nonce( $post_data ) {
+        if ( ! isset( $post_data['enhanced_icf_form_nonce'] ) || ! wp_verify_nonce( $post_data['enhanced_icf_form_nonce'], 'enhanced_icf_form_action' ) ) {
             return [
                 'type'    => 'Nonce Failed',
                 'message' => 'Invalid submission detected.',
@@ -83,8 +83,8 @@ class Enhanced_ICF_Form_Processor {
         return [];
     }
 
-    private function check_honeypot() {
-        if (!empty($_POST['enhanced_url'])) {
+    private function check_honeypot( $post_data ) {
+        if ( ! empty( $post_data['enhanced_url'] ) ) {
             return [
                 'type'    => 'Bot Alert: Honeypot Filled',
                 'message' => 'Bot test failed.',
@@ -93,9 +93,9 @@ class Enhanced_ICF_Form_Processor {
         return [];
     }
 
-    private function check_submission_time() {
-        $submit_time = $_POST['enhanced_form_time'] ?? 0;
-        if (time() - intval($submit_time) < 5) {
+    private function check_submission_time( $post_data ) {
+        $submit_time = $post_data['enhanced_form_time'] ?? 0;
+        if ( time() - intval( $submit_time ) < 5 ) {
             return [
                 'type'    => 'Bot Alert: Fast Submission',
                 'message' => 'Submission too fast. Please try again.',
@@ -104,8 +104,8 @@ class Enhanced_ICF_Form_Processor {
         return [];
     }
 
-    private function check_js_enabled() {
-        if (empty($_POST['enhanced_js_check'])) {
+    private function check_js_enabled( $post_data ) {
+        if ( empty( $post_data['enhanced_js_check'] ) ) {
             return [
                 'type'    => 'Bot Alert: JS Check Missing',
                 'message' => 'JavaScript must be enabled.',

--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -31,12 +31,13 @@ class Enhanced_Internal_Contact_Form {
             return;
         }
 
-        $template = sanitize_key($_POST['enhanced_template'] ?? 'default');
+        $post_data  = wp_unslash( $_POST );
+        $template   = sanitize_key( $post_data['enhanced_template'] ?? 'default' );
         $submit_key = 'enhanced_form_submit_' . $template;
 
-        if (isset($_POST[$submit_key])) {
+        if ( isset( $post_data[ $submit_key ] ) ) {
             $this->processed_template = $template;
-            $result = $this->processor->process_form_submission($template);
+            $result                   = $this->processor->process_form_submission( $template, $post_data );
             if ($result['success']) {
                 $this->form_submitted = true;
                 if ( ! empty( $this->redirect_url ) ) {


### PR DESCRIPTION
## Summary
- Store `$_POST` in a local unslashed `$post_data` within `maybe_handle_form` for template detection and submission checks.
- Pass this array to the form processor, whose validators operate on the provided data instead of the global `$_POST`.

## Testing
- `php -l includes/class-enhanced-icf.php`
- `php -l includes/class-enhanced-icf-processor.php`


------
https://chatgpt.com/codex/tasks/task_e_689174c32020832da40914b69af12320