### PR TITLE
Validate field callbacks on registration

### DIFF
--- a/includes/field-registry.php
+++ b/includes/field-registry.php
@@ -59,10 +59,26 @@ class FieldRegistry {
             return;
         }
 
-        $config = self::FIELDS[ $field ];
+        // Merge base configuration with any overrides.
+        $config = array_merge( self::FIELDS[ $field ], $args );
 
-        if ( isset( $args['required'] ) ) {
-            $config['required'] = (bool) $args['required'];
+        if ( isset( $config['required'] ) ) {
+            $config['required'] = (bool) $config['required'];
+        }
+
+        // Ensure callbacks are valid before registering.
+        foreach ( [ 'sanitize_cb', 'validate_cb' ] as $cb_key ) {
+            if ( isset( $config[ $cb_key ] ) && ! is_callable( $config[ $cb_key ] ) ) {
+                $message = sprintf(
+                    'Invalid %s for field "%s" in template "%s"',
+                    $cb_key,
+                    $field,
+                    $template
+                );
+                // Trigger a warning for invalid callbacks.
+                trigger_error( $message, E_USER_WARNING );
+                return;
+            }
         }
 
         $this->registered[ $template ][ $field ] = $config;

--- a/tests/FieldRegistryTest.php
+++ b/tests/FieldRegistryTest.php
@@ -1,0 +1,50 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class FieldRegistryTest extends TestCase {
+    public function testInvalidSanitizeCallbackTriggersWarningAndIsNotRegistered() {
+        $registry = new FieldRegistry();
+        $error = null;
+        set_error_handler(function($errno, $errstr) use (&$error) {
+            $error = $errstr;
+            return true; // suppress default error handling
+        });
+
+        // Attempt to register field with invalid sanitize callback.
+        $registry->register_field('template', 'name', ['sanitize_cb' => 'nonexistent_function']);
+
+        restore_error_handler();
+
+        // Register another valid field to inspect registered set for template.
+        $registry->register_field('template', 'email');
+
+        $fields = $registry->get_fields('template');
+        $this->assertArrayHasKey('email', $fields);
+        $this->assertArrayNotHasKey('name', $fields);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('sanitize_cb', $error);
+    }
+
+    public function testInvalidValidateCallbackTriggersWarningAndIsNotRegistered() {
+        $registry = new FieldRegistry();
+        $error = null;
+        set_error_handler(function($errno, $errstr) use (&$error) {
+            $error = $errstr;
+            return true; // suppress default error handling
+        });
+
+        // Attempt to register field with invalid validate callback.
+        $registry->register_field('template', 'email', ['validate_cb' => 'nonexistent_function']);
+
+        restore_error_handler();
+
+        // Register another valid field to ensure template exists.
+        $registry->register_field('template', 'name');
+
+        $fields = $registry->get_fields('template');
+        $this->assertArrayHasKey('name', $fields);
+        $this->assertArrayNotHasKey('email', $fields);
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('validate_cb', $error);
+    }
+}


### PR DESCRIPTION
## Summary
- verify sanitize and validate callbacks when registering fields
- skip registration and warn when callbacks are not callable
- add tests for invalid callback handling

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6897d615a490832dbebd2239ad3de14e