### PR TITLE
Remove per-field callbacks

### DIFF
--- a/includes/Renderer.php
+++ b/includes/Renderer.php
@@ -31,7 +31,7 @@ class Renderer {
             $required  = isset( $field['required'] ) ? ' required aria-required="true"' : '';
             $attr_str  = '';
             foreach ( $field as $attr => $val ) {
-                if ( in_array( $attr, [ 'type', 'required', 'style', 'key', 'sanitize', 'validate' ], true ) ) {
+                if ( in_array( $attr, [ 'type', 'required', 'style', 'key' ], true ) ) {
                     continue;
                 }
                 $attr_str .= sprintf( ' %s="%s"', esc_attr( $attr ), esc_attr( $val ) );

--- a/includes/Validator.php
+++ b/includes/Validator.php
@@ -34,7 +34,7 @@ class Validator {
     }
 
     /**
-     * Validate normalized data using sanitize/validate callbacks.
+     * Validate normalized data using callbacks registered for the field type.
      *
      * @param array $field_map        Field rules keyed by logical field key.
      * @param array $normalized_data  Normalized values keyed by logical field key.
@@ -45,22 +45,10 @@ class Validator {
         $data   = [];
         $errors = [];
         foreach ( $field_map as $field => $details ) {
-            $value = $normalized_data[ $field ] ?? '';
-            $type  = $details['type'] ?? 'text';
-            $sanitize_cb = $details['sanitize'] ?? null;
-            $validate_cb = $details['validate'] ?? null;
-            if ( is_string( $sanitize_cb ) && method_exists( self::class, $sanitize_cb ) ) {
-                $sanitize_cb = [ self::class, $sanitize_cb ];
-            }
-            if ( is_string( $validate_cb ) && method_exists( self::class, $validate_cb ) ) {
-                $validate_cb = [ self::class, $validate_cb ];
-            }
-            if ( ! $sanitize_cb ) {
-                $sanitize_cb = FieldRegistry::get_normalizer( $type );
-            }
-            if ( ! $validate_cb ) {
-                $validate_cb = FieldRegistry::get_validator( $type );
-            }
+            $value       = $normalized_data[ $field ] ?? '';
+            $type        = $details['type'] ?? 'text';
+            $sanitize_cb = FieldRegistry::get_normalizer( $type );
+            $validate_cb = FieldRegistry::get_validator( $type );
             if ( is_array( $value ) ) {
                 $sanitized = array_map( $sanitize_cb, $value );
             } else {

--- a/templates/default.json
+++ b/templates/default.json
@@ -8,9 +8,7 @@
       "autocomplete": "name",
       "aria-label": "Your Name",
       "aria-required": "true",
-      "style": "grid-area: name",
-      "sanitize": "sanitize_text_field",
-      "validate": "validate_pattern"
+      "style": "grid-area: name"
     },
     "email_input": {
       "key": "email",
@@ -20,9 +18,7 @@
       "autocomplete": "email",
       "aria-label": "email",
       "aria-required": "true",
-      "style": "grid-area: email",
-      "sanitize": "sanitize_email",
-      "validate": "validate_email"
+      "style": "grid-area: email"
     },
     "tel_input": {
       "key": "phone",
@@ -32,9 +28,7 @@
       "autocomplete": "tel",
       "aria-label": "Phone",
       "aria-required": "true",
-      "style": "grid-area: phone",
-      "sanitize": "sanitize_digits",
-      "validate": "validate_phone"
+      "style": "grid-area: phone"
     },
     "zip_input": {
       "key": "zip",
@@ -44,9 +38,7 @@
       "autocomplete": "postal-code",
       "aria-label": "Project Zip Code",
       "aria-required": "true",
-      "style": "grid-area: zip",
-      "sanitize": "sanitize_text_field",
-      "validate": "validate_zip"
+      "style": "grid-area: zip"
     },
     "message_input": {
       "key": "message",
@@ -57,9 +49,7 @@
       "required": true,
       "aria-label": "Message",
       "aria-required": "true",
-      "style": "grid-area: message",
-      "sanitize": "sanitize_textarea_field",
-      "validate": "validate_message"
+      "style": "grid-area: message"
     }
   },
   "success": {

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -42,7 +42,7 @@ class ValidatorTest extends TestCase {
         $this->assertSame(['name'], $result['invalid_fields']);
     }
 
-    public function test_per_field_rules_override_type() {
+    public function test_per_field_rules_ignored() {
         $validator = new Validator();
         $field_map = [
             'zip' => [
@@ -52,9 +52,9 @@ class ValidatorTest extends TestCase {
                 'required' => true,
             ],
         ];
-        $submitted = [ 'zip' => '12345' ];
+        $submitted = [ 'zip' => '12-34' ];
         $result = $validator->process_submission( $field_map, $submitted, ['checkbox'] );
-        $this->assertSame('12345', $result['data']['zip']);
+        $this->assertSame('12-34', $result['data']['zip']);
         $this->assertSame([], $result['errors']);
     }
     public function test_normalization_trims_before_validation() {


### PR DESCRIPTION
## Summary
- Drop `sanitize` and `validate` properties from form template fields
- Always sanitize and validate by field type using registry callbacks
- Ignore per-field callback overrides in validator and rendering logic

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689bb34f064c832d8fb21853fb9d284a