### PR TITLE
Ensure server-side enforcement of required fields

### DIFF
--- a/includes/field-registry.php
+++ b/includes/field-registry.php
@@ -186,7 +186,7 @@ class FieldRegistry {
 
         $field_config = [
             'post_key'    => $config['post_key'] ?? $field,
-            'required'    => ! empty( $config['required'] ),
+            'required'    => array_key_exists( 'required', $config ),
             'sanitize_cb' => $callbacks['sanitize_cb'],
             'validate_cb' => $callbacks['validate_cb'],
         ];
@@ -243,6 +243,9 @@ class FieldRegistry {
     }
 
     public static function validate_name(string $value, array $field): string {
+        if ($value === '') {
+            return ! empty($field['required']) ? 'Name is required.' : '';
+        }
         if (strlen($value) < 3) {
             return 'Name too short.';
         }
@@ -253,6 +256,9 @@ class FieldRegistry {
     }
 
     public static function validate_email(string $value, array $field): string {
+        if ($value === '') {
+            return ! empty($field['required']) ? 'Email is required.' : '';
+        }
         if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
             return 'Invalid email.';
         }
@@ -260,8 +266,8 @@ class FieldRegistry {
     }
 
     public static function validate_phone(string $value, array $field): string {
-        if ($field['required'] && empty($value)) {
-            return 'Phone is required.';
+        if ($value === '') {
+            return ! empty($field['required']) ? 'Phone is required.' : '';
         }
         if (!preg_match('/^\d{10}$/', $value)) {
             return 'Invalid phone number.';
@@ -270,6 +276,9 @@ class FieldRegistry {
     }
 
     public static function validate_zip(string $value, array $field): string {
+        if ($value === '') {
+            return ! empty($field['required']) ? 'Zip is required.' : '';
+        }
         if (!preg_match('/^\d{5}$/', $value)) {
             return 'Zip must be 5 digits.';
         }
@@ -278,6 +287,9 @@ class FieldRegistry {
 
     public static function validate_message(string $value, array $field): string {
         $plain = wp_strip_all_tags($value);
+        if ($plain === '') {
+            return ! empty($field['required']) ? 'Message is required.' : '';
+        }
         if (strlen($plain) < 20) {
             return 'Message too short.';
         }

--- a/templates/default.json
+++ b/templates/default.json
@@ -3,7 +3,7 @@
         "name_input": {
             "type": "text",
             "placeholder": "Your Name",
-            "required": "",
+            "required": true,
             "autocomplete": "name",
             "aria-label": "Your Name",
             "aria-required": "true",
@@ -12,7 +12,7 @@
         "email_input": {
             "type": "email",
             "placeholder": "Your Email",
-            "required": "",
+            "required": true,
             "autocomplete": "email",
             "aria-label": "email",
             "aria-required": "true",
@@ -21,7 +21,7 @@
         "tel_input": {
             "type": "tel",
             "placeholder": "Phone",
-            "required": "",
+            "required": true,
             "autocomplete": "tel",
             "aria-label": "Phone",
             "aria-required": "true",
@@ -30,7 +30,7 @@
         "zip_input": {
             "type": "text",
             "placeholder": "Project Zip Code",
-            "required": "",
+            "required": true,
             "autocomplete": "postal-code",
             "aria-label": "Project Zip Code",
             "aria-required": "true",
@@ -41,7 +41,7 @@
             "cols": "21",
             "rows": "5",
             "placeholder": "Please describe your project and let us know if there is any urgency",
-            "required": "",
+            "required": true,
             "aria-label": "Message",
             "aria-required": "true",
             "style": "grid-area: message"

--- a/tests/EnhancedICFFormProcessorTest.php
+++ b/tests/EnhancedICFFormProcessorTest.php
@@ -162,6 +162,32 @@ class EnhancedICFFormProcessorTest extends TestCase {
         $this->assertSame(['phone' => 'Phone is required.'], $result['errors']);
     }
 
+    public function test_required_name_missing() {
+        $data   = $this->build_submission(overrides: ['name' => '']);
+        $result = $this->processor->process_form_submission('default', $data);
+        $this->assertFalse($result['success']);
+        $this->assertSame('Please correct the highlighted fields', $result['message']);
+        $this->assertSame(['name' => 'This field is required.'], $result['errors']);
+    }
+
+    public function test_optional_field_can_be_blank() {
+        $registry = new FieldRegistry();
+        $registry->register_field_from_config('opt', 'name', [
+            'post_key' => 'name_input',
+            'type'     => 'text',
+        ]);
+        $processor = new Enhanced_ICF_Form_Processor(new Logger(), $registry);
+        $data = [
+            'enhanced_icf_form_nonce' => 'valid',
+            'enhanced_url'           => '',
+            'enhanced_form_time'     => time() - 10,
+            'enhanced_js_check'      => '1',
+            'name_input'             => '',
+        ];
+        $result = $processor->process_form_submission('opt', $data);
+        $this->assertTrue($result['success']);
+    }
+
     public function test_phone_with_leading_one_is_normalized() {
         $this->assertSame('2345678901', FieldRegistry::sanitize_digits('+1 (234) 567-8901'));
         $data   = $this->build_submission(overrides: ['phone' => '+1 (234) 567-8901']);


### PR DESCRIPTION
## Summary
- Treat presence of `required` in field configs as truthy
- Enforce required rules across all validators and clarify default template
- Add tests for required and optional field behavior

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68992a7799c8832d9d9e793b3a661969