### PR TITLE
Add helper for template fields and register usage

### DIFF
--- a/eform.php
+++ b/eform.php
@@ -29,11 +29,13 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/mail-error-logger.php';
  */
 new Mail_Error_Logger( $logger );
 require_once plugin_dir_path( __FILE__ ) . 'includes/field-registry.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/template-tags.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-enhanced-icf-processor.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-enhanced-icf.php';
 
 // Initialize plugin
 $registry  = new FieldRegistry();
+$GLOBALS['eform_registry'] = $registry;
 $processor = new Enhanced_ICF_Form_Processor( $logger, $registry );
 new Enhanced_Internal_Contact_Form( $processor, $logger );
 

--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -182,9 +182,14 @@ class Enhanced_Internal_Contact_Form {
         $template_path = plugin_dir_path( __FILE__ ) . "../templates/form-{$template}.php";
 
         if ( file_exists( $template_path ) ) {
+            global $eform_current_template, $eform_form;
+            $eform_current_template = $template;
+            $eform_form            = $this;
             ob_start();
             include $template_path;
-            return ob_get_clean();
+            $output = ob_get_clean();
+            unset( $GLOBALS['eform_current_template'], $GLOBALS['eform_form'] );
+            return $output;
         }
 
         $this->logger->log( sprintf( 'Enhanced ICF template missing: %s', $template_path ), 'error' );

--- a/includes/field-registry.php
+++ b/includes/field-registry.php
@@ -3,50 +3,76 @@
 
 class FieldRegistry {
     /**
-     * Field configuration per template.
+     * Base configuration for all available fields.
      *
      * @var array[]
      */
     private const FIELDS = [
-        'default' => [
-            'name'    => [
-                'post_key'     => 'name_input',
-                'required'     => true,
-                'sanitize_cb'  => 'sanitize_text_field',
-                'validate_cb'  => [self::class, 'validate_name'],
-            ],
-            'email'   => [
-                'post_key'     => 'email_input',
-                'required'     => true,
-                'sanitize_cb'  => 'sanitize_email',
-                'validate_cb'  => [self::class, 'validate_email'],
-            ],
-            'phone'   => [
-                'post_key'     => 'tel_input',
-                'required'     => true,
-                'sanitize_cb'  => [self::class, 'sanitize_digits'],
-                'validate_cb'  => [self::class, 'validate_phone'],
-            ],
-            'zip'     => [
-                'post_key'     => 'zip_input',
-                'required'     => true,
-                'sanitize_cb'  => 'sanitize_text_field',
-                'validate_cb'  => [self::class, 'validate_zip'],
-            ],
-            'message' => [
-                'post_key'     => 'message_input',
-                'required'     => true,
-                'sanitize_cb'  => 'sanitize_textarea_field',
-                'validate_cb'  => [self::class, 'validate_message'],
-            ],
+        'name'    => [
+            'post_key'     => 'name_input',
+            'required'     => true,
+            'sanitize_cb'  => 'sanitize_text_field',
+            'validate_cb'  => [self::class, 'validate_name'],
+        ],
+        'email'   => [
+            'post_key'     => 'email_input',
+            'required'     => true,
+            'sanitize_cb'  => 'sanitize_email',
+            'validate_cb'  => [self::class, 'validate_email'],
+        ],
+        'phone'   => [
+            'post_key'     => 'tel_input',
+            'required'     => true,
+            'sanitize_cb'  => [self::class, 'sanitize_digits'],
+            'validate_cb'  => [self::class, 'validate_phone'],
+        ],
+        'zip'     => [
+            'post_key'     => 'zip_input',
+            'required'     => true,
+            'sanitize_cb'  => 'sanitize_text_field',
+            'validate_cb'  => [self::class, 'validate_zip'],
+        ],
+        'message' => [
+            'post_key'     => 'message_input',
+            'required'     => true,
+            'sanitize_cb'  => 'sanitize_textarea_field',
+            'validate_cb'  => [self::class, 'validate_message'],
         ],
     ];
 
     /**
+     * Registered fields per template.
+     *
+     * @var array<string,array>
+     */
+    private $registered = [];
+
+    /**
+     * Register a field for a template.
+     *
+     * @param string $template Template slug.
+     * @param string $field    Field key.
+     * @param array  $args     Field overrides (e.g. ['required' => true]).
+     */
+    public function register_field( string $template, string $field, array $args = [] ): void {
+        if ( ! isset( self::FIELDS[ $field ] ) ) {
+            return;
+        }
+
+        $config = self::FIELDS[ $field ];
+
+        if ( isset( $args['required'] ) ) {
+            $config['required'] = (bool) $args['required'];
+        }
+
+        $this->registered[ $template ][ $field ] = $config;
+    }
+
+    /**
      * Retrieve field configuration for a template.
      */
-    public function get_fields(string $template): array {
-        return self::FIELDS[$template] ?? self::FIELDS['default'];
+    public function get_fields( string $template ): array {
+        return $this->registered[ $template ] ?? self::FIELDS;
     }
 
     /**

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -1,0 +1,75 @@
+<?php
+// includes/template-tags.php
+
+if ( ! function_exists( 'eform_field' ) ) {
+    /**
+     * Render a form field and register it for processing.
+     *
+     * @param string $field Field key (name, email, phone, zip, message).
+     * @param array  $args  Optional arguments.
+     *                     - required (bool)  Whether the field is required.
+     *                     - placeholder (string) Placeholder text.
+     *                     - rows (int)  Rows for textarea fields.
+     *                     - cols (int)  Cols for textarea fields.
+     */
+    function eform_field( string $field, array $args = [] ) {
+        global $eform_registry, $eform_current_template, $eform_form;
+
+        if ( empty( $eform_registry ) || empty( $eform_current_template ) ) {
+            return;
+        }
+
+        $defaults = [
+            'required'    => false,
+            'placeholder' => '',
+            'rows'        => 5,
+            'cols'        => 21,
+        ];
+        $args = array_merge( $defaults, $args );
+
+        $required_attr = $args['required'] ? ' required aria-required="true"' : '';
+
+        // Record field presence with registry.
+        $eform_registry->register_field( $eform_current_template, $field, [ 'required' => $args['required'] ] );
+
+        $value = $eform_form->form_data[ $field ] ?? '';
+
+        switch ( $field ) {
+            case 'name':
+                $placeholder = $args['placeholder'] ?: 'Your Name';
+                echo '<input class="form_field" type="text" name="name_input" autocomplete="name"' .
+                    $required_attr . ' aria-label="Your Name" placeholder="' . esc_attr( $placeholder ) .
+                    '" value="' . esc_attr( $value ) . '">';
+                break;
+
+            case 'email':
+                $placeholder = $args['placeholder'] ?: 'Your eMail';
+                echo '<input class="form_field" type="email" name="email_input" autocomplete="email"' .
+                    $required_attr . ' aria-label="Your Email" placeholder="' . esc_attr( $placeholder ) .
+                    '" value="' . esc_attr( $value ) . '">';
+                break;
+
+            case 'phone':
+                $placeholder = $args['placeholder'] ?: 'Phone';
+                $formatted   = $eform_form->format_phone( $value );
+                echo '<input class="form_field" type="tel" name="tel_input" autocomplete="tel"' .
+                    $required_attr . ' aria-label="Phone" placeholder="' . esc_attr( $placeholder ) .
+                    '" value="' . esc_attr( $formatted ) . '">';
+                break;
+
+            case 'zip':
+                $placeholder = $args['placeholder'] ?: 'Project Zip Code';
+                echo '<input class="form_field" type="text" name="zip_input" autocomplete="postal-code"' .
+                    $required_attr . ' aria-label="Project Zip Code" placeholder="' . esc_attr( $placeholder ) .
+                    '" value="' . esc_attr( $value ) . '">';
+                break;
+
+            case 'message':
+                $placeholder = $args['placeholder'] ?: 'Please describe your project and let us know if there is any urgency';
+                echo '<textarea name="message_input" cols="' . intval( $args['cols'] ) . '" rows="' . intval( $args['rows'] ) . '"'
+                    . $required_attr . ' aria-label="Message" placeholder="' . esc_attr( $placeholder ) . '">'
+                    . esc_textarea( $value ) . '</textarea>';
+                break;
+        }
+    }
+}

--- a/templates/form-custom.php
+++ b/templates/form-custom.php
@@ -4,8 +4,8 @@
 <div id="contact_form" class="contact_form">
     <form class="general_contact_form" id="general_contact_form" aria-label="Contact Form" method="post" action="">
         <?php Enhanced_Internal_Contact_Form::render_hidden_fields('custom'); ?>
-        <div><textarea name="message_input" placeholder="Write your message..." rows="6" required><?php echo esc_textarea($this->form_data['message'] ?? ''); ?></textarea></div>
-        <div><input type="email" name="email_input" placeholder="Enter Your Email*" required value="<?php echo esc_attr($this->form_data['email'] ?? ''); ?>"></div>
+        <div><?php eform_field('message', [ 'required' => true, 'placeholder' => 'Write your message...', 'rows' => 6 ]); ?></div>
+        <div><?php eform_field('email', [ 'required' => true, 'placeholder' => 'Enter Your Email*' ]); ?></div>
         <div><button type="submit" name="enhanced_form_submit_custom">Click to Send</button></div>
     </form>
 </div>

--- a/templates/form-default.php
+++ b/templates/form-default.php
@@ -7,17 +7,17 @@
     <form class="main_contact_form" id="main_contact_form" aria-label="Contact Form" method="post" action="">
         <?php Enhanced_Internal_Contact_Form::render_hidden_fields('default'); ?>
         <div class="inputwrap">
-            <input class="form_field" type="text" name="name_input" autocomplete="name" required aria-required="true" aria-label="Your Name" placeholder="Your Name" value="<?php echo esc_attr($this->form_data['name'] ?? ''); ?>">
+            <?php eform_field('name', [ 'required' => true ]); ?>
         </div>
         <div class="inputwrap">
-            <input class="form_field" type="email" name="email_input" autocomplete="email" required aria-required="true" aria-label="Your Email" placeholder="Your eMail" value="<?php echo esc_attr($this->form_data['email'] ?? ''); ?>">
+            <?php eform_field('email', [ 'required' => true ]); ?>
         </div>
         <div class="columns_nomargins inputwrap">
-            <input class="form_field" type="tel" name="tel_input" autocomplete="tel" required aria-required="true" aria-label="Phone" placeholder="Phone" value="<?php echo esc_attr($this->format_phone($this->form_data['phone'] ?? '')); ?>">
-            <input class="form_field" type="text" name="zip_input" autocomplete="postal-code" required aria-required="true" aria-label="Project Zip Code" placeholder="Project Zip Code" value="<?php echo esc_attr($this->form_data['zip'] ?? ''); ?>">
+            <?php eform_field('phone', [ 'required' => true ]); ?>
+            <?php eform_field('zip', [ 'required' => true ]); ?>
         </div>
         <div class="inputwrap">
-            <textarea cols="21" rows="5" name="message_input" required aria-required="true" aria-label="Message" placeholder="Please describe your project and let us know if there is any urgency"><?php echo esc_textarea($this->form_data['message'] ?? ''); ?></textarea>
+            <?php eform_field('message', [ 'required' => true ]); ?>
         </div>
 
         <input type="hidden" name="submitted" value="1" aria-hidden="true">


### PR DESCRIPTION
## Summary
- add global `eform_field()` template tag that renders fields and registers them
- track field registration in `FieldRegistry` and expose registry globally
- use helper in default and custom templates with template-level required flags

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689500964c58832d9281ef870e56833d