### PR TITLE
Optimize logger file handling and add rotation test

### DIFF
--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace LoggerTesting;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+#[RunTestsInSeparateProcesses]
+class LoggerTest extends TestCase {
+    private string $logDir;
+    private string $logFile;
+
+    protected function setUp(): void {
+        if (defined('WP_CONTENT_DIR') && is_dir(WP_CONTENT_DIR)) {
+            foreach (glob(WP_CONTENT_DIR . '/*') ?: [] as $file) {
+                is_dir($file) ? $this->rrmdir($file) : unlink($file);
+            }
+        } else {
+            mkdir(WP_CONTENT_DIR, 0777, true);
+        }
+
+        define('EFORM_LOG_FILE_MAX_SIZE', 200);
+        $this->logDir = WP_CONTENT_DIR . '/uploads/logs';
+        $this->logFile = $this->logDir . '/forms.log';
+    }
+
+    protected function tearDown(): void {
+        if (file_exists($this->logFile)) {
+            unlink($this->logFile);
+        }
+        foreach (glob($this->logDir . '/forms-*.log') ?: [] as $file) {
+            unlink($file);
+        }
+        if (is_dir($this->logDir)) {
+            rmdir($this->logDir);
+        }
+        if (is_dir(WP_CONTENT_DIR . '/uploads')) {
+            rmdir(WP_CONTENT_DIR . '/uploads');
+        }
+        if (is_dir(WP_CONTENT_DIR)) {
+            $this->rrmdir(WP_CONTENT_DIR);
+        }
+    }
+
+    public function test_rotation_when_size_exceeded(): void {
+        $logger = new \Logger();
+        $message = str_repeat('a', 300);
+        $logger->log($message);
+        $this->assertFileExists($this->logFile);
+        clearstatcache();
+        $this->assertGreaterThan(200, filesize($this->logFile));
+        $this->assertCount(0, glob($this->logDir . '/forms-*.log'));
+
+        $logger->log('second');
+        $rotated = glob($this->logDir . '/forms-*.log');
+        $this->assertNotEmpty($rotated, 'Log file should rotate after exceeding size limit');
+    }
+
+    private function rrmdir(string $dir): void {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (array_diff(scandir($dir), ['.', '..']) as $file) {
+            $path = $dir . DIRECTORY_SEPARATOR . $file;
+            if (is_dir($path)) {
+                $this->rrmdir($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -59,13 +59,16 @@ function wp_enqueue_style(){ }
 function wp_print_styles(){ }
 function wp_style_is(){ return false; }
 function wp_add_inline_style(){ }
-function wp_mkdir_p($dir){return true;}
-function wp_nonce_field(){ }
-
-class Logger {
-    public function get_ip(){ return '127.0.0.1'; }
-    public function log($message,$context=[],$form_data=null){ }
+function wp_mkdir_p($dir){
+    if (!is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+    return true;
 }
-
+function wp_nonce_field(){ }
+if ( ! defined('WP_CONTENT_DIR') ) {
+    define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wp-content');
+}
+require_once __DIR__.'/../includes/logger.php';
 require_once __DIR__.'/../includes/class-enhanced-icf-processor.php';
 require_once __DIR__.'/../includes/class-enhanced-icf.php';


### PR DESCRIPTION
## Summary
- cache the log file path in `Logger` and rotate only when the file exceeds the size limit
- bootstrap tests with a real logger and proper directory creation
- add PHPUnit coverage verifying log rotation when size threshold is hit

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689420c567f8832d9409b2a839150a2e