### PR TITLE
Use generic validation error banner and allow suppression

### DIFF
--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -77,7 +77,7 @@ class Enhanced_ICF_Form_Processor {
                 'errors'    => $errors,
                 'form_data' => $data,
             ];
-            $user_msg = implode( '<br>', array_values( $errors ) );
+            $user_msg = 'Please correct the highlighted fields';
             return $this->error_response( 'Validation errors', $details, $user_msg );
         }
 

--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -50,10 +50,18 @@ class Enhanced_Internal_Contact_Form {
                     exit;
                 }
             } else {
-                $sanitized_message   = wp_kses_post( $result['message'] );
-                $this->error_message = '<div class="form-message error">' . $sanitized_message . '</div>';
-                $this->form_data     = $result['form_data'] ?? [];
-                $this->field_errors  = $result['errors'] ?? [];
+                $this->form_data    = $result['form_data'] ?? [];
+                $this->field_errors = $result['errors'] ?? [];
+
+                $show_global = empty( $this->field_errors );
+                if ( function_exists( 'apply_filters' ) ) {
+                    $show_global = apply_filters( 'eform_show_global_error', $show_global, $result );
+                }
+
+                if ( $show_global ) {
+                    $sanitized_message   = wp_kses_post( $result['message'] );
+                    $this->error_message = '<div class="form-message error">' . $sanitized_message . '</div>';
+                }
             }
         }
     }

--- a/tests/EnhancedICFFormProcessorErrorsTest.php
+++ b/tests/EnhancedICFFormProcessorErrorsTest.php
@@ -24,9 +24,6 @@ class EnhancedICFFormProcessorErrorsTest extends TestCase {
         $this->assertArrayHasKey('errors', $result);
         $this->assertArrayHasKey('name', $result['errors']);
         $this->assertArrayHasKey('email', $result['errors']);
-        $this->assertSame(
-            implode('<br>', array_values($result['errors'])),
-            $result['message']
-        );
+        $this->assertSame('Please correct the highlighted fields', $result['message']);
     }
 }

--- a/tests/EnhancedICFFormProcessorTest.php
+++ b/tests/EnhancedICFFormProcessorTest.php
@@ -91,7 +91,8 @@ class EnhancedICFFormProcessorTest extends TestCase {
         $data = $this->build_submission(overrides: ['name' => 'Jo']);
         $result = $this->processor->process_form_submission('default', $data);
         $this->assertFalse($result['success']);
-        $this->assertStringContainsString('Name too short.', $result['message']);
+        $this->assertSame('Please correct the highlighted fields', $result['message']);
+        $this->assertSame(['name' => 'Name too short.'], $result['errors']);
     }
 
     public function test_validation_errors_follow_field_map() {
@@ -102,8 +103,10 @@ class EnhancedICFFormProcessorTest extends TestCase {
         ]);
         $result = $this->processor->process_form_submission('default', $data);
         $this->assertFalse($result['success']);
-        $this->assertStringContainsString('Invalid email.', $result['message']);
-        $this->assertStringNotContainsString('Invalid phone number.', $result['message']);
+        $this->assertSame('Please correct the highlighted fields', $result['message']);
+        $this->assertArrayHasKey('email', $result['errors']);
+        $this->assertArrayNotHasKey('phone', $result['errors']);
+        $this->assertSame('Invalid email.', $result['errors']['email']);
     }
 
     public function test_template_without_phone_field() {
@@ -122,6 +125,7 @@ class EnhancedICFFormProcessorTest extends TestCase {
         $data   = $this->build_submission('phone_only', overrides: ['phone' => '']);
         $result = $this->processor->process_form_submission('phone_only', $data);
         $this->assertFalse($result['success']);
-        $this->assertStringContainsString('Phone is required.', $result['message']);
+        $this->assertSame('Please correct the highlighted fields', $result['message']);
+        $this->assertSame(['phone' => 'Phone is required.'], $result['errors']);
     }
 }

--- a/tests/EnhancedInternalContactFormTest.php
+++ b/tests/EnhancedInternalContactFormTest.php
@@ -71,7 +71,7 @@ class EnhancedInternalContactFormTest extends TestCase {
 
         $error = $ref->getProperty('error_message');
         $error->setAccessible(true);
-        $this->assertSame('<div class="form-message error">Error happened</div>', $error->getValue($form));
+        $this->assertSame('', $error->getValue($form));
 
         $this->assertSame(['name' => 'Jane'], $form->form_data);
         $this->assertSame(['name' => 'Required'], $form->field_errors);


### PR DESCRIPTION
## Summary
- Return a generic "Please correct the highlighted fields" message on validation failure
- Only show the global error banner when no per-field errors are present and add `eform_show_global_error` filter to override
- Update tests for new messaging logic

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6897c261454c832d9170b04ef01190f6