### PR TITLE
Add HTML attribute support for form fields

### DIFF
--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -11,6 +11,9 @@ if ( ! function_exists( 'eform_field' ) ) {
      *                     - placeholder (string) Placeholder text.
      *                     - rows (int)  Rows for textarea fields.
      *                     - cols (int)  Cols for textarea fields.
+     *                     - pattern (string) Regex pattern for input validation.
+     *                     - maxlength (int) Maximum allowed length.
+     *                     - minlength (int) Minimum required length.
      */
     function eform_field( string $field, array $args = [] ) {
         global $eform_registry, $eform_current_template, $eform_form;
@@ -24,10 +27,22 @@ if ( ! function_exists( 'eform_field' ) ) {
             'placeholder' => '',
             'rows'        => 5,
             'cols'        => 21,
+            'pattern'     => '',
+            'maxlength'   => '',
+            'minlength'   => '',
         ];
         $args = array_merge( $defaults, $args );
 
         $required_attr = $args['required'] ? ' required aria-required="true"' : '';
+
+        $extra_attrs = '';
+        foreach ( [ 'pattern', 'maxlength', 'minlength' ] as $attr ) {
+            if ( ! empty( $args[ $attr ] ) ) {
+                $extra_attrs .= ' ' . $attr . '="' . esc_attr( $args[ $attr ] ) . '"';
+            }
+        }
+
+        $attrs = $required_attr . $extra_attrs;
 
         // Record field presence with registry.
         $eform_registry->register_field( $eform_current_template, $field, [ 'required' => $args['required'] ] );
@@ -38,14 +53,14 @@ if ( ! function_exists( 'eform_field' ) ) {
             case 'name':
                 $placeholder = $args['placeholder'] ?: 'Your Name';
                 echo '<input class="form_field" type="text" name="name_input" autocomplete="name"' .
-                    $required_attr . ' aria-label="Your Name" placeholder="' . esc_attr( $placeholder ) .
+                    $attrs . ' aria-label="Your Name" placeholder="' . esc_attr( $placeholder ) .
                     '" value="' . esc_attr( $value ) . '">';
                 break;
 
             case 'email':
                 $placeholder = $args['placeholder'] ?: 'Your eMail';
                 echo '<input class="form_field" type="email" name="email_input" autocomplete="email"' .
-                    $required_attr . ' aria-label="Your Email" placeholder="' . esc_attr( $placeholder ) .
+                    $attrs . ' aria-label="Your Email" placeholder="' . esc_attr( $placeholder ) .
                     '" value="' . esc_attr( $value ) . '">';
                 break;
 
@@ -53,22 +68,22 @@ if ( ! function_exists( 'eform_field' ) ) {
                 $placeholder = $args['placeholder'] ?: 'Phone';
                 $formatted   = $eform_form->format_phone( $value );
                 echo '<input class="form_field" type="tel" name="tel_input" autocomplete="tel"' .
-                    $required_attr . ' aria-label="Phone" placeholder="' . esc_attr( $placeholder ) .
+                    $attrs . ' aria-label="Phone" placeholder="' . esc_attr( $placeholder ) .
                     '" value="' . esc_attr( $formatted ) . '">';
                 break;
 
             case 'zip':
                 $placeholder = $args['placeholder'] ?: 'Project Zip Code';
                 echo '<input class="form_field" type="text" name="zip_input" autocomplete="postal-code"' .
-                    $required_attr . ' aria-label="Project Zip Code" placeholder="' . esc_attr( $placeholder ) .
+                    $attrs . ' aria-label="Project Zip Code" placeholder="' . esc_attr( $placeholder ) .
                     '" value="' . esc_attr( $value ) . '">';
                 break;
 
             case 'message':
                 $placeholder = $args['placeholder'] ?: 'Please describe your project and let us know if there is any urgency';
-                echo '<textarea name="message_input" cols="' . intval( $args['cols'] ) . '" rows="' . intval( $args['rows'] ) . '"'
-                    . $required_attr . ' aria-label="Message" placeholder="' . esc_attr( $placeholder ) . '">'
-                    . esc_textarea( $value ) . '</textarea>';
+                echo '<textarea name="message_input" cols="' . intval( $args['cols'] ) . '" rows="' . intval( $args['rows'] ) . '"' .
+                    $attrs . ' aria-label="Message" placeholder="' . esc_attr( $placeholder ) . '">' .
+                    esc_textarea( $value ) . '</textarea>';
                 break;
         }
     }
@@ -94,4 +109,3 @@ if ( ! function_exists( 'eform_field_error' ) ) {
         }
     }
 }
