### PR TITLE
fix: make phone regex compatible with js v flag

### DIFF
--- a/templates/form-default.php
+++ b/templates/form-default.php
@@ -17,7 +17,9 @@
         <div class="columns_nomargins inputwrap">
             <?php eform_field('phone', [
                 'required' => true,
-                'pattern'  => '(?:\\(\\d{3}\\)|\\d{3})[ .-]?\\d{3}[ .-]?\\d{4}',
+                // Use explicit alternation instead of a character class so the pattern
+                // is compatible with JavaScript's upcoming `v` flag syntax.
+                'pattern'  => '(?:\\(\\d{3}\\)|\\d{3})(?: |\\.|-)?\\d{3}(?: |\\.|-)?\\d{4}',
                 'title'    => 'U.S. phone number (10 digits)',
             ]); ?>
             <?php eform_field_error('phone'); ?>

--- a/tests/TemplateTagsTest.php
+++ b/tests/TemplateTagsTest.php
@@ -47,14 +47,17 @@ class TemplateTagsTest extends TestCase {
 
         ob_start();
         eform_field( 'phone', [
-            'pattern'   => '(?:\\(\\d{3}\\)|\\d{3})[ .-]?\\d{3}[ .-]?\\d{4}',
+            'pattern'   => '(?:\\(\\d{3}\\)|\\d{3})(?: |\\.|-)?\\d{3}(?: |\\.|-)?\\d{4}',
             'maxlength' => 14,
             'minlength' => 10,
             'title'     => 'U.S. phone number (10 digits)',
         ] );
         $output = ob_get_clean();
 
-        $this->assertStringContainsString( 'pattern="(?:\\(\\d{3}\\)|\\d{3})[ .-]?\\d{3}[ .-]?\\d{4}"', $output );
+        $this->assertStringContainsString(
+            'pattern="(?:\\(\\d{3}\\)|\\d{3})(?: |\\.|-)?\\d{3}(?: |\\.|-)?\\d{4}"',
+            $output
+        );
         $this->assertStringContainsString( 'maxlength="14"', $output );
         $this->assertStringContainsString( 'minlength="10"', $output );
         $this->assertStringContainsString( 'title="U.S. phone number (10 digits)"', $output );


### PR DESCRIPTION
## Summary
- replace phone number character class with explicit alternation
- explain v flag compatibility and update tests

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6897cbda5fc8832d91be78d8faa10ffe