### PR TITLE
Refactor field registry for config-driven fields

### DIFF
--- a/tests/EnhancedICFFormProcessorErrorsTest.php
+++ b/tests/EnhancedICFFormProcessorErrorsTest.php
@@ -4,6 +4,7 @@ use PHPUnit\Framework\TestCase;
 class EnhancedICFFormProcessorErrorsTest extends TestCase {
     public function test_process_form_submission_returns_errors_with_keys() {
         $registry  = new FieldRegistry();
+        register_template_fields_from_config( $registry, 'default' );
         $processor = new Enhanced_ICF_Form_Processor(new Logger(), $registry);
 
         $submitted = [
@@ -22,8 +23,9 @@ class EnhancedICFFormProcessorErrorsTest extends TestCase {
 
         $this->assertFalse($result['success']);
         $this->assertArrayHasKey('errors', $result);
-        $this->assertArrayHasKey('name', $result['errors']);
         $this->assertArrayHasKey('email', $result['errors']);
+        $this->assertArrayHasKey('phone', $result['errors']);
+        $this->assertArrayHasKey('message', $result['errors']);
         $this->assertSame('Please correct the highlighted fields', $result['message']);
     }
 }

--- a/tests/EnhancedICFFormProcessorTest.php
+++ b/tests/EnhancedICFFormProcessorTest.php
@@ -143,18 +143,45 @@ class EnhancedICFFormProcessorTest extends TestCase {
     }
 
     public function test_template_without_phone_field() {
-        foreach (['name', 'email', 'zip', 'message'] as $field) {
-            $this->registry->register_field('no_phone', $field, [ 'required' => true ]);
-        }
+        $this->registry->register_field_from_config('no_phone', 'name', [
+            'post_key' => 'name_input',
+            'type'     => 'text',
+            'required' => true,
+        ]);
+        $this->registry->register_field_from_config('no_phone', 'email', [
+            'post_key' => 'email_input',
+            'type'     => 'email',
+            'required' => true,
+        ]);
+        $this->registry->register_field_from_config('no_phone', 'zip', [
+            'post_key' => 'zip_input',
+            'type'     => 'text',
+            'required' => true,
+        ]);
+        $this->registry->register_field_from_config('no_phone', 'message', [
+            'post_key' => 'message_input',
+            'type'     => 'textarea',
+            'required' => true,
+        ]);
         $data   = $this->build_submission('no_phone');
         $result = $this->processor->process_form_submission('no_phone', $data);
         $this->assertTrue($result['success']);
     }
 
     public function test_required_phone_missing() {
-        foreach (['name', 'email', 'phone'] as $field) {
-            $this->registry->register_field('phone_only', $field, [ 'required' => $field === 'phone' ]);
-        }
+        $this->registry->register_field_from_config('phone_only', 'name', [
+            'post_key' => 'name_input',
+            'type'     => 'text',
+        ]);
+        $this->registry->register_field_from_config('phone_only', 'email', [
+            'post_key' => 'email_input',
+            'type'     => 'email',
+        ]);
+        $this->registry->register_field_from_config('phone_only', 'phone', [
+            'post_key' => 'tel_input',
+            'type'     => 'tel',
+            'required' => true,
+        ]);
         $data   = $this->build_submission('phone_only', overrides: ['phone' => '']);
         $result = $this->processor->process_form_submission('phone_only', $data);
         $this->assertFalse($result['success']);

--- a/tests/EnhancedInternalContactFormTest.php
+++ b/tests/EnhancedInternalContactFormTest.php
@@ -93,8 +93,10 @@ class EnhancedInternalContactFormTest extends TestCase {
             'message_input' => ['short'],
         ];
 
-        $processor = new Enhanced_ICF_Form_Processor(new Logger(), new FieldRegistry());
-        $form = new Enhanced_Internal_Contact_Form($processor, new Logger());
+        $registry  = new FieldRegistry();
+        register_template_fields_from_config( $registry, 'default' );
+        $processor = new Enhanced_ICF_Form_Processor(new Logger(), $registry);
+        $form      = new Enhanced_Internal_Contact_Form($processor, new Logger());
         $ref = new ReflectionClass($form);
         $prop = $ref->getProperty('redirect_url');
         $prop->setAccessible(true);


### PR DESCRIPTION
## Summary
- remove generic field definitions and `get_field_map()`
- rely on `register_field_from_config()` and `type_map` for field callbacks
- register template fields solely from config and update tests accordingly

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689a34448584832da02749bcf3d9fa7f