### PR TITLE
Fix missing template config include so form shortcode renders

### DIFF
--- a/eform.php
+++ b/eform.php
@@ -35,6 +35,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/mail-error-logger.php';
 new Mail_Error_Logger( $logger );
 require_once plugin_dir_path( __FILE__ ) . 'includes/field-registry.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/template-tags.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/template-config.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-enhanced-icf-processor.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-enhanced-icf.php';
 


### PR DESCRIPTION
## Summary
- Include template-config.php to provide eform_get_template_config

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6898f68908f8832d9d1a22d308c4e5c7