### PR TITLE
Use wp_add_inline_style for inline CSS

### DIFF
--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -54,8 +54,17 @@ class Enhanced_Internal_Contact_Form {
 
     // Method hooked to wp_head or wp_footer when inline CSS is needed
     public function print_inline_css() {
-        if (!empty($this->inline_css) && ! $this->css_printed) {
-            echo '<style id="enhanced-icf-inline-style">' . $this->inline_css . '</style>';
+        if ( ! empty( $this->inline_css ) && ! $this->css_printed ) {
+            $handle = 'enhanced-icf-inline-style';
+
+            if ( ! wp_style_is( $handle, 'registered' ) ) {
+                wp_register_style( $handle, false );
+            }
+
+            wp_enqueue_style( $handle );
+            wp_add_inline_style( $handle, $this->inline_css );
+            wp_print_styles( $handle );
+
             $this->css_printed = true;
         }
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -57,6 +57,8 @@ function has_action($hook,$callback){return false;}
 function wp_register_style(){ }
 function wp_enqueue_style(){ }
 function wp_print_styles(){ }
+function wp_style_is(){ return false; }
+function wp_add_inline_style(){ }
 function wp_mkdir_p($dir){return true;}
 function wp_nonce_field(){ }
 


### PR DESCRIPTION
## Summary
- Replace echo-based inline CSS output with wp_add_inline_style and a registered handle for WordPress style queue
- Stub wp_style_is and wp_add_inline_style in the test bootstrap

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6892e5508f48832d897525f9bada841d