### PR TITLE
Allow plugin-level template configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,6 @@ Themes may override default form settings by placing JSON or YAML files within
 `{theme}/eform/`. For example, `wp-content/themes/my-theme/eform/default.json`
 can adjust placeholders or other field attributes for the `default` template.
 Files are validated against `includes/form-template-schema.json` before being
-merged with the plugin's defaults.
+merged with the plugin's defaults. If a theme file is not found, the plugin
+will also look for a matching configuration within its own
+`templates/` directory, providing a plugin-level fallback.

--- a/includes/template-config.php
+++ b/includes/template-config.php
@@ -70,12 +70,23 @@ function eform_get_template_config(string $template): array {
 
     $base = $defaults[$template] ?? [];
 
-    $theme_dir = rtrim(get_stylesheet_directory(), '/\\') . '/eform';
-    $paths = [
+    $theme_dir   = rtrim( get_stylesheet_directory(), '/\\' ) . '/eform';
+    $paths       = [
         $theme_dir . '/' . $template . '.json',
         $theme_dir . '/' . $template . '.yaml',
         $theme_dir . '/' . $template . '.yml',
     ];
+
+    // Fallback to bundled templates when theme files are absent.
+    $plugin_dir = rtrim( plugin_dir_path( __DIR__ ), '/\\' ) . '/templates';
+    $paths      = array_merge(
+        $paths,
+        [
+            $plugin_dir . '/' . $template . '.json',
+            $plugin_dir . '/' . $template . '.yaml',
+            $plugin_dir . '/' . $template . '.yml',
+        ]
+    );
 
     $data = [];
     foreach ( $paths as $path ) {


### PR DESCRIPTION
## Summary
- Look for template config files in the plugin's `templates/` directory when missing from the theme
- Document plugin-level fallback behaviour in README
- Test plugin template configuration

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6898ed653388832dafdc7d08713f879a