### PR TITLE
Add labels and ARIA error linkage to form fields

### DIFF
--- a/includes/render.php
+++ b/includes/render.php
@@ -14,27 +14,35 @@ function eform_render_form( $form, string $template, array $config ) {
     echo '<form class="main_contact_form" id="main_contact_form" aria-label="Contact Form" method="post" action="">';
     Enhanced_Internal_Contact_Form::render_hidden_fields( $template );
 
-    foreach ($config['fields'] ?? [] as $post_key => $field) {
-        $field_key = FieldRegistry::field_key_from_post($post_key);
-        $value = $form->form_data[$field_key] ?? '';
+    foreach ( $config['fields'] ?? [] as $post_key => $field ) {
+        $field_key = FieldRegistry::field_key_from_post( $post_key );
+        $value     = $form->form_data[ $field_key ] ?? '';
         if ( ( $field['type'] ?? '' ) === 'tel' ) {
             $value = $form->format_phone( $value );
         }
-        $required = isset($field['required']) ? ' required aria-required="true"' : '';
-        $attr_str = '';
-        foreach ($field as $attr => $val) {
-            if (in_array($attr, ['type','required','style'], true)) {
+
+        $required   = isset( $field['required'] ) ? ' required aria-required="true"' : '';
+        $attr_str   = '';
+        foreach ( $field as $attr => $val ) {
+            if ( in_array( $attr, [ 'type', 'required', 'style', 'id' ], true ) ) {
                 continue;
             }
-            $attr_str .= sprintf(' %s="%s"', esc_attr($attr), esc_attr($val));
+            $attr_str .= sprintf( ' %s="%s"', esc_attr( $attr ), esc_attr( $val ) );
         }
-        echo '<div class="inputwrap" style="' . esc_attr($field['style'] ?? '') . '">';
-        if (($field['type'] ?? '') === 'textarea') {
-            echo '<textarea name="' . esc_attr($post_key) . '"' . $required . $attr_str . '>' . esc_textarea($value) . '</textarea>';
+
+        $field_id    = $field_key;
+        $has_error   = ! empty( $form->field_errors[ $field_key ] ?? '' );
+        $error_attrs = $has_error ? ' aria-invalid="true" aria-describedby="' . esc_attr( $field_id . '-error' ) . '"' : '';
+
+        echo '<div class="inputwrap" style="' . esc_attr( $field['style'] ?? '' ) . '">';
+        echo '<label for="' . esc_attr( $field_id ) . '">';
+        if ( ( $field['type'] ?? '' ) === 'textarea' ) {
+            echo '<textarea id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $post_key ) . '"' . $required . $attr_str . $error_attrs . '>' . esc_textarea( $value ) . '</textarea>';
         } else {
             $type = $field['type'] ?? 'text';
-            echo '<input type="' . esc_attr($type) . '" name="' . esc_attr($post_key) . '" value="' . esc_attr($value) . '"' . $required . $attr_str . '>';
+            echo '<input id="' . esc_attr( $field_id ) . '" type="' . esc_attr( $type ) . '" name="' . esc_attr( $post_key ) . '" value="' . esc_attr( $value ) . '"' . $required . $attr_str . $error_attrs . '>';
         }
+        echo '</label>';
         eform_field_error( $form, $field_key );
         echo '</div>';
     }

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -16,7 +16,7 @@ if ( ! function_exists( 'eform_field_error' ) ) {
         $error = $form->field_errors[ $field ] ?? '';
 
         if ( $error ) {
-            echo '<div class="field-error">' . esc_html( $error ) . '</div>';
+            echo '<div id="' . esc_attr( $field ) . '-error" class="field-error">' . esc_html( $error ) . '</div>';
         }
     }
 }

--- a/tests/TemplateTagsTest.php
+++ b/tests/TemplateTagsTest.php
@@ -15,7 +15,7 @@ class TemplateTagsTest extends TestCase {
         eform_field_error( $form, 'name' );
         $output = ob_get_clean();
 
-        $this->assertSame( '<div class="field-error">Required</div>', $output );
+        $this->assertSame( '<div id="name-error" class="field-error">Required</div>', $output );
     }
 
     public function test_eform_field_error_outputs_nothing_when_no_message() {


### PR DESCRIPTION
## Summary
- Wrap generated inputs and textareas in `<label>` tags with explicit `id` attributes for accessibility
- Mark invalid fields with `aria-invalid` and link to error containers via `aria-describedby`
- Provide unique error container IDs for screen reader association

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689a8833aae8832db954eda8e511fb49