-

--- a/templates/form-custom.php
+++ b/templates/form-custom.php
@@ -4,7 +4,13 @@
 <div id="contact_form" class="contact_form">
     <form class="general_contact_form" id="general_contact_form" aria-label="Contact Form" method="post" action="">
         <?php Enhanced_Internal_Contact_Form::render_hidden_fields('custom'); ?>
-        <div><?php eform_field('message', [ 'required' => true, 'placeholder' => 'Write your message...', 'rows' => 6 ]); ?>
+        <div><?php eform_field('message', [
+                'required'  => true,
+                'placeholder' => 'Write your message...',
+                'rows'      => 6,
+                'minlength' => 20,
+                'maxlength' => 1000,
+            ]); ?>
             <?php eform_field_error('message'); ?></div>
         <div><?php eform_field('email', [ 'required' => true, 'placeholder' => 'Enter Your Email*' ]); ?>
             <?php eform_field_error('email'); ?></div>

--- a/templates/form-default.php
+++ b/templates/form-default.php
@@ -15,13 +15,27 @@
             <?php eform_field_error('email'); ?>
         </div>
         <div class="columns_nomargins inputwrap">
-            <?php eform_field('phone', [ 'required' => true ]); ?>
+            <?php eform_field('phone', [
+                'required'  => true,
+                'pattern'   => '\\d{3}-?\\d{3}-?\\d{4}',
+                'maxlength' => 12,
+                'minlength' => 10,
+            ]); ?>
             <?php eform_field_error('phone'); ?>
-            <?php eform_field('zip', [ 'required' => true ]); ?>
+            <?php eform_field('zip', [
+                'required'  => true,
+                'pattern'   => '\\d{5}',
+                'maxlength' => 5,
+                'minlength' => 5,
+            ]); ?>
             <?php eform_field_error('zip'); ?>
         </div>
         <div class="inputwrap">
-            <?php eform_field('message', [ 'required' => true ]); ?>
+            <?php eform_field('message', [
+                'required'  => true,
+                'minlength' => 20,
+                'maxlength' => 1000,
+            ]); ?>
             <?php eform_field_error('message'); ?>
         </div>
 

--- a/tests/TemplateTagsTest.php
+++ b/tests/TemplateTagsTest.php
@@ -33,5 +33,48 @@ class TemplateTagsTest extends TestCase {
 
         $this->assertSame( '', $output );
     }
+
+    public function test_eform_field_outputs_additional_attributes() {
+        global $eform_form, $eform_registry, $eform_current_template;
+
+        $eform_registry        = new FieldRegistry();
+        $eform_current_template = 'default';
+
+        $eform_form = new class {
+            public $form_data = [];
+            public function format_phone( $digits ) { return $digits; }
+        };
+
+        ob_start();
+        eform_field( 'phone', [
+            'pattern'   => '\\d{3}-?\\d{3}-?\\d{4}',
+            'maxlength' => 12,
+            'minlength' => 10,
+        ] );
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'pattern="\\d{3}-?\\d{3}-?\\d{4}"', $output );
+        $this->assertStringContainsString( 'maxlength="12"', $output );
+        $this->assertStringContainsString( 'minlength="10"', $output );
+    }
+
+    public function test_eform_field_outputs_textarea_attributes() {
+        global $eform_form, $eform_registry, $eform_current_template;
+
+        $eform_registry        = new FieldRegistry();
+        $eform_current_template = 'default';
+
+        $eform_form = (object) [ 'form_data' => [] ];
+
+        ob_start();
+        eform_field( 'message', [
+            'minlength' => 20,
+            'maxlength' => 1000,
+        ] );
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'minlength="20"', $output );
+        $this->assertStringContainsString( 'maxlength="1000"', $output );
+    }
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,6 +26,9 @@ function esc_html($text){
 function esc_attr($text){
     return htmlspecialchars($text, ENT_QUOTES);
 }
+function esc_textarea($text){
+    return htmlspecialchars($text, ENT_QUOTES);
+}
 function get_option($name,$default=''){
     if($name==='admin_email'){return 'admin@example.com';}
     return $default;


### PR DESCRIPTION
## Summary
- allow `eform_field()` to render pattern/length attributes on inputs and textareas
- include phone, zip, and message constraints in bundled form templates
- cover new attributes with unit tests

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6897bbc6fd54832dbe5bbfdc0f489f86