### PR TITLE
fix regex in phone field pattern

### DIFF
--- a/templates/form-default.php
+++ b/templates/form-default.php
@@ -17,7 +17,7 @@
         <div class="columns_nomargins inputwrap">
             <?php eform_field('phone', [
                 'required' => true,
-                'pattern'  => '\\s*(?:\\(\\d{3}\\)|\\d{3})[-.\\s]?\\d{3}[-.\\s]?\\d{4}\\s*',
+                'pattern'  => '(?:\\(\\d{3}\\)|\\d{3})[ .-]?\\d{3}[ .-]?\\d{4}',
                 'title'    => 'U.S. phone number (10 digits)',
             ]); ?>
             <?php eform_field_error('phone'); ?>

--- a/tests/TemplateTagsTest.php
+++ b/tests/TemplateTagsTest.php
@@ -47,14 +47,14 @@ class TemplateTagsTest extends TestCase {
 
         ob_start();
         eform_field( 'phone', [
-            'pattern'   => '\\s*(?:\\(\\d{3}\\)|\\d{3})[-.\\s]?\\d{3}[-.\\s]?\\d{4}\\s*',
+            'pattern'   => '(?:\\(\\d{3}\\)|\\d{3})[ .-]?\\d{3}[ .-]?\\d{4}',
             'maxlength' => 14,
             'minlength' => 10,
             'title'     => 'U.S. phone number (10 digits)',
         ] );
         $output = ob_get_clean();
 
-        $this->assertStringContainsString( 'pattern="\\s*(?:\\(\\d{3}\\)|\\d{3})[-.\\s]?\\d{3}[-.\\s]?\\d{4}\\s*"', $output );
+        $this->assertStringContainsString( 'pattern="(?:\\(\\d{3}\\)|\\d{3})[ .-]?\\d{3}[ .-]?\\d{4}"', $output );
         $this->assertStringContainsString( 'maxlength="14"', $output );
         $this->assertStringContainsString( 'minlength="10"', $output );
         $this->assertStringContainsString( 'title="U.S. phone number (10 digits)"', $output );


### PR DESCRIPTION
## Summary
- adjust phone field regex to avoid invalid character class and drop unsupported whitespace escapes
- update template tag tests for new phone pattern

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6897ca06dc94832db47612eea83664d7