### PR TITLE
Add centralized default field values helper

### DIFF
--- a/tests/EnhancedICFFormProcessorTest.php
+++ b/tests/EnhancedICFFormProcessorTest.php
@@ -20,13 +20,7 @@ class EnhancedICFFormProcessorTest extends TestCase {
             'enhanced_js_check'      => '1',
         ];
 
-        $defaults = [
-            'name'    => 'John Doe',
-            'email'   => 'john@example.com',
-            'phone'   => '1234567890',
-            'zip'     => '12345',
-            'message' => str_repeat('a', 25),
-        ];
+        $defaults = get_default_field_values( $this->registry, $template );
 
         foreach ($field_map as $field => $details) {
             $value = $defaults[$field] ?? '';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,6 +36,24 @@ function wp_mail($to,$subject,$message,$headers){
 function eform_get_safe_fields($data){
     return array_keys($data);
 }
+
+function get_default_field_values( FieldRegistry $registry, string $template = 'default' ): array {
+    $defaults = [
+        'name'    => 'John Doe',
+        'email'   => 'john@example.com',
+        'phone'   => '1234567890',
+        'zip'     => '12345',
+        'message' => str_repeat('a', 25),
+    ];
+
+    $fields = $registry->get_fields( $template );
+    $values = [];
+    foreach ( $fields as $field => $_ ) {
+        $values[ $field ] = $defaults[ $field ] ?? '';
+    }
+
+    return $values;
+}
 function sanitize_key($key){
     return preg_replace('/[^a-z0-9_]/','', strtolower($key));
 }


### PR DESCRIPTION
## Summary
- add `get_default_field_values()` helper to supply sample field values based on registered fields
- update `build_submission()` in tests to use the centralized defaults

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68951b6df7dc832d88458c94d4613c4e