### PR TITLE
Respect explicit false required config

### DIFF
--- a/includes/field-registry.php
+++ b/includes/field-registry.php
@@ -53,7 +53,7 @@ class FieldRegistry {
 
         $field_config = [
             'post_key'    => $config['post_key'] ?? $field,
-            'required'    => array_key_exists( 'required', $config ),
+            'required'    => (bool) ( $config['required'] ?? false ),
             'sanitize_cb' => $callbacks['sanitize_cb'],
             'validate_cb' => $callbacks['validate_cb'],
         ];

--- a/tests/FieldRegistryTest.php
+++ b/tests/FieldRegistryTest.php
@@ -24,6 +24,18 @@ class FieldRegistryTest extends TestCase {
         $this->assertSame([FieldRegistry::class, 'validate_email'], $fields['email']['validate_cb']);
     }
 
+    public function testRequiredFalseResultsInNonRequiredField() {
+        $registry = new FieldRegistry();
+        $registry->register_field_from_config('tmpl', 'code', [
+            'post_key' => 'code_input',
+            'type'     => 'text',
+            'required' => false,
+        ]);
+        $field = $registry->get_fields('tmpl')['code'];
+        $this->assertFalse($field['required']);
+        $this->assertSame('', FieldRegistry::validate_pattern('', $field));
+    }
+
     public function testValidatePatternHonorsRegex() {
         $registry = new FieldRegistry();
         $registry->register_field_from_config('tmpl', 'code', [


### PR DESCRIPTION
## Summary
- Preserve explicit `required => false` in field configuration
- Cover `required => false` case in tests

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689a40fbe458832d8e50054264dc5c96