### PR TITLE
Return detailed validation errors

### DIFF
--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -77,7 +77,7 @@ class Enhanced_ICF_Form_Processor {
                 'errors'    => $errors,
                 'form_data' => $data,
             ];
-            $user_msg = implode( '<br>', $errors );
+            $user_msg = implode( '<br>', array_values( $errors ) );
             return $this->error_response( 'Validation errors', $details, $user_msg );
         }
 
@@ -181,7 +181,7 @@ class Enhanced_ICF_Form_Processor {
         foreach ( $field_map as $field => $details ) {
             $error = call_user_func( $details['validate_cb'], $data[ $field ] ?? '', $details );
             if ( $error ) {
-                $errors[] = $error;
+                $errors[ $field ] = $error;
             }
         }
 
@@ -259,6 +259,7 @@ class Enhanced_ICF_Form_Processor {
             'success'   => false,
             'message'   => $user_msg,
             'form_data' => $details['form_data'] ?? [],
+            'errors'    => $details['errors'] ?? [],
         ];
     }
 }

--- a/tests/EnhancedICFFormProcessorErrorsTest.php
+++ b/tests/EnhancedICFFormProcessorErrorsTest.php
@@ -1,0 +1,32 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class EnhancedICFFormProcessorErrorsTest extends TestCase {
+    public function test_process_form_submission_returns_errors_with_keys() {
+        $registry  = new FieldRegistry();
+        $processor = new Enhanced_ICF_Form_Processor(new Logger(), $registry);
+
+        $submitted = [
+            'enhanced_icf_form_nonce' => 'valid',
+            'enhanced_url'           => '',
+            'enhanced_form_time'     => time() - 10,
+            'enhanced_js_check'      => '1',
+            'name_input'             => 'Jo',
+            'email_input'            => 'not-an-email',
+            'tel_input'              => '123',
+            'zip_input'              => 'abcde',
+            'message_input'          => 'short',
+        ];
+
+        $result = $processor->process_form_submission('default', $submitted);
+
+        $this->assertFalse($result['success']);
+        $this->assertArrayHasKey('errors', $result);
+        $this->assertArrayHasKey('name', $result['errors']);
+        $this->assertArrayHasKey('email', $result['errors']);
+        $this->assertSame(
+            implode('<br>', array_values($result['errors'])),
+            $result['message']
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Track validation errors per field and use them to build user feedback
- Surface collected field errors via process error responses
- Add regression test ensuring detailed validation errors are returned

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6896ab411414832dabf4fc7d39997625