### PR TITLE
Add accessible error markup and focus helper

### DIFF
--- a/assets/enhanced-form.js
+++ b/assets/enhanced-form.js
@@ -6,6 +6,13 @@ document.addEventListener('DOMContentLoaded', function () {
         // Set JS check right away (in case form was prefilled)
         jsField.value = 'valid';
 
+        // Focus helper: if the server rendered any invalid fields,
+        // move focus to the first one for easier accessibility.
+        let invalid = form.querySelector('[aria-invalid="true"]');
+        if (invalid) {
+            invalid.focus();
+        }
+
         form.addEventListener('submit', function () {
             jsField.value = 'valid';
         });

--- a/includes/Renderer.php
+++ b/includes/Renderer.php
@@ -14,6 +14,7 @@ class Renderer {
      */
     public function render( FormData $form, string $template, array $config ) {
         echo '<div id="contact_form" class="contact_form">';
+        echo '<div aria-live="polite"></div>';
         echo '<form class="main_contact_form" id="main_contact_form" aria-label="Contact Form" method="post" action="">';
         $form_id = Enhanced_Internal_Contact_Form::render_hidden_fields( $template );
 
@@ -26,8 +27,8 @@ class Renderer {
             if ( ( $field['type'] ?? '' ) === 'tel' ) {
                 $value = $form->format_phone( $value );
             }
-            $required = isset( $field['required'] ) ? ' required aria-required="true"' : '';
-            $attr_str = '';
+            $required  = isset( $field['required'] ) ? ' required aria-required="true"' : '';
+            $attr_str  = '';
             foreach ( $field as $attr => $val ) {
                 if ( in_array( $attr, [ 'type', 'required', 'style', 'key', 'sanitize', 'validate' ], true ) ) {
                     continue;
@@ -35,14 +36,18 @@ class Renderer {
                 $attr_str .= sprintf( ' %s="%s"', esc_attr( $attr ), esc_attr( $val ) );
             }
             echo '<div class="inputwrap" style="' . esc_attr( $field['style'] ?? '' ) . '">';
-            $name = $form_id . '[' . $field_key . ']';
+            $name      = $form_id . '[' . $field_key . ']';
+            $input_id  = $form_id . '-' . $field_key;
+            $error_id  = 'error-' . $input_id;
+            $error_msg = $form->field_errors[ $field_key ] ?? '';
+            $aria      = $error_msg ? sprintf( ' aria-describedby="%s" aria-invalid="true"', esc_attr( $error_id ) ) : '';
             if ( ( $field['type'] ?? '' ) === 'textarea' ) {
-                echo '<textarea name="' . esc_attr( $name ) . '"' . $required . $attr_str . '>' . esc_textarea( $value ) . '</textarea>';
+                echo '<textarea id="' . esc_attr( $input_id ) . '" name="' . esc_attr( $name ) . '"' . $required . $attr_str . $aria . '>' . esc_textarea( $value ) . '</textarea>';
             } else {
                 $type = $field['type'] ?? 'text';
-                echo '<input type="' . esc_attr( $type ) . '" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '"' . $required . $attr_str . '>';
+                echo '<input id="' . esc_attr( $input_id ) . '" type="' . esc_attr( $type ) . '" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '"' . $required . $attr_str . $aria . '>';
             }
-            eform_field_error( $form, $field_key );
+            echo '<span id="' . esc_attr( $error_id ) . '" class="field-error">' . esc_html( $error_msg ) . '</span>';
             echo '</div>';
         }
 

--- a/tests/RendererAccessibilityTest.php
+++ b/tests/RendererAccessibilityTest.php
@@ -1,0 +1,44 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class RendererAccessibilityTest extends TestCase {
+    public function test_fields_have_ids_and_error_associations() {
+        $form = new FormData();
+        $form->form_data = [];
+        $form->field_errors = [ 'name' => 'Required' ];
+
+        $config = [
+            'fields' => [
+                'name_input'  => [ 'type' => 'text', 'required' => true ],
+                'email_input' => [ 'type' => 'email' ],
+            ],
+        ];
+
+        $renderer = new Renderer();
+
+        ob_start();
+        $renderer->render( $form, 'default', $config );
+        $output = ob_get_clean();
+
+        $dom = new DOMDocument();
+        @$dom->loadHTML('<!DOCTYPE html><html><body>' . $output . '</body></html>');
+        $xpath = new DOMXPath( $dom );
+
+        $live = $xpath->query('//div[@aria-live="polite"]')->item(0);
+        $this->assertNotNull( $live );
+
+        $invalid = $xpath->query('//*[@aria-invalid="true"]')->item(0);
+        $this->assertNotNull( $invalid );
+        $id = $invalid->getAttribute('id');
+        $this->assertNotEmpty( $id );
+        $describedby = $invalid->getAttribute('aria-describedby');
+        $this->assertSame( 'error-' . $id, $describedby );
+        $error = $xpath->query('//span[@id="' . $describedby . '"]')->item(0);
+        $this->assertNotNull( $error );
+        $this->assertSame( 'Required', $error->textContent );
+
+        $valid = $xpath->query('//input[@type="email"]')->item(0);
+        $this->assertFalse( $valid->hasAttribute('aria-invalid') );
+        $this->assertFalse( $valid->hasAttribute('aria-describedby') );
+    }
+}


### PR DESCRIPTION
## Summary
- Assign IDs to form controls and add matching error `<span>` containers with `aria-invalid` and `aria-describedby`
- Add global `aria-live` region for summary messages and document focus helper in JavaScript
- Introduce tests ensuring accessibility markup is rendered

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689ba91fd9f8832da0f5ccf310a4bec4