### PR TITLE
Add field error helper and display in templates

### DIFF
--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -73,3 +73,25 @@ if ( ! function_exists( 'eform_field' ) ) {
         }
     }
 }
+
+if ( ! function_exists( 'eform_field_error' ) ) {
+    /**
+     * Output a field-specific error message when available.
+     *
+     * @param string $field Field key.
+     */
+    function eform_field_error( string $field ) {
+        global $eform_form;
+
+        if ( empty( $eform_form ) ) {
+            return;
+        }
+
+        $error = $eform_form->field_errors[ $field ] ?? '';
+
+        if ( $error ) {
+            echo '<div class="field-error">' . esc_html( $error ) . '</div>';
+        }
+    }
+}
+

--- a/templates/form-custom.php
+++ b/templates/form-custom.php
@@ -4,8 +4,10 @@
 <div id="contact_form" class="contact_form">
     <form class="general_contact_form" id="general_contact_form" aria-label="Contact Form" method="post" action="">
         <?php Enhanced_Internal_Contact_Form::render_hidden_fields('custom'); ?>
-        <div><?php eform_field('message', [ 'required' => true, 'placeholder' => 'Write your message...', 'rows' => 6 ]); ?></div>
-        <div><?php eform_field('email', [ 'required' => true, 'placeholder' => 'Enter Your Email*' ]); ?></div>
+        <div><?php eform_field('message', [ 'required' => true, 'placeholder' => 'Write your message...', 'rows' => 6 ]); ?>
+            <?php eform_field_error('message'); ?></div>
+        <div><?php eform_field('email', [ 'required' => true, 'placeholder' => 'Enter Your Email*' ]); ?>
+            <?php eform_field_error('email'); ?></div>
         <div><button type="submit" name="enhanced_form_submit_custom">Click to Send</button></div>
     </form>
 </div>

--- a/templates/form-default.php
+++ b/templates/form-default.php
@@ -8,16 +8,21 @@
         <?php Enhanced_Internal_Contact_Form::render_hidden_fields('default'); ?>
         <div class="inputwrap">
             <?php eform_field('name', [ 'required' => true ]); ?>
+            <?php eform_field_error('name'); ?>
         </div>
         <div class="inputwrap">
             <?php eform_field('email', [ 'required' => true ]); ?>
+            <?php eform_field_error('email'); ?>
         </div>
         <div class="columns_nomargins inputwrap">
             <?php eform_field('phone', [ 'required' => true ]); ?>
+            <?php eform_field_error('phone'); ?>
             <?php eform_field('zip', [ 'required' => true ]); ?>
+            <?php eform_field_error('zip'); ?>
         </div>
         <div class="inputwrap">
             <?php eform_field('message', [ 'required' => true ]); ?>
+            <?php eform_field_error('message'); ?>
         </div>
 
         <input type="hidden" name="submitted" value="1" aria-hidden="true">

--- a/tests/TemplateTagsTest.php
+++ b/tests/TemplateTagsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/template-tags.php';
+
+class TemplateTagsTest extends TestCase {
+    protected function tearDown(): void {
+        // Clean up global form object between tests.
+        unset( $GLOBALS['eform_form'] );
+    }
+
+    public function test_eform_field_error_outputs_message() {
+        global $eform_form;
+        $eform_form = (object) [
+            'field_errors' => [ 'name' => 'Required' ],
+        ];
+
+        ob_start();
+        eform_field_error( 'name' );
+        $output = ob_get_clean();
+
+        $this->assertSame( '<div class="field-error">Required</div>', $output );
+    }
+
+    public function test_eform_field_error_outputs_nothing_when_no_message() {
+        global $eform_form;
+        $eform_form = (object) [ 'field_errors' => [] ];
+
+        ob_start();
+        eform_field_error( 'email' );
+        $output = ob_get_clean();
+
+        $this->assertSame( '', $output );
+    }
+}
+


### PR DESCRIPTION
## Summary
- provide `eform_field_error()` to output field-specific errors
- show field errors beneath inputs in default and custom templates
- cover field error helper with unit tests

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6897a4658704832d86d0600e53578a31