### PR TITLE
Expose form field errors in Enhanced ICF

### DIFF
--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -7,7 +7,8 @@ class Enhanced_Internal_Contact_Form {
     private $error_message = '';
     private $form_submitted = false;
     private $inline_css = ''; // Holds aggregated inline CSS
-    private $form_data = [];
+    public $form_data = [];
+    public $field_errors = [];
     private $load_css = false; // Flag to control CSS loading
     private $use_inline_css = true; // Use inline CSS or enqueue stylesheet
     private $processed_template = ''; // Track which template was submitted
@@ -27,6 +28,9 @@ class Enhanced_Internal_Contact_Form {
     }
 
     public function maybe_handle_form() {
+        $this->form_data    = [];
+        $this->field_errors = [];
+
         if ('POST' !== $_SERVER['REQUEST_METHOD']) {
             return;
         }
@@ -48,6 +52,7 @@ class Enhanced_Internal_Contact_Form {
             } else {
                 $this->error_message = '<div class="form-message error">' . $result['message'] . '</div>';
                 $this->form_data     = $result['form_data'] ?? [];
+                $this->field_errors  = $result['errors'] ?? [];
             }
         }
     }

--- a/tests/EnhancedInternalContactFormTest.php
+++ b/tests/EnhancedInternalContactFormTest.php
@@ -53,7 +53,8 @@ class EnhancedInternalContactFormTest extends TestCase {
             ->willReturn([
                 'success' => false,
                 'message' => 'Error happened',
-                'form_data' => ['name' => 'Jane']
+                'form_data' => ['name' => 'Jane'],
+                'errors'    => ['name' => 'Required'],
             ]);
 
         $form = new Enhanced_Internal_Contact_Form($processor, new Logger());
@@ -72,9 +73,8 @@ class EnhancedInternalContactFormTest extends TestCase {
         $error->setAccessible(true);
         $this->assertSame('<div class="form-message error">Error happened</div>', $error->getValue($form));
 
-        $formData = $ref->getProperty('form_data');
-        $formData->setAccessible(true);
-        $this->assertSame(['name' => 'Jane'], $formData->getValue($form));
+        $this->assertSame(['name' => 'Jane'], $form->form_data);
+        $this->assertSame(['name' => 'Required'], $form->field_errors);
     }
 
     public function test_maybe_handle_form_rejects_array_fields() {
@@ -106,9 +106,8 @@ class EnhancedInternalContactFormTest extends TestCase {
         $submitted->setAccessible(true);
         $this->assertFalse($submitted->getValue($form));
 
-        $formData = $ref->getProperty('form_data');
-        $formData->setAccessible(true);
-        $this->assertSame([], $formData->getValue($form));
+        $this->assertSame([], $form->form_data);
+        $this->assertSame([], $form->field_errors);
 
         $error = $ref->getProperty('error_message');
         $error->setAccessible(true);


### PR DESCRIPTION
## Summary
- make `$form_data` public and add new `$field_errors` property
- reset form data and field errors when handling submissions and capture validation errors
- adjust tests for new public properties and error handling

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6897a123861c832d9a34ed85813c334f