### PR TITLE
Invoke callbacks directly in form processor

### DIFF
--- a/includes/class-enhanced-icf-processor.php
+++ b/includes/class-enhanced-icf-processor.php
@@ -155,7 +155,8 @@ class Enhanced_ICF_Form_Processor {
                 continue;
             }
 
-            $data[ $field ] = call_user_func( $details['sanitize_cb'], $value );
+            $sanitize_cb    = $details['sanitize_cb'];
+            $data[ $field ] = $sanitize_cb( $value );
         }
 
         return [
@@ -168,7 +169,8 @@ class Enhanced_ICF_Form_Processor {
         $errors = [];
 
         foreach ( $field_map as $field => $details ) {
-            $error = call_user_func( $details['validate_cb'], $data[ $field ] ?? '', $details );
+            $validate_cb = $details['validate_cb'];
+            $error       = $validate_cb( $data[ $field ] ?? '', $details );
             if ( $error ) {
                 $errors[ $field ] = $error;
             }

--- a/tests/FieldRegistryTest.php
+++ b/tests/FieldRegistryTest.php
@@ -2,6 +2,15 @@
 use PHPUnit\Framework\TestCase;
 
 class FieldRegistryTest extends TestCase {
+    public function testRegisteredCallbacksAreCallable() {
+        $registry = new FieldRegistry();
+        register_template_fields_from_config( $registry, 'default' );
+        $fields = $registry->get_fields( 'default' );
+        foreach ( $fields as $details ) {
+            $this->assertIsCallable( $details['sanitize_cb'] );
+            $this->assertIsCallable( $details['validate_cb'] );
+        }
+    }
     public function testInvalidSanitizeCallbackTriggersWarningAndIsNotRegistered() {
         $registry = new FieldRegistry();
         $error = null;


### PR DESCRIPTION
## Summary
- Replace `call_user_func` with direct invocation for sanitization and validation callbacks
- Add regression test ensuring registered field callbacks are callable

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68990d164b90832dac0e8d2d8f7e473c