### PR TITLE
Sanitize and reuse submitted form data

### DIFF
--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -31,12 +31,14 @@ class Enhanced_Internal_Contact_Form {
             return;
         }
 
-        $template = sanitize_key($_POST['enhanced_template'] ?? 'default');
+        $submitted_data = array_map( 'sanitize_text_field', wp_unslash( $_POST ) );
+
+        $template   = sanitize_key( $submitted_data['enhanced_template'] ?? 'default' );
         $submit_key = 'enhanced_form_submit_' . $template;
 
-        if (isset($_POST[$submit_key])) {
+        if ( isset( $submitted_data[ $submit_key ] ) ) {
             $this->processed_template = $template;
-            $result = $this->processor->process_form_submission($template, $_POST);
+            $result                   = $this->processor->process_form_submission( $template, $submitted_data );
             if ($result['success']) {
                 $this->form_submitted = true;
                 if ( ! empty( $this->redirect_url ) ) {


### PR DESCRIPTION
## Summary
- Sanitize and store form submission data in `maybe_handle_form`
- Replace direct `$_POST` references with sanitized `$submitted_data`

## Testing
- `php -l includes/class-enhanced-icf.php`


------
https://chatgpt.com/codex/tasks/task_e_68917ab86850832d86040c74f512b8ef