### PR TITLE
Conditionally enqueue assets for shortcode

### DIFF
--- a/eform.php
+++ b/eform.php
@@ -11,11 +11,16 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// Load global assets
-add_action('wp_enqueue_scripts', function () {
-    $js_url = plugins_url('assets/enhanced-form.js', __FILE__);
-    wp_enqueue_script('enhanced-icf-js', $js_url, array(), '1.0', true);
-});
+// Load assets only when shortcode is present
+function enhanced_icf_enqueue_scripts() {
+    global $post;
+
+    if ( isset( $post->post_content ) && has_shortcode( $post->post_content, 'enhanced_icf_shortcode' ) ) {
+        $js_url = plugins_url( 'assets/enhanced-form.js', __FILE__ );
+        wp_enqueue_script( 'enhanced-icf-js', $js_url, array(), '1.0', true );
+    }
+}
+add_action( 'wp_enqueue_scripts', 'enhanced_icf_enqueue_scripts' );
 
 // Include supporting files
 require_once plugin_dir_path( __FILE__ ) . 'includes/logger.php';

--- a/tests/AssetsEnqueueTest.php
+++ b/tests/AssetsEnqueueTest.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/../eform.php';
+
+use PHPUnit\Framework\TestCase;
+
+class AssetsEnqueueTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['enqueued_scripts'] = [];
+    }
+
+    public function test_scripts_enqueued_when_shortcode_present() {
+        global $post;
+        $post = new WP_Post();
+        $post->post_content = '[enhanced_icf_shortcode]';
+
+        enhanced_icf_enqueue_scripts();
+
+        $this->assertContains( 'enhanced-icf-js', $GLOBALS['enqueued_scripts'] );
+    }
+
+    public function test_scripts_not_enqueued_without_shortcode() {
+        global $post;
+        $post = new WP_Post();
+        $post->post_content = 'No shortcode here';
+
+        enhanced_icf_enqueue_scripts();
+
+        $this->assertEmpty( $GLOBALS['enqueued_scripts'] );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,9 @@
 <?php
 require_once __DIR__ . '/../vendor/autoload.php';
 // Minimal WordPress stubs for testing
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ );
+}
 function sanitize_text_field($str){
     $str = strip_tags($str);
     $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
@@ -82,6 +85,15 @@ function wp_safe_redirect($url){
 function esc_url_raw($url){
     return $url;
 }
+function plugins_url( $path = '', $plugin = '' ) {
+    return $path;
+}
+function has_shortcode( $content, $shortcode ) {
+    return strpos( $content, '[' . $shortcode ) !== false;
+}
+function wp_enqueue_script( $handle, $src = '', $deps = [], $ver = false, $in_footer = false ) {
+    $GLOBALS['enqueued_scripts'][] = $handle;
+}
 function add_action($hook,$callback,$priority=10){
 }
 function add_shortcode($tag,$callback){
@@ -106,6 +118,9 @@ function wp_mkdir_p($dir){
     return true;
 }
 function wp_nonce_field(){ }
+class WP_Post {
+    public $post_content;
+}
 if ( ! defined('WP_CONTENT_DIR') ) {
     define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wp-content');
 }


### PR DESCRIPTION
## Summary
- enqueue plugin script only when `enhanced_icf_shortcode` is present
- expand test bootstrap with WordPress stubs for asset checks
- add integration tests ensuring scripts load only with shortcode

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6898f501b8a4832d9312a56854842238