### PR TITLE
Remove magic template method rendering

### DIFF
--- a/includes/class-enhanced-icf.php
+++ b/includes/class-enhanced-icf.php
@@ -207,23 +207,6 @@ class Enhanced_Internal_Contact_Form extends FormData {
         return $form_html;
     }
 
-    /**
-     * Magic method to handle dynamic template rendering.
-     *
-     * Allows calling methods named after templates, e.g. `$form->contact()`,
-     * to render a form using the template's JSON configuration.
-     *
-     * @param string $name      The called method name.
-     * @param array  $arguments Unused.
-     *
-     * @return string Rendered template HTML.
-     */
-    public function __call( $name, $arguments ) {
-        $template = sanitize_key( $name );
-
-        return $this->handle_shortcode( [ 'template' => $template ] );
-    }
-
     // Expose phone formatting for templates
     public function format_phone(string $digits): string {
         return $this->processor ? $this->processor->format_phone($digits) : $digits;

--- a/tests/EnhancedInternalContactFormTest.php
+++ b/tests/EnhancedInternalContactFormTest.php
@@ -157,4 +157,14 @@ class EnhancedInternalContactFormTest extends TestCase {
 
         unlink( $path );
     }
+
+    public function test_calling_template_method_is_not_supported() {
+        $form = new Enhanced_Internal_Contact_Form(
+            new Enhanced_ICF_Form_Processor( new Logger() ),
+            new Logger()
+        );
+
+        $this->expectException( \Error::class );
+        $form->default();
+    }
 }


### PR DESCRIPTION
## Summary
- drop `__call` magic method so templates can't be invoked as methods
- add regression test ensuring calling a template method throws an error

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689bacf66390832db0b98414a8f6e02f