### PR TITLE
Refactor template tags to accept registry and form instances

### DIFF
--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -5,21 +5,22 @@ if ( ! function_exists( 'eform_field' ) ) {
     /**
      * Render a form field and register it for processing.
      *
-     * @param string $field Field key (name, email, phone, zip, message).
-     * @param array  $args  Optional arguments.
-     *                     - required (bool)  Whether the field is required.
-     *                     - placeholder (string) Placeholder text.
-     *                     - rows (int)  Rows for textarea fields.
-     *                     - cols (int)  Cols for textarea fields.
-     *                     - pattern (string) Regex pattern for input validation.
-     *                     - maxlength (int) Maximum allowed length.
-     *                     - minlength (int) Minimum required length.
-     *                     - title (string)   Accessible description.
+     * @param FieldRegistry $registry Field registry instance.
+     * @param object        $form     Form instance providing data and helpers.
+     * @param string        $template Template slug.
+     * @param string        $field    Field key (name, email, phone, zip, message).
+     * @param array         $args     Optional arguments.
+     *                               - required (bool)  Whether the field is required.
+     *                               - placeholder (string) Placeholder text.
+     *                               - rows (int)  Rows for textarea fields.
+     *                               - cols (int)  Cols for textarea fields.
+     *                               - pattern (string) Regex pattern for input validation.
+     *                               - maxlength (int) Maximum allowed length.
+     *                               - minlength (int) Minimum required length.
+     *                               - title (string)   Accessible description.
      */
-    function eform_field( string $field, array $args = [] ) {
-        global $eform_registry, $eform_current_template, $eform_form;
-
-        if ( empty( $eform_registry ) || empty( $eform_current_template ) ) {
+    function eform_field( FieldRegistry $registry, $form, string $template, string $field, array $args = [] ) {
+        if ( empty( $template ) ) {
             return;
         }
 
@@ -47,9 +48,9 @@ if ( ! function_exists( 'eform_field' ) ) {
         $attrs = $required_attr . $extra_attrs;
 
         // Record field presence with registry.
-        $eform_registry->register_field( $eform_current_template, $field, [ 'required' => $args['required'] ] );
+        $registry->register_field( $template, $field, [ 'required' => $args['required'] ] );
 
-        $value = $eform_form->form_data[ $field ] ?? '';
+        $value = $form->form_data[ $field ] ?? '';
 
         switch ( $field ) {
             case 'name':
@@ -68,7 +69,7 @@ if ( ! function_exists( 'eform_field' ) ) {
 
             case 'phone':
                 $placeholder = $args['placeholder'] ?: 'Phone';
-                $formatted   = $eform_form->format_phone( $value );
+                $formatted   = $form->format_phone( $value );
                 echo '<input class="form_field" type="tel" name="tel_input" autocomplete="tel"' .
                     $attrs . ' aria-label="Phone" placeholder="' . esc_attr( $placeholder ) .
                     '" value="' . esc_attr( $formatted ) . '">';
@@ -95,16 +96,15 @@ if ( ! function_exists( 'eform_field_error' ) ) {
     /**
      * Output a field-specific error message when available.
      *
+     * @param object $form  Form instance containing validation errors.
      * @param string $field Field key.
      */
-    function eform_field_error( string $field ) {
-        global $eform_form;
-
-        if ( empty( $eform_form ) ) {
+    function eform_field_error( $form, string $field ) {
+        if ( empty( $form ) ) {
             return;
         }
 
-        $error = $eform_form->field_errors[ $field ] ?? '';
+        $error = $form->field_errors[ $field ] ?? '';
 
         if ( $error ) {
             echo '<div class="field-error">' . esc_html( $error ) . '</div>';

--- a/templates/form-custom.php
+++ b/templates/form-custom.php
@@ -1,19 +1,20 @@
 <?php
 // templates/form-custom.php
+global $eform_registry, $eform_form, $eform_current_template;
 ?>
 <div id="contact_form" class="contact_form">
     <form class="general_contact_form" id="general_contact_form" aria-label="Contact Form" method="post" action="">
         <?php Enhanced_Internal_Contact_Form::render_hidden_fields('custom'); ?>
-        <div><?php eform_field('message', [
+        <div><?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'message', [
                 'required'  => true,
                 'placeholder' => 'Write your message...',
                 'rows'      => 6,
                 'minlength' => 20,
                 'maxlength' => 1000,
-            ]); ?>
-            <?php eform_field_error('message'); ?></div>
-        <div><?php eform_field('email', [ 'required' => true, 'placeholder' => 'Enter Your Email*' ]); ?>
-            <?php eform_field_error('email'); ?></div>
+            ] ); ?>
+            <?php eform_field_error( $eform_form, 'message' ); ?></div>
+        <div><?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'email', [ 'required' => true, 'placeholder' => 'Enter Your Email*' ] ); ?>
+            <?php eform_field_error( $eform_form, 'email' ); ?></div>
         <div><button type="submit" name="enhanced_form_submit_custom">Click to Send</button></div>
     </form>
 </div>

--- a/templates/form-default.php
+++ b/templates/form-default.php
@@ -2,42 +2,43 @@
 /**
  * Template: form-default.php
  */
+global $eform_registry, $eform_form, $eform_current_template;
 ?>
 <div id="contact_form" class="contact_form">
     <form class="main_contact_form" id="main_contact_form" aria-label="Contact Form" method="post" action="">
         <?php Enhanced_Internal_Contact_Form::render_hidden_fields('default'); ?>
         <div class="inputwrap">
-            <?php eform_field('name', [ 'required' => true ]); ?>
-            <?php eform_field_error('name'); ?>
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'name', [ 'required' => true ] ); ?>
+            <?php eform_field_error( $eform_form, 'name' ); ?>
         </div>
         <div class="inputwrap">
-            <?php eform_field('email', [ 'required' => true ]); ?>
-            <?php eform_field_error('email'); ?>
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'email', [ 'required' => true ] ); ?>
+            <?php eform_field_error( $eform_form, 'email' ); ?>
         </div>
         <div class="columns_nomargins inputwrap">
-            <?php eform_field('phone', [
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'phone', [
                 'required' => true,
                 // Use explicit alternation instead of a character class so the pattern
                 // is compatible with JavaScript's upcoming `v` flag syntax.
                 'pattern'  => '(?:\\(\\d{3}\\)|\\d{3})(?: |\\.|-)?\\d{3}(?: |\\.|-)?\\d{4}',
                 'title'    => 'U.S. phone number (10 digits)',
-            ]); ?>
-            <?php eform_field_error('phone'); ?>
-            <?php eform_field('zip', [
+            ] ); ?>
+            <?php eform_field_error( $eform_form, 'phone' ); ?>
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'zip', [
                 'required'  => true,
                 'pattern'   => '\\d{5}',
                 'maxlength' => 5,
                 'minlength' => 5,
-            ]); ?>
-            <?php eform_field_error('zip'); ?>
+            ] ); ?>
+            <?php eform_field_error( $eform_form, 'zip' ); ?>
         </div>
         <div class="inputwrap">
-            <?php eform_field('message', [
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'message', [
                 'required'  => true,
                 'minlength' => 20,
                 'maxlength' => 1000,
-            ]); ?>
-            <?php eform_field_error('message'); ?>
+            ] ); ?>
+            <?php eform_field_error( $eform_form, 'message' ); ?>
         </div>
 
         <input type="hidden" name="submitted" value="1" aria-hidden="true">

--- a/tests/TemplateTagsTest.php
+++ b/tests/TemplateTagsTest.php
@@ -5,48 +5,40 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../includes/template-tags.php';
 
 class TemplateTagsTest extends TestCase {
-    protected function tearDown(): void {
-        // Clean up global form object between tests.
-        unset( $GLOBALS['eform_form'] );
-    }
 
     public function test_eform_field_error_outputs_message() {
-        global $eform_form;
-        $eform_form = (object) [
+        $form = (object) [
             'field_errors' => [ 'name' => 'Required' ],
         ];
 
         ob_start();
-        eform_field_error( 'name' );
+        eform_field_error( $form, 'name' );
         $output = ob_get_clean();
 
         $this->assertSame( '<div class="field-error">Required</div>', $output );
     }
 
     public function test_eform_field_error_outputs_nothing_when_no_message() {
-        global $eform_form;
-        $eform_form = (object) [ 'field_errors' => [] ];
+        $form = (object) [ 'field_errors' => [] ];
 
         ob_start();
-        eform_field_error( 'email' );
+        eform_field_error( $form, 'email' );
         $output = ob_get_clean();
 
         $this->assertSame( '', $output );
     }
 
     public function test_eform_field_outputs_additional_attributes() {
-        global $eform_form, $eform_registry, $eform_current_template;
+        $registry          = new FieldRegistry();
+        $current_template  = 'default';
 
-        $eform_registry        = new FieldRegistry();
-        $eform_current_template = 'default';
-
-        $eform_form = new class {
+        $form = new class {
             public $form_data = [];
             public function format_phone( $digits ) { return $digits; }
         };
 
         ob_start();
-        eform_field( 'phone', [
+        eform_field( $registry, $form, $current_template, 'phone', [
             'pattern'   => '(?:\\(\\d{3}\\)|\\d{3})(?: |\\.|-)?\\d{3}(?: |\\.|-)?\\d{4}',
             'maxlength' => 14,
             'minlength' => 10,
@@ -64,15 +56,13 @@ class TemplateTagsTest extends TestCase {
     }
 
     public function test_eform_field_outputs_textarea_attributes() {
-        global $eform_form, $eform_registry, $eform_current_template;
+        $registry         = new FieldRegistry();
+        $current_template = 'default';
 
-        $eform_registry        = new FieldRegistry();
-        $eform_current_template = 'default';
-
-        $eform_form = (object) [ 'form_data' => [] ];
+        $form = (object) [ 'form_data' => [] ];
 
         ob_start();
-        eform_field( 'message', [
+        eform_field( $registry, $form, $current_template, 'message', [
             'minlength' => 20,
             'maxlength' => 1000,
         ] );


### PR DESCRIPTION
## Summary
- refactor `eform_field` and `eform_field_error` to accept registry and form instances instead of relying on globals
- update form templates to pass registry, form, and template slug explicitly
- adjust unit tests for new function signatures

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6897d1ad6424832d8180cb540c421e59