### PR TITLE
Invalidate template config cache on file changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,12 @@ placeholders or other field attributes for the `default` template. Configuration
 files are parsed using core PHP functions. If a theme file is not found, the
 plugin will look for a matching configuration within its own `templates/`
 directory, providing a plugin-level fallback.
+
+### Template Configuration Caching
+
+Template configurations are cached both in-memory and via WordPress' object
+cache. The cache key includes a version token derived from the most recent
+modification time of the plugin and theme configuration files. When any of these
+files change the token differs, causing the cache to refresh. Call
+`eform_purge_template_config_cache()` after activating a theme or the plugin to
+remove any stale entries.

--- a/includes/template-config.php
+++ b/includes/template-config.php
@@ -14,39 +14,72 @@ function eform_get_template_config( string $template ): array {
     static $cache = [];
 
     $theme_dir = rtrim( get_stylesheet_directory(), '/\\' );
-    $cache_key = $template . '|' . $theme_dir;
 
-    if ( isset( $cache[ $cache_key ] ) ) {
-        return $cache[ $cache_key ];
-    }
-
-    $cached = function_exists( 'wp_cache_get' ) ? wp_cache_get( $cache_key, 'eform_template_config' ) : false;
-    if ( false !== $cached ) {
-        $cache[ $cache_key ] = $cached;
-        return $cached;
-    }
-
-    $plugin_dir = rtrim( plugin_dir_path( __DIR__ ), '/\\' ) . '/templates';
+    $plugin_dir  = rtrim( plugin_dir_path( __DIR__ ), '/\\' ) . '/templates';
     $plugin_paths = [
         $plugin_dir . '/' . $template . '.php',
         $plugin_dir . '/' . $template . '.json',
     ];
-    $base = eform_load_config_from_paths( $plugin_paths );
 
     $theme_paths = [
         $theme_dir . '/eform/' . $template . '.php',
         $theme_dir . '/eform/' . $template . '.json',
     ];
+
+    $version = eform_config_version_token( array_merge( $plugin_paths, $theme_paths ) );
+    $cache_key = $template . '|' . $theme_dir;
+
+    if ( isset( $cache[ $cache_key ] ) && $cache[ $cache_key ]['v'] === $version ) {
+        return $cache[ $cache_key ]['c'];
+    }
+
+    $cached = function_exists( 'wp_cache_get' ) ? wp_cache_get( $cache_key, 'eform_template_config' ) : false;
+    if ( is_array( $cached ) && isset( $cached['v'], $cached['c'] ) && $cached['v'] === $version ) {
+        $cache[ $cache_key ] = $cached;
+        return $cached['c'];
+    }
+
+    $base = eform_load_config_from_paths( $plugin_paths );
     $data = eform_load_config_from_paths( $theme_paths );
 
     $config = array_replace_recursive( $base, $data );
 
-    $cache[ $cache_key ] = $config;
+    $entry = [ 'v' => $version, 'c' => $config ];
+    $cache[ $cache_key ] = $entry;
     if ( function_exists( 'wp_cache_set' ) ) {
-        wp_cache_set( $cache_key, $config, 'eform_template_config' );
+        wp_cache_set( $cache_key, $entry, 'eform_template_config' );
+
+        $keys = wp_cache_get( 'keys', 'eform_template_config' );
+        if ( ! is_array( $keys ) ) {
+            $keys = [];
+        }
+        if ( ! in_array( $cache_key, $keys, true ) ) {
+            $keys[] = $cache_key;
+            wp_cache_set( 'keys', $keys, 'eform_template_config' );
+        }
     }
 
     return $config;
+}
+
+/**
+ * Calculate a version token for a set of configuration file paths.
+ *
+ * Uses the most recent modification time among the provided files as a simple
+ * numeric token. Whenever any configuration file changes, its `filemtime`
+ * updates and the derived token differs, forcing the cache to refresh.
+ *
+ * @param array $paths File paths to inspect.
+ * @return string Version token.
+ */
+function eform_config_version_token( array $paths ): string {
+    $latest = 0;
+    foreach ( $paths as $path ) {
+        $mtime  = file_exists( $path ) ? filemtime( $path ) : 0;
+        $latest = max( $latest, $mtime );
+    }
+
+    return (string) $latest;
 }
 
 /**
@@ -78,4 +111,24 @@ function eform_load_config_from_paths( array $paths ): array {
     }
 
     return [];
+}
+
+/**
+ * Remove all cached template configuration entries.
+ *
+ * Intended for use on theme or plugin activation to clear potentially stale
+ * data stored in the object cache.
+ */
+function eform_purge_template_config_cache(): void {
+    if ( ! function_exists( 'wp_cache_delete' ) ) {
+        return;
+    }
+
+    $keys = wp_cache_get( 'keys', 'eform_template_config' );
+    if ( is_array( $keys ) ) {
+        foreach ( $keys as $key ) {
+            wp_cache_delete( $key, 'eform_template_config' );
+        }
+        wp_cache_delete( 'keys', 'eform_template_config' );
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -47,6 +47,23 @@ function eform_get_safe_fields($data){
     return array_keys($data);
 }
 
+// Simple in-memory cache for testing wp_cache_* functions.
+$GLOBALS['wp_cache'] = [];
+function wp_cache_set( $key, $data, $group = '' ) {
+    $GLOBALS['wp_cache'][ $group ][ $key ] = $data;
+    return true;
+}
+function wp_cache_get( $key, $group = '' ) {
+    return $GLOBALS['wp_cache'][ $group ][ $key ] ?? false;
+}
+function wp_cache_delete( $key, $group = '' ) {
+    if ( isset( $GLOBALS['wp_cache'][ $group ][ $key ] ) ) {
+        unset( $GLOBALS['wp_cache'][ $group ][ $key ] );
+        return true;
+    }
+    return false;
+}
+
 function register_template_fields_from_config( FieldRegistry $registry, string $template ): void {
     $config = eform_get_template_config( $template );
     foreach ( $config['fields'] ?? [] as $post_key => $field ) {


### PR DESCRIPTION
## Summary
- compute cache version token from latest template file mtime
- document template configuration caching and purge helper

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68994e1657fc832da071aa38eee65115