### PR TITLE
Refactor validation flow with exception-based pipeline

### DIFF
--- a/eform.php
+++ b/eform.php
@@ -43,6 +43,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/field-registry.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/template-tags.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/render.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/template-config.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-validation-exception.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-enhanced-icf-processor.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-enhanced-icf.php';
 

--- a/includes/class-validation-exception.php
+++ b/includes/class-validation-exception.php
@@ -1,0 +1,25 @@
+<?php
+// includes/class-validation-exception.php
+
+class ValidationException extends \Exception {
+    /**
+     * Underlying WP_Error instance.
+     *
+     * @var WP_Error
+     */
+    private $error;
+
+    public function __construct( WP_Error $error ) {
+        $this->error = $error;
+        parent::__construct( $error->get_error_message() );
+    }
+
+    /**
+     * Retrieve the wrapped WP_Error instance.
+     *
+     * @return WP_Error
+     */
+    public function get_error(): WP_Error {
+        return $this->error;
+    }
+}

--- a/tests/EnhancedICFFormProcessorErrorsTest.php
+++ b/tests/EnhancedICFFormProcessorErrorsTest.php
@@ -18,6 +18,15 @@ class EnhancedICFFormProcessorErrorsTest extends TestCase {
             'message_input'          => 'short',
         ];
 
+        try {
+            $ref = new \ReflectionClass( $processor );
+            $m   = $ref->getMethod( 'validate_request' );
+            $m->setAccessible( true );
+            $m->invoke( $processor, $submitted );
+        } catch ( ValidationException $e ) {
+            $this->fail( 'ValidationException should not be thrown for field errors.' );
+        }
+
         $result = $processor->process_form_submission('default', $submitted);
 
         $this->assertFalse($result['success']);

