### PR TITLE
Log request URI and template in form submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Rotated log files older than 30 days are automatically deleted; customize this
 window by defining `EFORM_LOG_RETENTION_DAYS` or filtering
 `eform_log_retention_days`.
 
-Each entry is stored as JSON and includes a `timestamp` field. An example
-entry looks like this:
+Each entry is stored as JSON and includes a `timestamp` field along with details
+about the request. When available the request URI and template name are
+recorded. An example entry looks like this:
 
 ```
 {
@@ -21,7 +22,9 @@ entry looks like this:
     "source": "Enhanced iContact Form",
     "message": "Submitted form",
     "user_agent": "Mozilla/5.0",
-    "referrer": "No referrer"
+    "referrer": "No referrer",
+    "request_uri": "/contact",
+    "template": "default"
 }
 ```
 
@@ -43,8 +46,9 @@ approved fields are recorded.
 
 By default a successful form submission writes a "Form submission sent" entry to
 the log. The entry records only the safe fields configured via the
-`eform_log_safe_fields` option or filter. Administrators may disable this logging
-by setting `DEBUG_LEVEL` to `0` or filtering the behavior:
+`eform_log_safe_fields` option or filter and includes the template name.
+Administrators may disable this logging by setting `DEBUG_LEVEL` to `0` or
+filtering the behavior:
 
 ```
 add_filter('eform_log_successful_submission', '__return_false');

--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -86,7 +86,7 @@ class Enhanced_ICF_Form_Processor {
             return $this->error_response( 'Email Sending Failure', $details, 'Something went wrong. Please try again later.' );
         }
 
-        $this->log_success( $data );
+        $this->log_success( $template, $data );
         return [ 'success' => true ];
     }
 
@@ -177,7 +177,7 @@ class Enhanced_ICF_Form_Processor {
         return $errors;
     }
 
-    private function log_success( array $data ): void {
+    private function log_success( string $template, array $data ): void {
         $should_log = true;
         if ( defined( 'DEBUG_LEVEL' ) && DEBUG_LEVEL < 1 ) {
             $should_log = false;
@@ -191,7 +191,7 @@ class Enhanced_ICF_Form_Processor {
 
         $safe_fields = eform_get_safe_fields( $data );
         $safe_data   = array_intersect_key( $data, array_flip( $safe_fields ) );
-        $this->logger->log( 'Form submission sent', Logger::LEVEL_INFO, [ 'form_data' => $safe_data ] );
+        $this->logger->log( 'Form submission sent', Logger::LEVEL_INFO, [ 'form_data' => $safe_data, 'template' => $template ] );
     }
 
     private function build_email_body(array $data): string {

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -84,6 +84,10 @@ class Logger {
         $context['message']   = $message;
         $context['user_agent'] = isset($server['HTTP_USER_AGENT']) ? sanitize_text_field($server['HTTP_USER_AGENT']) : '';
         $context['referrer']  = isset($server['HTTP_REFERER']) ? sanitize_text_field($server['HTTP_REFERER']) : 'No referrer';
+        $context['request_uri'] = isset($server['REQUEST_URI']) ? sanitize_text_field($server['REQUEST_URI']) : '';
+        if ( isset( $context['template'] ) ) {
+            $context['template'] = sanitize_text_field( $context['template'] );
+        }
 
         $jsonLogEntry = json_encode($context, JSON_PRETTY_PRINT);
         if (json_last_error() !== JSON_ERROR_NONE) {

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -82,6 +82,17 @@ class LoggerTest extends TestCase {
         $this->assertNotEquals($oldFile, $rotatedAfter[0], 'Old rotated log should be deleted');
     }
 
+    public function test_logs_request_uri_and_template(): void {
+        $_SERVER['REQUEST_URI'] = '/sample-page';
+        $logger = new \Logger();
+        $logger->log('hi', \Logger::LEVEL_INFO, ['template' => 'contact']);
+        $contents = file_get_contents($this->logFile);
+        $this->assertNotEmpty($contents);
+        $entry = json_decode($contents, true);
+        $this->assertSame('/sample-page', $entry['request_uri']);
+        $this->assertSame('contact', $entry['template']);
+    }
+
     private function rrmdir(string $dir): void {
         if (!is_dir($dir)) {
             return;


### PR DESCRIPTION
## Summary
- Include request URI and optional template name in log entries
- Pass template name when logging successful submissions
- Document new log fields and test logging behavior

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6897cff35f90832d88b6fd24b74fd30a