### PR TITLE
Refactor Logger logging helpers and tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -47,6 +47,10 @@ function eform_get_safe_fields($data){
     return array_keys($data);
 }
 
+function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+    return json_encode( $data, $options | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES, $depth );
+}
+
 // Simple in-memory cache for testing wp_cache_* functions.
 $GLOBALS['wp_cache'] = [];
 function wp_cache_set( $key, $data, $group = '' ) {


### PR DESCRIPTION
## Summary
- Refactor Logger::log to delegate to new private helpers for context formatting and entry writing
- Switch log encoding to `wp_json_encode` with unescaped slashes
- Add unit tests covering helper methods and ensuring log rotation

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6899733b39bc832dad2a08a5248f68ae