### PR TITLE
Limit form validation to rendered fields

### DIFF
--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -56,6 +56,13 @@ class Enhanced_ICF_Form_Processor {
         }
 
         $field_map      = $this->registry->get_fields( $template );
+
+        $field_list = $this->get_first_value( $submitted_data['enhanced_fields'] ?? '' );
+        if ( ! empty( $field_list ) ) {
+            $keys      = array_filter( array_map( 'sanitize_key', explode( ',', $field_list ) ) );
+            $field_map = array_intersect_key( $field_map, array_flip( $keys ) );
+        }
+
         $raw_values     = [];
         $invalid_fields = [];
         foreach ( $field_map as $field => $details ) {
@@ -181,11 +188,11 @@ class Enhanced_ICF_Form_Processor {
     private function build_email_body(array $data): string {
         $ip = esc_html($this->ipaddress);
         $rows = [
-            ['label' => 'Name',    'value' => esc_html($data['name'])],
-            ['label' => 'Email',   'value' => esc_html($data['email'])],
-            ['label' => 'Phone',   'value' => esc_html($this->format_phone($data['phone']))],
-            ['label' => 'Zip',     'value' => esc_html($data['zip'])],
-            ['label' => 'Message', 'value' => nl2br(esc_html($data['message'])), 'valign' => 'top'],
+            ['label' => 'Name',    'value' => esc_html($data['name'] ?? '')],
+            ['label' => 'Email',   'value' => esc_html($data['email'] ?? '')],
+            ['label' => 'Phone',   'value' => esc_html($this->format_phone($data['phone'] ?? ''))],
+            ['label' => 'Zip',     'value' => esc_html($data['zip'] ?? '')],
+            ['label' => 'Message', 'value' => nl2br(esc_html($data['message'] ?? '')), 'valign' => 'top'],
             ['label' => 'Sent from', 'value' => $ip],
         ];
 
@@ -199,16 +206,16 @@ class Enhanced_ICF_Form_Processor {
     }
 
     private function send_email(array $data): bool {
-        $to = get_option('admin_email');
-        $subject = 'Quote Request - ' . sanitize_text_field($data['name']);
+        $to      = get_option('admin_email');
+        $subject = 'Quote Request - ' . sanitize_text_field($data['name'] ?? '');
         $message = $this->build_email_body($data);
 
         $noreply = 'noreply@flooringartists.com';
         $headers = [];
-        $headers[] = "From: {$data['name']} <{$noreply}>";
+        $headers[] = "From: " . ($data['name'] ?? '') . " <{$noreply}>";
         $headers[] = 'Content-Type: text/html; charset=UTF-8';
         $headers[] = 'Content-Transfer-Encoding: 8bit';
-        $headers[] = "Reply-To: {$data['name']} <{$data['email']}>";
+        $headers[] = "Reply-To: " . ($data['name'] ?? '') . " <" . ($data['email'] ?? '') . ">";
 
         return wp_mail($to, $subject, $message, $headers);
     }

--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -207,6 +207,17 @@ class Enhanced_Internal_Contact_Form {
 
         $form_html = $this->include_template( $template );
 
+        // Inject hidden field listing keys used in this template for processing
+        global $eform_registry;
+        if ( isset( $eform_registry ) ) {
+            $fields = $eform_registry->get_fields( $template );
+            if ( ! empty( $fields ) ) {
+                $keys   = implode( ',', array_keys( $fields ) );
+                $hidden = '<input type="hidden" name="enhanced_fields" value="' . esc_attr( $keys ) . '">';
+                $form_html = preg_replace( '/<\/form>/', $hidden . '</form>', $form_html, 1 );
+            }
+        }
+
         $form_html = $this->prepend_form_messages( $template, $form_html );
 
         return $form_html;

--- a/tests/EnhancedICFFormProcessorTest.php
+++ b/tests/EnhancedICFFormProcessorTest.php
@@ -83,4 +83,12 @@ class EnhancedICFFormProcessorTest extends TestCase {
         $this->assertFalse($result['success']);
         $this->assertStringContainsString('Name too short.', $result['message']);
     }
+
+    public function test_only_registered_fields_validated() {
+        $data = $this->valid_submission();
+        unset($data['tel_input'], $data['zip_input']);
+        $data['enhanced_fields'] = 'name,email,message';
+        $result = $this->processor->process_form_submission('default', $data);
+        $this->assertTrue($result['success']);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,9 @@ function wp_strip_all_tags($str){
 function esc_html($text){
     return htmlspecialchars($text, ENT_QUOTES);
 }
+function esc_attr($text){
+    return htmlspecialchars($text, ENT_QUOTES);
+}
 function get_option($name,$default=''){
     if($name==='admin_email'){return 'admin@example.com';}
     return $default;


### PR DESCRIPTION
## Summary
- Collect rendered field keys and add as hidden input on form render
- Restrict submission validation to these collected field keys
- Harden email building to handle missing optional fields
- Test that only registered fields are validated

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6895101f418c832dbf48ef4a821d3b88