--- a/tests/EnhancedICFFormProcessorTest.php
+++ b/tests/EnhancedICFFormProcessorTest.php
@@ -56,50 +56,70 @@ class EnhancedICFFormProcessorTest extends TestCase {
         $data = $this->build_submission(overrides: ['enhanced_icf_form_nonce' => 'invalid']);
         $result = $this->processor->process_form_submission('default', $data);
         $this->assertFalse($result['success']);
-        $expected = $this->invoke_method($this->processor, 'build_error', ['Nonce Failed', 'Invalid submission detected.']);
-        $actual   = $this->invoke_method($this->processor, 'check_nonce', [$data]);
-        $this->assertSame($expected, $actual);
-        $this->assertSame($expected['message'], $result['message']);
+        $this->assertSame('Invalid submission detected.', $result['message']);
+        try {
+            $this->invoke_method($this->processor, 'validate_request', [$data]);
+            $this->fail('ValidationException was not thrown');
+        } catch ( ValidationException $e ) {
+            $this->assertSame('Nonce Failed', $e->get_error()->get_error_code());
+            $this->assertSame('Invalid submission detected.', $e->get_error()->get_error_message());
+        }
     }
 
     public function test_honeypot_failure() {
         $data = $this->build_submission(overrides: ['enhanced_url' => 'http://spam']);
         $result = $this->processor->process_form_submission('default', $data);
         $this->assertFalse($result['success']);
-        $expected = $this->invoke_method($this->processor, 'build_error', ['Bot Alert: Honeypot Filled', 'Bot test failed.']);
-        $actual   = $this->invoke_method($this->processor, 'check_honeypot', [$data]);
-        $this->assertSame($expected, $actual);
-        $this->assertSame($expected['message'], $result['message']);
+        $this->assertSame('Bot test failed.', $result['message']);
+        try {
+            $this->invoke_method($this->processor, 'validate_request', [$data]);
+            $this->fail('ValidationException was not thrown');
+        } catch ( ValidationException $e ) {
+            $this->assertSame('Bot Alert: Honeypot Filled', $e->get_error()->get_error_code());
+            $this->assertSame('Bot test failed.', $e->get_error()->get_error_message());
+        }
     }
 
     public function test_honeypot_array_failure() {
         $data = $this->build_submission(overrides: ['enhanced_url' => ['spam']]);
         $result = $this->processor->process_form_submission('default', $data);
         $this->assertFalse($result['success']);
-        $expected = $this->invoke_method($this->processor, 'build_error', ['Bot Alert: Honeypot Filled', 'Bot test failed.']);
-        $actual   = $this->invoke_method($this->processor, 'check_honeypot', [$data]);
-        $this->assertSame($expected, $actual);
-        $this->assertSame($expected['message'], $result['message']);
+        $this->assertSame('Bot test failed.', $result['message']);
+        try {
+            $this->invoke_method($this->processor, 'validate_request', [$data]);
+            $this->fail('ValidationException was not thrown');
+        } catch ( ValidationException $e ) {
+            $this->assertSame('Bot Alert: Honeypot Filled', $e->get_error()->get_error_code());
+            $this->assertSame('Bot test failed.', $e->get_error()->get_error_message());
+        }
     }
 
     public function test_submission_time_failure() {
         $data = $this->build_submission(overrides: ['enhanced_form_time' => time()]);
         $result = $this->processor->process_form_submission('default', $data);
         $this->assertFalse($result['success']);
-        $expected = $this->invoke_method($this->processor, 'build_error', ['Bot Alert: Fast Submission', 'Submission too fast. Please try again.']);
-        $actual   = $this->invoke_method($this->processor, 'check_submission_time', [$data]);
-        $this->assertSame($expected, $actual);
-        $this->assertSame($expected['message'], $result['message']);
+        $this->assertSame('Submission too fast. Please try again.', $result['message']);
+        try {
+            $this->invoke_method($this->processor, 'validate_request', [$data]);
+            $this->fail('ValidationException was not thrown');
+        } catch ( ValidationException $e ) {
+            $this->assertSame('Bot Alert: Fast Submission', $e->get_error()->get_error_code());
+            $this->assertSame('Submission too fast. Please try again.', $e->get_error()->get_error_message());
+        }
     }
 
     public function test_submission_time_array_failure() {
         $data = $this->build_submission(overrides: ['enhanced_form_time' => ['now']]);
         $result = $this->processor->process_form_submission('default', $data);
         $this->assertFalse($result['success']);
-        $expected = $this->invoke_method($this->processor, 'build_error', ['Bot Alert: Fast Submission', 'Submission too fast. Please try again.']);
-        $actual   = $this->invoke_method($this->processor, 'check_submission_time', [$data]);
-        $this->assertSame($expected, $actual);
-        $this->assertSame($expected['message'], $result['message']);
+        $this->assertSame('Submission too fast. Please try again.', $result['message']);
+        try {
+            $this->invoke_method($this->processor, 'validate_request', [$data]);
+            $this->fail('ValidationException was not thrown');
+        } catch ( ValidationException $e ) {
+            $this->assertSame('Bot Alert: Fast Submission', $e->get_error()->get_error_code());
+            $this->assertSame('Submission too fast. Please try again.', $e->get_error()->get_error_message());
+        }
     }
 
     public function test_js_check_failure() {
@@ -107,10 +127,14 @@ class EnhancedICFFormProcessorTest extends TestCase {
         unset($data['enhanced_js_check']);
         $result = $this->processor->process_form_submission('default', $data);
         $this->assertFalse($result['success']);
-        $expected = $this->invoke_method($this->processor, 'build_error', ['Bot Alert: JS Check Missing', 'JavaScript must be enabled.']);
-        $actual   = $this->invoke_method($this->processor, 'check_js_enabled', [$data]);
-        $this->assertSame($expected, $actual);
-        $this->assertSame($expected['message'], $result['message']);
+        $this->assertSame('JavaScript must be enabled.', $result['message']);
+        try {
+            $this->invoke_method($this->processor, 'validate_request', [$data]);
+            $this->fail('ValidationException was not thrown');
+        } catch ( ValidationException $e ) {
+            $this->assertSame('Bot Alert: JS Check Missing', $e->get_error()->get_error_code());
+            $this->assertSame('JavaScript must be enabled.', $e->get_error()->get_error_message());
+        }
     }
 
     public function test_field_validation_failure() {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,34 @@ require_once __DIR__ . '/../vendor/autoload.php';
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', __DIR__ );
 }
+
+class WP_Error {
+    private $code;
+    private $message;
+    private $data;
+
+    public function __construct( $code = '', $message = '', $data = [] ) {
+        $this->code    = $code;
+        $this->message = $message;
+        $this->data    = $data;
+    }
+
+    public function get_error_code() {
+        return $this->code;
+    }
+
+    public function get_error_message() {
+        return $this->message;
+    }
+
+    public function get_error_data() {
+        return $this->data;
+    }
+}
+
+function is_wp_error( $thing ) {
+    return $thing instanceof WP_Error;
+}
 function sanitize_text_field($str){
     $str = strip_tags($str);
     $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
@@ -149,6 +177,7 @@ require_once __DIR__.'/../includes/logger.php';
 require_once __DIR__.'/../includes/field-registry.php';
 require_once __DIR__.'/../includes/template-tags.php';
 require_once __DIR__.'/../includes/render.php';
+require_once __DIR__.'/../includes/template-config.php';
+require_once __DIR__.'/../includes/class-validation-exception.php';
 require_once __DIR__.'/../includes/class-enhanced-icf-processor.php';
 require_once __DIR__.'/../includes/class-enhanced-icf.php';
-require_once __DIR__.'/../includes/template-config.php';


### PR DESCRIPTION
## Summary
- Replace per-check arrays with a single `validate_request` pipeline that throws `ValidationException`
- Consolidate error handling into `handle_error` using `WP_Error` objects
- Expand tests to cover exception-based flow and add `WP_Error` test stub

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689a1ce4ec70832da32c7297fcdc28b5