### PR TITLE
Refactor field map to use type map

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ capture extra information:
 Each generic field requires a `post_key` parameter when registered. Radio fields
 also require a `choices` array of allowed values.
 
+### Adding Field Types
+
+`FieldRegistry` maps HTML input types to sanitize and validate callbacks using a
+`$type_map` array. To introduce a new type you only need to supply the callback
+pairs and then reference the type when registering a field or in template
+configuration.
+
+```php
+add_filter( 'eform_field_type_map', function( array $map ) {
+    $map['url'] = [
+        'sanitize_cb' => 'esc_url_raw',
+        'validate_cb' => 'wp_http_validate_url',
+    ];
+    return $map;
+} );
+```
+
+With the `url` type added, a template can register a field using
+`"type": "url"` without specifying callbacks; `FieldRegistry` merges the type's
+callbacks with the field's base configuration.
+
 ## Theme-based Template Configuration
 
 The plugin ships with its default field configuration in `templates/default.json`.

--- a/tests/FieldRegistryTest.php
+++ b/tests/FieldRegistryTest.php
@@ -11,6 +11,22 @@ class FieldRegistryTest extends TestCase {
             $this->assertIsCallable( $details['validate_cb'] );
         }
     }
+
+    public function testFieldMapUsesTypeMap() {
+        $registry = new FieldRegistry();
+
+        // Override the email sanitize callback via the internal type map to
+        // ensure get_field_map() derives callbacks from the map rather than
+        // hard-coded values.
+        $ref = new \ReflectionProperty( FieldRegistry::class, 'type_map' );
+        $ref->setAccessible( true );
+        $map = $ref->getValue( $registry );
+        $map['email']['sanitize_cb'] = 'strrev';
+        $ref->setValue( $registry, $map );
+
+        $fields = $registry->get_field_map();
+        $this->assertSame( 'strrev', $fields['email']['sanitize_cb'] );
+    }
     public function testInvalidSanitizeCallbackTriggersWarningAndIsNotRegistered() {
         $registry = new FieldRegistry();
         $error = null;


### PR DESCRIPTION
## Summary
- build default field definitions from a base config merged with type/callback map
- allow filtering of field type map and test that get_field_map respects it
- document extending field types through the type map

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689a272b4a04832d93ad06660cf9842b