### PR TITLE
Add PHPUnit tests and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,12 @@ by setting `DEBUG_LEVEL` to `0` or filtering the behavior:
 ```
 add_filter('eform_log_successful_submission', '__return_false');
 ```
+
+## Running Tests
+
+Install dependencies and execute the test suite:
+
+```bash
+composer install
+vendor/bin/phpunit
+```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "eform/eform",
+    "require-dev": {
+        "phpunit/phpunit": "^10"
+    },
+    "require": {}
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="eform">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/EnhancedICFFormProcessorTest.php
+++ b/tests/EnhancedICFFormProcessorTest.php
@@ -1,0 +1,70 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class EnhancedICFFormProcessorTest extends TestCase {
+    private $processor;
+
+    protected function setUp(): void {
+        $this->processor = new Enhanced_ICF_Form_Processor(new Logger());
+    }
+
+    private function valid_submission(): array {
+        return [
+            'enhanced_icf_form_nonce' => 'valid',
+            'enhanced_url' => '',
+            'enhanced_form_time' => time() - 10,
+            'enhanced_js_check' => '1',
+            'name_input' => 'John Doe',
+            'email_input' => 'john@example.com',
+            'tel_input' => '1234567890',
+            'zip_input' => '12345',
+            'message_input' => str_repeat('a', 25),
+        ];
+    }
+
+    public function test_successful_submission() {
+        $data = $this->valid_submission();
+        $result = $this->processor->process_form_submission('default', $data);
+        $this->assertTrue($result['success']);
+    }
+
+    public function test_nonce_failure() {
+        $data = $this->valid_submission();
+        $data['enhanced_icf_form_nonce'] = 'invalid';
+        $result = $this->processor->process_form_submission('default', $data);
+        $this->assertFalse($result['success']);
+        $this->assertSame('Invalid submission detected.', $result['message']);
+    }
+
+    public function test_honeypot_failure() {
+        $data = $this->valid_submission();
+        $data['enhanced_url'] = 'http://spam';
+        $result = $this->processor->process_form_submission('default', $data);
+        $this->assertFalse($result['success']);
+        $this->assertSame('Bot test failed.', $result['message']);
+    }
+
+    public function test_submission_time_failure() {
+        $data = $this->valid_submission();
+        $data['enhanced_form_time'] = time();
+        $result = $this->processor->process_form_submission('default', $data);
+        $this->assertFalse($result['success']);
+        $this->assertSame('Submission too fast. Please try again.', $result['message']);
+    }
+
+    public function test_js_check_failure() {
+        $data = $this->valid_submission();
+        unset($data['enhanced_js_check']);
+        $result = $this->processor->process_form_submission('default', $data);
+        $this->assertFalse($result['success']);
+        $this->assertSame('JavaScript must be enabled.', $result['message']);
+    }
+
+    public function test_field_validation_failure() {
+        $data = $this->valid_submission();
+        $data['name_input'] = 'Jo';
+        $result = $this->processor->process_form_submission('default', $data);
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('Name too short.', $result['message']);
+    }
+}

