### PR TITLE
Use constants for log levels

### DIFF
--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -100,7 +100,7 @@ class Enhanced_ICF_Form_Processor {
             if ($should_log) {
                 $safe_fields = eform_get_safe_fields( $data );
                 $safe_data   = array_intersect_key( $data, array_flip( $safe_fields ) );
-                $this->logger->log( 'Form submission sent', 'info', [ 'form_data' => $safe_data ] );
+                $this->logger->log( 'Form submission sent', Logger::LEVEL_INFO, [ 'form_data' => $safe_data ] );
             }
             return [ 'success' => true ];
         }
@@ -240,7 +240,7 @@ class Enhanced_ICF_Form_Processor {
         if (isset($details['form_data'])) {
             unset($details['form_data']);
         }
-        $this->logger->log($type, 'error', [
+        $this->logger->log($type, Logger::LEVEL_ERROR, [
             'type'    => $type,
             'details' => $details,
         ], $form_data);

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -27,6 +27,21 @@ if ( ! function_exists( 'eform_get_safe_fields' ) ) {
 
 class Logger {
     /**
+     * Log level for informational messages.
+     */
+    public const LEVEL_INFO = 'info';
+
+    /**
+     * Log level for warnings.
+     */
+    public const LEVEL_WARNING = 'warning';
+
+    /**
+     * Log level for errors.
+     */
+    public const LEVEL_ERROR = 'error';
+
+    /**
      * Cached path to the log file.
      *
      * @var string|null
@@ -37,11 +52,11 @@ class Logger {
      * Write a log entry.
      *
      * @param string     $message   Human readable message.
-     * @param string     $level     Severity level (e.g. info, warning, error).
+     * @param string     $level     Severity level (e.g. Logger::LEVEL_INFO, Logger::LEVEL_WARNING, Logger::LEVEL_ERROR).
      * @param array      $context   Additional context to record.
      * @param array|null $form_data Optional form data for safe logging.
      */
-    public function log($message, $level = 'info', $context = [], $form_data = null) {
+    public function log($message, $level = self::LEVEL_INFO, $context = [], $form_data = null) {
         $server = $_SERVER;
 
         // Prepare the log file if it hasn't been prepared yet, rotation is needed,

--- a/includes/mail-error-logger.php
+++ b/includes/mail-error-logger.php
@@ -29,7 +29,7 @@ class Mail_Error_Logger {
     }
 
     /**
-     * Logs WP mail errors.
+     * Logs WP mail errors using Logger::LEVEL_ERROR.
      *
      * @param WP_Error $wp_error The WordPress error object.
      * @return void
@@ -39,7 +39,7 @@ class Mail_Error_Logger {
             $data = $wp_error->get_error_data();
             $this->logger->log(
                 'Mail send failure',
-                'error',
+                Logger::LEVEL_ERROR,
                 [
                     'error'   => $wp_error->get_error_message(),
                     'details' => is_array( $data ) ? $data : [],
@@ -50,6 +50,7 @@ class Mail_Error_Logger {
 
     /**
      * Enables PHPMailer debugging when DEBUG_LEVEL is 3.
+     * Logs output using Logger::LEVEL_INFO.
      *
      * @param PHPMailer $phpmailer PHPMailer instance.
      * @return void
@@ -58,7 +59,7 @@ class Mail_Error_Logger {
         if ( defined( 'DEBUG_LEVEL' ) && DEBUG_LEVEL === 3 ) {
             $phpmailer->SMTPDebug  = 3;
             $phpmailer->Debugoutput = function ( $str, $level ) {
-                $this->logger->log( 'PHPMailer Debug', 'info', [ 'debug' => $str, 'phpmailer_level' => $level ] );
+                $this->logger->log( 'PHPMailer Debug', Logger::LEVEL_INFO, [ 'debug' => $str, 'phpmailer_level' => $level ] );
             };
         }
     }


### PR DESCRIPTION
## Summary
- add Logger::LEVEL_* constants
- replace log level strings with new constants
- document log level usage in Mail_Error_Logger

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68942bd5202c832d972c70cba8dcd373