### PR TITLE
Add log level support

### DIFF
--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -75,7 +75,7 @@ class Enhanced_ICF_Form_Processor {
             if ($should_log) {
                 $safe_fields = eform_get_safe_fields( $data );
                 $safe_data   = array_intersect_key( $data, array_flip( $safe_fields ) );
-                $this->logger->log( 'Form submission sent', [ 'form_data' => $safe_data ] );
+                $this->logger->log( 'Form submission sent', 'info', [ 'form_data' => $safe_data ] );
             }
             return [ 'success' => true ];
         }
@@ -198,7 +198,7 @@ class Enhanced_ICF_Form_Processor {
         if (isset($details['form_data'])) {
             unset($details['form_data']);
         }
-        $this->logger->log($type, [
+        $this->logger->log($type, 'error', [
             'type'    => $type,
             'details' => $details,
         ], $form_data);

--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -98,7 +98,7 @@ class Enhanced_Internal_Contact_Form {
         $css_path = plugin_dir_path( __FILE__ ) . '/../' . $css_file;
 
         if ( ! file_exists( $css_path ) ) {
-            $this->logger->log( sprintf( 'Enhanced ICF CSS file missing: %s', $css_path ) );
+            $this->logger->log( sprintf( 'Enhanced ICF CSS file missing: %s', $css_path ), 'warning' );
             return;
         }
 
@@ -111,13 +111,13 @@ class Enhanced_Internal_Contact_Form {
 
     private function load_inline_css( $template, $css_path ) {
         if ( ! is_readable( $css_path ) ) {
-            $this->logger->log( sprintf( 'Enhanced ICF CSS file not readable: %s', $css_path ) );
+            $this->logger->log( sprintf( 'Enhanced ICF CSS file not readable: %s', $css_path ), 'warning' );
             return;
         }
 
         $css = file_get_contents( $css_path );
         if ( false === $css ) {
-            $this->logger->log( sprintf( 'Failed to read Enhanced ICF CSS file: %s', $css_path ) );
+            $this->logger->log( sprintf( 'Failed to read Enhanced ICF CSS file: %s', $css_path ), 'warning' );
             return;
         }
 
@@ -178,7 +178,7 @@ class Enhanced_Internal_Contact_Form {
             return ob_get_clean();
         }
 
-        $this->logger->log( sprintf( 'Enhanced ICF template missing: %s', $template_path ) );
+        $this->logger->log( sprintf( 'Enhanced ICF template missing: %s', $template_path ), 'error' );
 
         return '<p>Form template not found.</p>';
     }

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -26,7 +26,15 @@ if ( ! function_exists( 'eform_get_safe_fields' ) ) {
 }
 
 class Logger {
-    public function log($message, $context = [], $form_data = null) {
+    /**
+     * Write a log entry.
+     *
+     * @param string     $message   Human readable message.
+     * @param string     $level     Severity level (e.g. info, warning, error).
+     * @param array      $context   Additional context to record.
+     * @param array|null $form_data Optional form data for safe logging.
+     */
+    public function log($message, $level = 'info', $context = [], $form_data = null) {
         $server = $_SERVER;
 
         // Store logs in a location outside of the plugin directory.
@@ -75,6 +83,7 @@ class Logger {
         $context['timestamp'] = date('c');
         $context['ip']        = $this->get_ip();
         $context['source']    = 'Enhanced iContact Form';
+        $context['level']     = $level;
         $context['message']   = $message;
         $context['user_agent'] = isset($server['HTTP_USER_AGENT']) ? sanitize_text_field($server['HTTP_USER_AGENT']) : '';
         $context['referrer']  = isset($server['HTTP_REFERER']) ? sanitize_text_field($server['HTTP_REFERER']) : 'No referrer';

--- a/includes/mail-error-logger.php
+++ b/includes/mail-error-logger.php
@@ -39,6 +39,7 @@ class Mail_Error_Logger {
             $data = $wp_error->get_error_data();
             $this->logger->log(
                 'Mail send failure',
+                'error',
                 [
                     'error'   => $wp_error->get_error_message(),
                     'details' => is_array( $data ) ? $data : [],
@@ -57,7 +58,7 @@ class Mail_Error_Logger {
         if ( defined( 'DEBUG_LEVEL' ) && DEBUG_LEVEL === 3 ) {
             $phpmailer->SMTPDebug  = 3;
             $phpmailer->Debugoutput = function ( $str, $level ) {
-                $this->logger->log( 'PHPMailer Debug', [ 'debug' => $str, 'level' => $level ] );
+                $this->logger->log( 'PHPMailer Debug', 'info', [ 'debug' => $str, 'phpmailer_level' => $level ] );
             };
         }
     }


### PR DESCRIPTION
## Summary
- extend logger to accept severity level
- include level data in log context and document
- tag log entries with info/warning/error across plugin

## Testing
- `composer install` *(fails: CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892ce03401c832d9788ad9c4013fb7d