### PR TITLE
Drop theme overrides and inline CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,12 @@ composer install
 vendor/bin/phpunit
 ```
 
-## Theme-based Template Configuration
+## Template Configuration
 
 The plugin ships with its default field configuration in `templates/default.json`.
-Themes may override these settings by placing JSON files within `{theme}/eform/`.
-For example, `wp-content/themes/my-theme/eform/default.json` can adjust
-placeholders or other field attributes for the `default` template. Configuration
-files are parsed using core PHP functions. If a theme file is not found, the
-plugin will look for a matching configuration within its own `templates/`
-directory, providing a plugin-level fallback.
+Additional templates can be defined by adding JSON files to the plugin's
+`templates/` directory. Each file describes the fields and settings for a form
+template.
 
 ### Multi-value Fields
 
@@ -96,8 +93,7 @@ one selection must be present.
 ### Template Configuration Caching
 
 Template configurations are cached both in-memory and via WordPress' object
-cache. The cache key includes a version token derived from the most recent
-modification time of the plugin and theme configuration files. When any of these
-files change the token differs, causing the cache to refresh. Call
-`eform_purge_template_config_cache()` after activating a theme or the plugin to
-remove any stale entries.
+cache. The cache key includes a version token derived from the template file's
+modification time. When a template file changes the token differs, causing the
+cache to refresh. Call `eform_purge_template_config_cache()` after modifying
+template files to remove any stale entries.

--- a/tests/AssetsEnqueueTest.php
+++ b/tests/AssetsEnqueueTest.php
@@ -7,7 +7,6 @@ class AssetsEnqueueTest extends TestCase {
     protected function setUp(): void {
         $GLOBALS['enqueued_scripts'] = [];
         $GLOBALS['enqueued_styles']  = [];
-        $GLOBALS['inline_styles']    = [];
         $GLOBALS['registered_styles'] = [];
         $GLOBALS['printed_styles']   = [];
         $_SERVER['REQUEST_METHOD']   = 'GET';
@@ -42,6 +41,6 @@ class AssetsEnqueueTest extends TestCase {
         $form->handle_shortcode( [ 'template' => 'default', 'style' => 'true' ], $processor );
 
         $this->assertCount( 1, $GLOBALS['enqueued_styles'] );
-        $this->assertArrayHasKey( 'enhanced-icf-inline-default', $GLOBALS['inline_styles'] );
+        $this->assertContains( 'enhanced-icf-default', $GLOBALS['enqueued_styles'] );
     }
 }

--- a/tests/TemplateConfigTest.php
+++ b/tests/TemplateConfigTest.php
@@ -4,105 +4,38 @@ use PHPUnit\Framework\TestCase;
 
 class TemplateConfigTest extends TestCase {
 
-    private string $themeDir;
     private string $pluginTemplatesDir;
 
     protected function setUp(): void {
-        $this->themeDir             = sys_get_temp_dir() . '/theme_' . uniqid();
-        $GLOBALS['_eform_theme_dir'] = $this->themeDir;
-        mkdir( $this->themeDir . '/eform', 0777, true );
-
         $this->pluginTemplatesDir = dirname( __DIR__ ) . '/templates';
-
-        $GLOBALS['wp_cache'] = [];
+        $GLOBALS['wp_cache']      = [];
     }
 
-    protected function tearDown(): void {
-        if ( is_dir( $this->themeDir ) ) {
-            $files = new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator( $this->themeDir, RecursiveDirectoryIterator::SKIP_DOTS ),
-                RecursiveIteratorIterator::CHILD_FIRST
-            );
-            foreach ( $files as $file ) {
-                $file->isDir() ? rmdir( $file->getRealPath() ) : unlink( $file->getRealPath() );
-            }
-            rmdir( $this->themeDir );
-        }
-    }
-
-    public function test_json_config_merges_with_defaults(): void {
-        $config = [
-            'fields' => [
-                'name_input' => [
-                    'type' => 'text',
-                    'placeholder' => 'Alt Name'
-                ],
-            ],
-        ];
-        file_put_contents( $this->themeDir . '/eform/default.json', json_encode( $config ) );
-
+    public function test_plugin_config_loaded(): void {
         $result = eform_get_template_config( 'default' );
 
-        $this->assertSame( 'Alt Name', $result['fields']['name_input']['placeholder'] );
-        $this->assertArrayHasKey( 'email_input', $result['fields'] );
-    }
-
-    public function test_php_config_merges_with_defaults(): void {
-        $php = "<?php\nreturn [\n    'fields' => [\n        'email_input' => [\n            'type' => 'email',\n            'placeholder' => 'Alt Email'\n        ],\n    ],\n];\n";
-        file_put_contents( $this->themeDir . '/eform/default.php', $php );
-
-        $result = eform_get_template_config( 'default' );
-
-        $this->assertSame( 'Alt Email', $result['fields']['email_input']['placeholder'] );
-        $this->assertArrayHasKey( 'name_input', $result['fields'] );
-    }
-
-    public function test_invalid_json_returns_defaults(): void {
-        file_put_contents( $this->themeDir . '/eform/default.json', '{invalid json' );
-
-        $result = eform_get_template_config( 'default' );
-
-        $this->assertSame( 'Your Name', $result['fields']['name_input']['placeholder'] );
-    }
-
-    public function test_plugin_config_used_when_theme_missing(): void {
-        $result = eform_get_template_config( 'default' );
         $this->assertSame( 'Your Name', $result['fields']['name_input']['placeholder'] );
         $this->assertArrayHasKey( 'email_input', $result['fields'] );
     }
 
-    public function test_cache_invalidates_when_file_changes(): void {
-        $path = $this->themeDir . '/eform/default.json';
-        file_put_contents( $path, json_encode( [
-            'fields' => [
-                'name_input' => [ 'placeholder' => 'First' ],
-            ],
-        ] ) );
-
-        $result = eform_get_template_config( 'default' );
-        $this->assertSame( 'First', $result['fields']['name_input']['placeholder'] );
-
-        // Ensure file modification time changes.
-        sleep( 1 );
-        file_put_contents( $path, json_encode( [
-            'fields' => [
-                'name_input' => [ 'placeholder' => 'Second' ],
-            ],
-        ] ) );
-
-        $result = eform_get_template_config( 'default' );
-        $this->assertSame( 'Second', $result['fields']['name_input']['placeholder'] );
+    public function test_missing_template_returns_empty(): void {
+        $this->assertSame( [], eform_get_template_config( 'missing' ) );
     }
 
     public function test_cache_can_be_purged(): void {
-        file_put_contents( $this->themeDir . '/eform/default.json', json_encode( [ 'fields' => [] ] ) );
-        eform_get_template_config( 'default' );
+        $template = 'temp';
+        $path     = $this->pluginTemplatesDir . "/$template.json";
+        file_put_contents( $path, json_encode( [ 'fields' => [] ] ) );
 
-        $cache_key = 'default|' . rtrim( $this->themeDir, '/\\' );
-        $this->assertArrayHasKey( $cache_key, $GLOBALS['wp_cache']['eform_template_config'] );
+        eform_get_template_config( $template );
+
+        $this->assertArrayHasKey( $template, $GLOBALS['wp_cache']['eform_template_config'] );
 
         eform_purge_template_config_cache();
 
-        $this->assertArrayNotHasKey( $cache_key, $GLOBALS['wp_cache']['eform_template_config'] ?? [] );
+        $this->assertArrayNotHasKey( $template, $GLOBALS['wp_cache']['eform_template_config'] ?? [] );
+
+        unlink( $path );
     }
 }
+


### PR DESCRIPTION
## Summary
- remove theme-level template overrides and PHP config parsing
- drop inline CSS rendering in favor of enqueued stylesheets
- document plugin-only template configuration and update tests

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689bab3fb508832d977afe08f27dd33f