### PR TITLE
Remove option-based safe field configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,15 @@ recorded. An example entry looks like this:
 ## Logged Form Fields
 
 When `DEBUG_LEVEL` is set to `2`, selected form fields may be included in the log
-for troubleshooting. By default only the `name` and `zip` fields are stored. To
-adjust this list you may either:
-
-1. Update the `eform_log_safe_fields` option in WordPress to contain an array of
-   allowed field keys.
-2. Use the `eform_log_safe_fields` filter to programmatically modify the array of
-   field keys prior to logging.
-
-Both approaches will replace the default values, ensuring that only explicitly
-approved fields are recorded.
+for troubleshooting. By default only the `name` and `zip` fields are stored.
+Use the `eform_log_safe_fields` filter to programmatically modify the array of
+field keys prior to logging.
 
 ## Successful Submission Logging
 
 By default a successful form submission writes a "Form submission sent" entry to
 the log. The entry records only the safe fields configured via the
-`eform_log_safe_fields` option or filter and includes the template name.
+`eform_log_safe_fields` filter and includes the template name.
 Administrators may disable this logging by setting `DEBUG_LEVEL` to `0` or
 filtering the behavior:
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -16,19 +16,13 @@ if ( ! function_exists( 'eform_get_safe_fields' ) ) {
     /**
      * Retrieve fields considered safe for logging.
      *
-     * Allows overriding via the `eform_log_safe_fields` option or filter.
+     * Allows overriding via the `eform_log_safe_fields` filter.
      *
      * @param array|null $form_data Optional form data for filter context.
      * @return array List of safe field keys.
      */
     function eform_get_safe_fields( $form_data = null ) {
         $safe_fields = [ 'name', 'zip' ];
-        if ( function_exists( 'get_option' ) ) {
-            $option_fields = get_option( 'eform_log_safe_fields', [] );
-            if ( ! empty( $option_fields ) && is_array( $option_fields ) ) {
-                $safe_fields = $option_fields;
-            }
-        }
         if ( function_exists( 'apply_filters' ) ) {
             $safe_fields = apply_filters( 'eform_log_safe_fields', $safe_fields, $form_data );
         }


### PR DESCRIPTION
## Summary
- drop `get_option('eform_log_safe_fields')` and rely on default fields with a filter for customization
- update docs to reflect filter-based configuration

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689bccc994ec832da457ca181d5b9c85