### PR TITLE
Handle array inputs in form submission

### DIFF
--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -31,7 +31,7 @@ class Enhanced_Internal_Contact_Form {
             return;
         }
 
-        $submitted_data = array_map( 'sanitize_text_field', wp_unslash( $_POST ) );
+        $submitted_data = wp_unslash( $_POST );
 
         $template   = sanitize_key( $submitted_data['enhanced_template'] ?? 'default' );
         $submit_key = 'enhanced_form_submit_' . $template;


### PR DESCRIPTION
## Summary
- pass raw POST data to the form processor
- sanitize and validate scalar values in the processor, gracefully handling array inputs
- add tests for array field submissions

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6892e9a77b64832dad4842baa7a2b808