--- a/tests/EnhancedInternalContactFormTest.php
+++ b/tests/EnhancedInternalContactFormTest.php
@@ -1,0 +1,79 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class EnhancedInternalContactFormTest extends TestCase {
+    public function test_maybe_handle_form_forwards_sanitized_data_and_sets_flag_on_success() {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST = [
+            'enhanced_template' => 'default',
+            'enhanced_form_submit_default' => 'send',
+            'name_input' => ' <b>Jane</b> ',
+        ];
+
+        $processor = $this->getMockBuilder(Enhanced_ICF_Form_Processor::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['process_form_submission'])
+            ->getMock();
+        $processor->expects($this->once())
+            ->method('process_form_submission')
+            ->with('default', [
+                'enhanced_template' => 'default',
+                'enhanced_form_submit_default' => 'send',
+                'name_input' => 'Jane',
+            ])
+            ->willReturn(['success' => true]);
+
+        $form = new Enhanced_Internal_Contact_Form($processor, new Logger());
+        $ref = new ReflectionClass($form);
+        $prop = $ref->getProperty('redirect_url');
+        $prop->setAccessible(true);
+        $prop->setValue($form, '');
+
+        $form->maybe_handle_form();
+
+        $submitted = $ref->getProperty('form_submitted');
+        $submitted->setAccessible(true);
+        $this->assertTrue($submitted->getValue($form));
+    }
+
+    public function test_maybe_handle_form_handles_error_response() {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST = [
+            'enhanced_template' => 'default',
+            'enhanced_form_submit_default' => 'send',
+            'name_input' => ' <b>Jane</b> ',
+        ];
+
+        $processor = $this->getMockBuilder(Enhanced_ICF_Form_Processor::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['process_form_submission'])
+            ->getMock();
+        $processor->expects($this->once())
+            ->method('process_form_submission')
+            ->willReturn([
+                'success' => false,
+                'message' => 'Error happened',
+                'form_data' => ['name' => 'Jane']
+            ]);
+
+        $form = new Enhanced_Internal_Contact_Form($processor, new Logger());
+        $ref = new ReflectionClass($form);
+        $prop = $ref->getProperty('redirect_url');
+        $prop->setAccessible(true);
+        $prop->setValue($form, '');
+
+        $form->maybe_handle_form();
+
+        $submitted = $ref->getProperty('form_submitted');
+        $submitted->setAccessible(true);
+        $this->assertFalse($submitted->getValue($form));
+
+        $error = $ref->getProperty('error_message');
+        $error->setAccessible(true);
+        $this->assertSame('<div class="form-message error">Error happened</div>', $error->getValue($form));
+
+        $formData = $ref->getProperty('form_data');
+        $formData->setAccessible(true);
+        $this->assertSame(['name' => 'Jane'], $formData->getValue($form));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,69 @@
+<?php
+// Minimal WordPress stubs for testing
+function sanitize_text_field($str){
+    $str = strip_tags($str);
+    $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
+    return trim($str);
+}
+function sanitize_email($email){
+    return filter_var($email, FILTER_SANITIZE_EMAIL);
+}
+function sanitize_textarea_field($str){
+    return strip_tags($str);
+}
+function wp_verify_nonce($nonce,$action){
+    return $nonce === 'valid';
+}
+function wp_strip_all_tags($str){
+    return strip_tags($str);
+}
+function esc_html($text){
+    return htmlspecialchars($text, ENT_QUOTES);
+}
+function get_option($name,$default=''){
+    if($name==='admin_email'){return 'admin@example.com';}
+    return $default;
+}
+function apply_filters($tag,$value){
+    return $value;
+}
+function wp_mail($to,$subject,$message,$headers){
+    return true;
+}
+function eform_get_safe_fields($data){
+    return array_keys($data);
+}
+function sanitize_key($key){
+    return preg_replace('/[^a-z0-9_]/','', strtolower($key));
+}
+function wp_unslash($value){
+    return $value;
+}
+function wp_safe_redirect($url){
+    $GLOBALS['redirected_to']=$url;
+}
+function esc_url_raw($url){
+    return $url;
+}
+function add_action($hook,$callback,$priority=10){
+}
+function add_shortcode($tag,$callback){
+}
+function plugin_dir_path($file){
+    return dirname($file) . '/';
+}
+function did_action($hook){return false;}
+function has_action($hook,$callback){return false;}
+function wp_register_style(){ }
+function wp_enqueue_style(){ }
+function wp_print_styles(){ }
+function wp_mkdir_p($dir){return true;}
+function wp_nonce_field(){ }
+
+class Logger {
+    public function get_ip(){ return '127.0.0.1'; }
+    public function log($message,$context=[],$form_data=null){ }
+}
+
+require_once __DIR__.'/../includes/class-enhanced-icf-processor.php';
+require_once __DIR__.'/../includes/class-enhanced-icf.php';


### PR DESCRIPTION
## Summary
- add PHPUnit configuration and bootstrap stubs
- cover Enhanced_ICF_Form_Processor submission scenarios
- test Enhanced_Internal_Contact_Form request handling

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689181ae42fc832d9b2226fbb85bbd3d