### PR TITLE
Handle array inputs in honeypot and submission time checks

### DIFF
--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -122,7 +122,14 @@ class Enhanced_ICF_Form_Processor {
     }
 
     private function check_honeypot(array $submitted_data): array {
-        $honeypot = $this->get_first_value( $submitted_data['enhanced_url'] ?? '' );
+        $honeypot_field = $submitted_data['enhanced_url'] ?? '';
+        if ( is_array( $honeypot_field ) ) {
+            return [
+                'type'    => 'Bot Alert: Honeypot Filled',
+                'message' => 'Bot test failed.',
+            ];
+        }
+        $honeypot = $this->get_first_value( $honeypot_field );
         if ( ! empty( $honeypot ) ) {
             return [
                 'type'    => 'Bot Alert: Honeypot Filled',
@@ -133,7 +140,14 @@ class Enhanced_ICF_Form_Processor {
     }
 
     private function check_submission_time(array $submitted_data): array {
-        $submit_time = intval( $this->get_first_value( $submitted_data['enhanced_form_time'] ?? 0 ) );
+        $submit_time_field = $submitted_data['enhanced_form_time'] ?? 0;
+        if ( is_array( $submit_time_field ) ) {
+            return [
+                'type'    => 'Bot Alert: Fast Submission',
+                'message' => 'Submission too fast. Please try again.',
+            ];
+        }
+        $submit_time = intval( $this->get_first_value( $submit_time_field ) );
         if ( time() - $submit_time < 5 ) {
             return [
                 'type'    => 'Bot Alert: Fast Submission',

--- a/tests/EnhancedICFFormProcessorTest.php
+++ b/tests/EnhancedICFFormProcessorTest.php
@@ -44,9 +44,25 @@ class EnhancedICFFormProcessorTest extends TestCase {
         $this->assertSame('Bot test failed.', $result['message']);
     }
 
+    public function test_honeypot_array_failure() {
+        $data = $this->valid_submission();
+        $data['enhanced_url'] = ['spam'];
+        $result = $this->processor->process_form_submission('default', $data);
+        $this->assertFalse($result['success']);
+        $this->assertSame('Bot test failed.', $result['message']);
+    }
+
     public function test_submission_time_failure() {
         $data = $this->valid_submission();
         $data['enhanced_form_time'] = time();
+        $result = $this->processor->process_form_submission('default', $data);
+        $this->assertFalse($result['success']);
+        $this->assertSame('Submission too fast. Please try again.', $result['message']);
+    }
+
+    public function test_submission_time_array_failure() {
+        $data = $this->valid_submission();
+        $data['enhanced_form_time'] = ['now'];
         $result = $this->processor->process_form_submission('default', $data);
         $this->assertFalse($result['success']);
         $this->assertSame('Submission too fast. Please try again.', $result['message']);


### PR DESCRIPTION
## Summary
- guard honeypot field against array input
- guard submission time field against array input
- test array validation for honeypot and submission time

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689414938c60832db99af71b2c9d7e9b