### PR TITLE
Refactor shortcode handling for per-form processors

### DIFF
--- a/eform.php
+++ b/eform.php
@@ -46,9 +46,16 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/template-config.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-enhanced-icf-processor.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-enhanced-icf.php';
 
-// Initialize plugin
+// Initialize plugin with global defaults for backward compatibility.
 $registry  = new FieldRegistry();
 $GLOBALS['eform_registry'] = $registry;
 $processor = new Enhanced_ICF_Form_Processor( $logger, $registry );
-new Enhanced_Internal_Contact_Form( $processor, $logger );
+$form      = new Enhanced_Internal_Contact_Form( $processor, $logger );
+
+// Each shortcode instance gets its own registry and processor.
+add_shortcode( 'enhanced_icf_shortcode', function( $atts = [] ) use ( $logger, $form ) {
+    $registry_instance  = new FieldRegistry();
+    $processor_instance = new Enhanced_ICF_Form_Processor( $logger, $registry_instance );
+    return $form->handle_shortcode( $atts, $registry_instance, $processor_instance );
+} );
 

--- a/tests/EnhancedInternalContactFormTest.php
+++ b/tests/EnhancedInternalContactFormTest.php
@@ -29,7 +29,7 @@ class EnhancedInternalContactFormTest extends TestCase {
         $prop->setAccessible(true);
         $prop->setValue($form, '');
 
-        $form->maybe_handle_form();
+        $form->maybe_handle_form( $processor );
 
         $submitted = $ref->getProperty('form_submitted');
         $submitted->setAccessible(true);
@@ -63,7 +63,7 @@ class EnhancedInternalContactFormTest extends TestCase {
         $prop->setAccessible(true);
         $prop->setValue($form, '');
 
-        $form->maybe_handle_form();
+        $form->maybe_handle_form( $processor );
 
         $submitted = $ref->getProperty('form_submitted');
         $submitted->setAccessible(true);
@@ -100,7 +100,7 @@ class EnhancedInternalContactFormTest extends TestCase {
         $prop->setAccessible(true);
         $prop->setValue($form, '');
 
-        $form->maybe_handle_form();
+        $form->maybe_handle_form( $processor );
 
         $submitted = $ref->getProperty('form_submitted');
         $submitted->setAccessible(true);


### PR DESCRIPTION
## Summary
- Instantiate a fresh `FieldRegistry` and `Enhanced_ICF_Form_Processor` for each shortcode rendering while keeping global defaults.
- Update `Enhanced_Internal_Contact_Form` to accept per-form processor and registry instances and fall back to globals.
- Adjust tests to account for the new processor dependency in `maybe_handle_form`.

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6899517f73fc832db4c0685269e663dc