### PR TITLE
Render form fields from template config

### DIFF
--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -16,6 +16,7 @@ class Enhanced_Internal_Contact_Form {
     private $css_printed = false; // Ensure CSS only printed once
     private $processor;
     private $logger;
+    public $template_config = [];
 
     public function __construct( Enhanced_ICF_Form_Processor $processor, Logger $logger ) {
         $this->processor = $processor;
@@ -208,6 +209,17 @@ class Enhanced_Internal_Contact_Form {
 
     private function render_form( $template ) {
         $this->prepare_css( $template );
+
+        // Load template configuration and register fields for this template.
+        $this->template_config = eform_get_template_config( $template );
+        global $eform_registry;
+        if ( isset( $eform_registry ) ) {
+            foreach ( $this->template_config['fields'] ?? [] as $post_key => $field ) {
+                $key   = FieldRegistry::field_key_from_post( $post_key );
+                $field = array_merge( $field, [ 'post_key' => $post_key ] );
+                $eform_registry->register_field_from_config( $template, $key, $field );
+            }
+        }
 
         // If we succeeded *and* have a redirect URL, bail out (we’ll redirect instead)
         if ( $this->form_submitted && ! empty( $this->redirect_url ) ) {

--- a/templates/form-custom.php
+++ b/templates/form-custom.php
@@ -1,20 +1,35 @@
 <?php
 // templates/form-custom.php
-global $eform_registry, $eform_form, $eform_current_template;
+global $eform_form;
+$config = $eform_form->template_config;
 ?>
 <div id="contact_form" class="contact_form">
     <form class="general_contact_form" id="general_contact_form" aria-label="Contact Form" method="post" action="">
         <?php Enhanced_Internal_Contact_Form::render_hidden_fields('custom'); ?>
-        <div><?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'message', [
-                'required'  => true,
-                'placeholder' => 'Write your message...',
-                'rows'      => 6,
-                'minlength' => 20,
-                'maxlength' => 1000,
-            ] ); ?>
-            <?php eform_field_error( $eform_form, 'message' ); ?></div>
-        <div><?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'email', [ 'required' => true, 'placeholder' => 'Enter Your Email*' ] ); ?>
-            <?php eform_field_error( $eform_form, 'email' ); ?></div>
+        <?php foreach ( $config['fields'] ?? [] as $post_key => $field ) :
+            $field_key = FieldRegistry::field_key_from_post( $post_key );
+            $value     = $eform_form->form_data[ $field_key ] ?? '';
+            if ( ( $field['type'] ?? '' ) === 'tel' ) {
+                $value = $eform_form->format_phone( $value );
+            }
+            $required = isset( $field['required'] ) ? ' required aria-required="true"' : '';
+            $attr_str = '';
+            foreach ( $field as $attr => $val ) {
+                if ( in_array( $attr, [ 'type', 'required', 'style' ], true ) ) {
+                    continue;
+                }
+                $attr_str .= sprintf( ' %s="%s"', esc_attr( $attr ), esc_attr( $val ) );
+            }
+        ?>
+        <div class="inputwrap" style="<?php echo esc_attr( $field['style'] ?? '' ); ?>">
+            <?php if ( ( $field['type'] ?? '' ) === 'textarea' ) : ?>
+                <textarea name="<?php echo esc_attr( $post_key ); ?>"<?php echo $required . $attr_str; ?>><?php echo esc_textarea( $value ); ?></textarea>
+            <?php else : ?>
+                <input type="<?php echo esc_attr( $field['type'] ?? 'text' ); ?>" name="<?php echo esc_attr( $post_key ); ?>" value="<?php echo esc_attr( $value ); ?>"<?php echo $required . $attr_str; ?>>
+            <?php endif; ?>
+            <?php eform_field_error( $eform_form, $field_key ); ?>
+        </div>
+        <?php endforeach; ?>
         <div><button type="submit" name="enhanced_form_submit_custom">Click to Send</button></div>
     </form>
 </div>

--- a/templates/form-default.php
+++ b/templates/form-default.php
@@ -2,44 +2,36 @@
 /**
  * Template: form-default.php
  */
-global $eform_registry, $eform_form, $eform_current_template;
+global $eform_form, $eform_current_template;
+$config = $eform_form->template_config;
 ?>
 <div id="contact_form" class="contact_form">
     <form class="main_contact_form" id="main_contact_form" aria-label="Contact Form" method="post" action="">
         <?php Enhanced_Internal_Contact_Form::render_hidden_fields('default'); ?>
-        <div class="inputwrap">
-            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'name', [ 'required' => true ] ); ?>
-            <?php eform_field_error( $eform_form, 'name' ); ?>
+        <?php foreach ( $config['fields'] ?? [] as $post_key => $field ) :
+            $field_key = FieldRegistry::field_key_from_post( $post_key );
+            $value     = $eform_form->form_data[ $field_key ] ?? '';
+            if ( ( $field['type'] ?? '' ) === 'tel' ) {
+                $value = $eform_form->format_phone( $value );
+            }
+            $required = isset( $field['required'] ) ? ' required aria-required="true"' : '';
+            $attr_str = '';
+            foreach ( $field as $attr => $val ) {
+                if ( in_array( $attr, [ 'type', 'required', 'style' ], true ) ) {
+                    continue;
+                }
+                $attr_str .= sprintf( ' %s="%s"', esc_attr( $attr ), esc_attr( $val ) );
+            }
+        ?>
+        <div class="inputwrap" style="<?php echo esc_attr( $field['style'] ?? '' ); ?>">
+            <?php if ( ( $field['type'] ?? '' ) === 'textarea' ) : ?>
+                <textarea name="<?php echo esc_attr( $post_key ); ?>"<?php echo $required . $attr_str; ?>><?php echo esc_textarea( $value ); ?></textarea>
+            <?php else : ?>
+                <input type="<?php echo esc_attr( $field['type'] ?? 'text' ); ?>" name="<?php echo esc_attr( $post_key ); ?>" value="<?php echo esc_attr( $value ); ?>"<?php echo $required . $attr_str; ?>>
+            <?php endif; ?>
+            <?php eform_field_error( $eform_form, $field_key ); ?>
         </div>
-        <div class="inputwrap">
-            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'email', [ 'required' => true ] ); ?>
-            <?php eform_field_error( $eform_form, 'email' ); ?>
-        </div>
-        <div class="columns_nomargins inputwrap">
-            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'phone', [
-                'required' => true,
-                // Use explicit alternation instead of a character class so the pattern
-                // is compatible with JavaScript's upcoming `v` flag syntax.
-                'pattern'  => '(?:\\(\\d{3}\\)|\\d{3})(?: |\\.|-)?\\d{3}(?: |\\.|-)?\\d{4}',
-                'title'    => 'U.S. phone number (10 digits)',
-            ] ); ?>
-            <?php eform_field_error( $eform_form, 'phone' ); ?>
-            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'zip', [
-                'required'  => true,
-                'pattern'   => '\\d{5}',
-                'maxlength' => 5,
-                'minlength' => 5,
-            ] ); ?>
-            <?php eform_field_error( $eform_form, 'zip' ); ?>
-        </div>
-        <div class="inputwrap">
-            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'message', [
-                'required'  => true,
-                'minlength' => 20,
-                'maxlength' => 1000,
-            ] ); ?>
-            <?php eform_field_error( $eform_form, 'message' ); ?>
-        </div>
+        <?php endforeach; ?>
 
         <input type="hidden" name="submitted" value="1" aria-hidden="true">
         <button type="submit" name="enhanced_form_submit_default" aria-label="Send Request" value="Send Request">Send Request</button>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,6 +44,15 @@ function eform_get_safe_fields($data){
     return array_keys($data);
 }
 
+function register_template_fields_from_config( FieldRegistry $registry, string $template ): void {
+    $config = eform_get_template_config( $template );
+    foreach ( $config['fields'] ?? [] as $post_key => $field ) {
+        $key   = FieldRegistry::field_key_from_post( $post_key );
+        $field = array_merge( $field, [ 'post_key' => $post_key ] );
+        $registry->register_field_from_config( $template, $key, $field );
+    }
+}
+
 function get_default_field_values( FieldRegistry $registry, string $template = 'default' ): array {
     $defaults = [
         'name'    => 'John Doe',


### PR DESCRIPTION
## Summary
- load field configuration during form rendering and register each field
- map field types to sanitize and validate callbacks with dynamic registry helpers
- render templates using loaded configuration and verify only configured fields are processed

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6898f0eb6878832d95199f3c12e95ac0