### PR TITLE
Normalize and validate US phone input

### DIFF
--- a/includes/field-registry.php
+++ b/includes/field-registry.php
@@ -79,7 +79,11 @@ class FieldRegistry {
      * Sanitize to keep digits only.
      */
     public static function sanitize_digits(string $value): string {
-        return preg_replace('/\D/', '', $value);
+        $digits = preg_replace('/\D+/', '', $value);
+        if (strlen($digits) === 11 && $digits[0] === '1') {
+            $digits = substr($digits, 1);
+        }
+        return $digits;
     }
 
     public static function validate_name(string $value, array $field): string {

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -14,6 +14,7 @@ if ( ! function_exists( 'eform_field' ) ) {
      *                     - pattern (string) Regex pattern for input validation.
      *                     - maxlength (int) Maximum allowed length.
      *                     - minlength (int) Minimum required length.
+     *                     - title (string)   Accessible description.
      */
     function eform_field( string $field, array $args = [] ) {
         global $eform_registry, $eform_current_template, $eform_form;
@@ -30,13 +31,14 @@ if ( ! function_exists( 'eform_field' ) ) {
             'pattern'     => '',
             'maxlength'   => '',
             'minlength'   => '',
+            'title'       => '',
         ];
         $args = array_merge( $defaults, $args );
 
         $required_attr = $args['required'] ? ' required aria-required="true"' : '';
 
         $extra_attrs = '';
-        foreach ( [ 'pattern', 'maxlength', 'minlength' ] as $attr ) {
+        foreach ( [ 'pattern', 'maxlength', 'minlength', 'title' ] as $attr ) {
             if ( ! empty( $args[ $attr ] ) ) {
                 $extra_attrs .= ' ' . $attr . '="' . esc_attr( $args[ $attr ] ) . '"';
             }

--- a/templates/form-default.php
+++ b/templates/form-default.php
@@ -16,10 +16,9 @@
         </div>
         <div class="columns_nomargins inputwrap">
             <?php eform_field('phone', [
-                'required'  => true,
-                'pattern'   => '\\d{3}-?\\d{3}-?\\d{4}',
-                'maxlength' => 12,
-                'minlength' => 10,
+                'required' => true,
+                'pattern'  => '\\s*(?:\\(\\d{3}\\)|\\d{3})[-.\\s]?\\d{3}[-.\\s]?\\d{4}\\s*',
+                'title'    => 'U.S. phone number (10 digits)',
             ]); ?>
             <?php eform_field_error('phone'); ?>
             <?php eform_field('zip', [

--- a/tests/EnhancedICFFormProcessorTest.php
+++ b/tests/EnhancedICFFormProcessorTest.php
@@ -128,4 +128,11 @@ class EnhancedICFFormProcessorTest extends TestCase {
         $this->assertSame('Please correct the highlighted fields', $result['message']);
         $this->assertSame(['phone' => 'Phone is required.'], $result['errors']);
     }
+
+    public function test_phone_with_leading_one_is_normalized() {
+        $this->assertSame('2345678901', FieldRegistry::sanitize_digits('+1 (234) 567-8901'));
+        $data   = $this->build_submission(overrides: ['phone' => '+1 (234) 567-8901']);
+        $result = $this->processor->process_form_submission('default', $data);
+        $this->assertTrue($result['success']);
+    }
 }

--- a/tests/TemplateTagsTest.php
+++ b/tests/TemplateTagsTest.php
@@ -47,15 +47,17 @@ class TemplateTagsTest extends TestCase {
 
         ob_start();
         eform_field( 'phone', [
-            'pattern'   => '\\d{3}-?\\d{3}-?\\d{4}',
-            'maxlength' => 12,
+            'pattern'   => '\\s*(?:\\(\\d{3}\\)|\\d{3})[-.\\s]?\\d{3}[-.\\s]?\\d{4}\\s*',
+            'maxlength' => 14,
             'minlength' => 10,
+            'title'     => 'U.S. phone number (10 digits)',
         ] );
         $output = ob_get_clean();
 
-        $this->assertStringContainsString( 'pattern="\\d{3}-?\\d{3}-?\\d{4}"', $output );
-        $this->assertStringContainsString( 'maxlength="12"', $output );
+        $this->assertStringContainsString( 'pattern="\\s*(?:\\(\\d{3}\\)|\\d{3})[-.\\s]?\\d{3}[-.\\s]?\\d{4}\\s*"', $output );
+        $this->assertStringContainsString( 'maxlength="14"', $output );
         $this->assertStringContainsString( 'minlength="10"', $output );
+        $this->assertStringContainsString( 'title="U.S. phone number (10 digits)"', $output );
     }
 
     public function test_eform_field_outputs_textarea_attributes() {


### PR DESCRIPTION
## Summary
- Allow form helper to accept a `title` attribute and expose it on inputs
- Normalize digits-only phone numbers server-side, trimming a leading country code
- Relax phone field pattern to allow common separators while forbidding `+1`

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6897c649dfb4832da5640959daf0b652