### PR TITLE
Reject array inputs in form submission

### DIFF
--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -11,8 +11,8 @@ class Enhanced_ICF_Form_Processor {
     }
 
     private function get_first_value( $value ) {
-        while ( is_array( $value ) ) {
-            $value = reset( $value );
+        if ( is_array( $value ) ) {
+            return null;
         }
         return $value;
     }
@@ -53,12 +53,24 @@ class Enhanced_ICF_Form_Processor {
             }
         }
 
+        $raw_values = [
+            'name'    => $this->get_first_value( $submitted_data['name_input'] ?? '' ),
+            'email'   => $this->get_first_value( $submitted_data['email_input'] ?? '' ),
+            'phone'   => $this->get_first_value( $submitted_data['tel_input'] ?? '' ),
+            'zip'     => $this->get_first_value( $submitted_data['zip_input'] ?? '' ),
+            'message' => $this->get_first_value( $submitted_data['message_input'] ?? '' ),
+        ];
+
+        if ( in_array( null, $raw_values, true ) ) {
+            return $this->error_response( 'Invalid form input', [], 'Invalid form input.' );
+        }
+
         $data = [
-            'name'    => sanitize_text_field( $this->get_first_value( $submitted_data['name_input'] ?? '' ) ),
-            'email'   => sanitize_email( $this->get_first_value( $submitted_data['email_input'] ?? '' ) ),
-            'phone'   => preg_replace( '/\\D/', '', $this->get_first_value( $submitted_data['tel_input'] ?? '' ) ),
-            'zip'     => sanitize_text_field( $this->get_first_value( $submitted_data['zip_input'] ?? '' ) ),
-            'message' => sanitize_textarea_field( $this->get_first_value( $submitted_data['message_input'] ?? '' ) ),
+            'name'    => sanitize_text_field( $raw_values['name'] ),
+            'email'   => sanitize_email( $raw_values['email'] ),
+            'phone'   => preg_replace( '/\\D/', '', $raw_values['phone'] ),
+            'zip'     => sanitize_text_field( $raw_values['zip'] ),
+            'message' => sanitize_textarea_field( $raw_values['message'] ),
         ];
 
         $errors = $this->validate_form($data);

--- a/tests/EnhancedInternalContactFormTest.php
+++ b/tests/EnhancedInternalContactFormTest.php
@@ -77,7 +77,7 @@ class EnhancedInternalContactFormTest extends TestCase {
         $this->assertSame(['name' => 'Jane'], $formData->getValue($form));
     }
 
-    public function test_maybe_handle_form_handles_array_fields() {
+    public function test_maybe_handle_form_rejects_array_fields() {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_POST = [
             'enhanced_template' => 'default',
@@ -108,16 +108,10 @@ class EnhancedInternalContactFormTest extends TestCase {
 
         $formData = $ref->getProperty('form_data');
         $formData->setAccessible(true);
-        $this->assertSame([
-            'name' => 'Jane',
-            'email' => 'jane@example.com',
-            'phone' => '1234567890',
-            'zip' => '12345',
-            'message' => 'short',
-        ], $formData->getValue($form));
+        $this->assertSame([], $formData->getValue($form));
 
         $error = $ref->getProperty('error_message');
         $error->setAccessible(true);
-        $this->assertSame('<div class="form-message error">Message too short.</div>', $error->getValue($form));
+        $this->assertSame('<div class="form-message error">Invalid form input.</div>', $error->getValue($form));
     }
 }


### PR DESCRIPTION
## Summary
- Prevent `get_first_value` from collapsing arrays and instead return `null`
- Abort processing when form fields contain arrays and report an "Invalid form input" error
- Verify array submissions are rejected in `EnhancedInternalContactFormTest`

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689410a57368832d9ffac30d9976d3cb