### PR TITLE
Ensure plugin loads Composer dependencies

### DIFF
--- a/eform.php
+++ b/eform.php
@@ -11,6 +11,12 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+// Load Composer autoloader if available for external dependencies.
+$autoload_path = plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+if ( file_exists( $autoload_path ) ) {
+    require_once $autoload_path;
+}
+
 // Load assets only when shortcode is present
 function enhanced_icf_enqueue_scripts() {
     global $post;


### PR DESCRIPTION
## Summary
- Autoload Composer packages when available so shortcode-driven forms can initialize.

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6899018408e0832d8c9e578b076efe4d