### PR TITLE
Sanitize form error messages

### DIFF
--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -50,7 +50,8 @@ class Enhanced_Internal_Contact_Form {
                     exit;
                 }
             } else {
-                $this->error_message = '<div class="form-message error">' . $result['message'] . '</div>';
+                $sanitized_message   = wp_kses_post( $result['message'] );
+                $this->error_message = '<div class="form-message error">' . $sanitized_message . '</div>';
                 $this->form_data     = $result['form_data'] ?? [];
                 $this->field_errors  = $result['errors'] ?? [];
             }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,9 @@ function wp_verify_nonce($nonce,$action){
 function wp_strip_all_tags($str){
     return strip_tags($str);
 }
+function wp_kses_post( $content ){
+    return strip_tags( $content );
+}
 function esc_html($text){
     return htmlspecialchars($text, ENT_QUOTES);
 }


### PR DESCRIPTION
## Summary
- sanitize error messages in Enhanced ICF using `wp_kses_post`
- add test stub for `wp_kses_post`

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6897a628cfa0832d9ccefab39dfb5851