### PR TITLE
Load template defaults from JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ ensuring submitted data is handled securely.
 
 ## Theme-based Template Configuration
 
-Themes may override default form settings by placing JSON or YAML files within
+The plugin ships with its default field configuration in `templates/default.json`.
+Themes may override these settings by placing JSON or YAML files within
 `{theme}/eform/`. For example, `wp-content/themes/my-theme/eform/default.json`
 can adjust placeholders or other field attributes for the `default` template.
 Files are validated against `includes/form-template-schema.json` before being
 merged with the plugin's defaults. If a theme file is not found, the plugin
-will also look for a matching configuration within its own
-`templates/` directory, providing a plugin-level fallback.
+will also look for a matching configuration within its own `templates/`
+directory, providing a plugin-level fallback.

--- a/templates/default.json
+++ b/templates/default.json
@@ -1,0 +1,50 @@
+{
+    "fields": {
+        "name_input": {
+            "type": "text",
+            "placeholder": "Your Name",
+            "required": "",
+            "autocomplete": "name",
+            "aria-label": "Your Name",
+            "aria-required": "true",
+            "style": "grid-area: name"
+        },
+        "email_input": {
+            "type": "email",
+            "placeholder": "Your Email",
+            "required": "",
+            "autocomplete": "email",
+            "aria-label": "email",
+            "aria-required": "true",
+            "style": "grid-area: email"
+        },
+        "tel_input": {
+            "type": "tel",
+            "placeholder": "Phone",
+            "required": "",
+            "autocomplete": "tel",
+            "aria-label": "Phone",
+            "aria-required": "true",
+            "style": "grid-area: phone"
+        },
+        "zip_input": {
+            "type": "text",
+            "placeholder": "Project Zip Code",
+            "required": "",
+            "autocomplete": "postal-code",
+            "aria-label": "Project Zip Code",
+            "aria-required": "true",
+            "style": "grid-area: zip"
+        },
+        "message_input": {
+            "type": "textarea",
+            "cols": "21",
+            "rows": "5",
+            "placeholder": "Please describe your project and let us know if there is any urgency",
+            "required": "",
+            "aria-label": "Message",
+            "aria-required": "true",
+            "style": "grid-area: message"
+        }
+    }
+}

--- a/tests/TemplateConfigTest.php
+++ b/tests/TemplateConfigTest.php
@@ -26,11 +26,6 @@ class TemplateConfigTest extends TestCase {
             }
             rmdir( $this->themeDir );
         }
-
-        $pluginConfig = $this->pluginTemplatesDir . '/default.json';
-        if ( file_exists( $pluginConfig ) ) {
-            unlink( $pluginConfig );
-        }
     }
 
     public function test_json_config_merges_with_defaults(): void {
@@ -77,20 +72,9 @@ class TemplateConfigTest extends TestCase {
     }
 
     public function test_plugin_config_used_when_theme_missing(): void {
-        $config = [
-            'fields' => [
-                'zip_input' => [
-                    'type'        => 'text',
-                    'placeholder' => 'Plugin Zip',
-                ],
-            ],
-        ];
-        file_put_contents( $this->pluginTemplatesDir . '/default.json', json_encode( $config ) );
-
         $result = eform_get_template_config( 'default' );
-
-        $this->assertSame( 'Plugin Zip', $result['fields']['zip_input']['placeholder'] );
-        $this->assertArrayHasKey( 'name_input', $result['fields'] );
+        $this->assertSame( 'Your Name', $result['fields']['name_input']['placeholder'] );
+        $this->assertArrayHasKey( 'email_input', $result['fields'] );
     }
 }
 


### PR DESCRIPTION
## Summary
- Move default field metadata into `templates/default.json`
- Rework `eform_get_template_config` to load JSON/YAML defaults and theme overrides
- Document and test file-based template configuration

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6898fe509f80832db726b17c642a0d2b