### PR TITLE
Refactor template JSON schema and parsing

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -20,7 +20,11 @@ class Renderer {
         $form_id = Enhanced_Internal_Contact_Form::render_hidden_fields( $template );
 
         foreach ( $config['fields'] ?? [] as $post_key => $field ) {
-            $field_key = isset( $field['key'] ) ? sanitize_key( $field['key'] ) : sanitize_key( preg_replace( '/_input$/', '', $post_key ) );
+            if ( isset( $field['key'] ) ) {
+                $field_key = sanitize_key( $field['key'] );
+            } else {
+                $field_key = sanitize_key( preg_replace( '/_input$/', '', (string) $post_key ) );
+            }
             if ( 'tel' === $field_key ) {
                 $field_key = 'phone';
             }

--- a/src/TemplateCache.php
+++ b/src/TemplateCache.php
@@ -101,8 +101,13 @@ function eform_get_template_fields( string $template ): array {
     $fields = [];
 
     foreach ( $config['fields'] ?? [] as $post_key => $field ) {
-        $key = isset( $field['key'] ) ? sanitize_key( $field['key'] )
-            : sanitize_key( preg_replace( '/_input$/', '', $post_key ) );
+        if ( isset( $field['key'] ) ) {
+            $key      = sanitize_key( $field['key'] );
+            $post_key = sanitize_key( $field['post_key'] ?? $field['key'] );
+        } else {
+            $post_key = is_string( $post_key ) ? $post_key : (string) $post_key;
+            $key      = sanitize_key( preg_replace( '/_input$/', '', $post_key ) );
+        }
         if ( 'tel' === $key ) {
             $key = 'phone';
         }

--- a/src/class-enhanced-icf-processor.php
+++ b/src/class-enhanced-icf-processor.php
@@ -25,10 +25,9 @@ class Enhanced_ICF_Form_Processor {
      * sanitized form data.
      *
      * @param string $template       Template slug.
-     * @param array  $submitted_data Associative array of raw form values. Keys
-     *                               include `name_input`, `email_input`,
-     *                               `tel_input`, `zip_input`, and
-     *                               `message_input`.
+     * @param array  $submitted_data Associative array of raw form values keyed
+     *                               by logical field names such as `name`,
+     *                               `email`, `phone`, `zip`, and `message`.
      *
      * @return array {
      *     @type bool   $success   Whether the submission was processed.

--- a/templates/contact.json
+++ b/templates/contact.json
@@ -1,6 +1,17 @@
 {
-  "fields": {
-    "name_input": {
+  "id": "contact",
+  "version": 1,
+  "title": "Contact Form",
+  "email": {
+    "to": "",
+    "subject": ""
+  },
+  "success": {
+    "mode": "inline",
+    "redirect_url": ""
+  },
+  "fields": [
+    {
       "key": "name",
       "type": "text",
       "placeholder": "Your Name",
@@ -10,7 +21,7 @@
       "aria-required": "true",
       "style": "grid-area: name"
     },
-    "email_input": {
+    {
       "key": "email",
       "type": "email",
       "placeholder": "Your Email",
@@ -20,7 +31,7 @@
       "aria-required": "true",
       "style": "grid-area: email"
     },
-    "tel_input": {
+    {
       "key": "phone",
       "type": "tel",
       "placeholder": "Phone",
@@ -30,7 +41,7 @@
       "aria-required": "true",
       "style": "grid-area: phone"
     },
-    "zip_input": {
+    {
       "key": "zip",
       "type": "text",
       "placeholder": "Project Zip Code",
@@ -40,7 +51,7 @@
       "aria-required": "true",
       "style": "grid-area: zip"
     },
-    "message_input": {
+    {
       "key": "message",
       "type": "textarea",
       "cols": "21",
@@ -51,9 +62,5 @@
       "aria-required": "true",
       "style": "grid-area: message"
     }
-  },
-  "success": {
-    "mode": "inline",
-    "redirect_url": ""
-  }
+  ]
 }

--- a/templates/default.json
+++ b/templates/default.json
@@ -1,6 +1,17 @@
 {
-  "fields": {
-    "name_input": {
+  "id": "default",
+  "version": 1,
+  "title": "Default Contact Form",
+  "email": {
+    "to": "",
+    "subject": ""
+  },
+  "success": {
+    "mode": "inline",
+    "redirect_url": ""
+  },
+  "fields": [
+    {
       "key": "name",
       "type": "text",
       "placeholder": "Your Name",
@@ -10,7 +21,7 @@
       "aria-required": "true",
       "style": "grid-area: name"
     },
-    "email_input": {
+    {
       "key": "email",
       "type": "email",
       "placeholder": "Your Email",
@@ -20,7 +31,7 @@
       "aria-required": "true",
       "style": "grid-area: email"
     },
-    "tel_input": {
+    {
       "key": "phone",
       "type": "tel",
       "placeholder": "Phone",
@@ -30,7 +41,7 @@
       "aria-required": "true",
       "style": "grid-area: phone"
     },
-    "zip_input": {
+    {
       "key": "zip",
       "type": "text",
       "placeholder": "Project Zip Code",
@@ -40,7 +51,7 @@
       "aria-required": "true",
       "style": "grid-area: zip"
     },
-    "message_input": {
+    {
       "key": "message",
       "type": "textarea",
       "cols": "21",
@@ -51,9 +62,5 @@
       "aria-required": "true",
       "style": "grid-area: message"
     }
-  },
-  "success": {
-    "mode": "inline",
-    "redirect_url": ""
-  }
+  ]
 }

--- a/tests/EnhancedICFFormProcessorTest.php
+++ b/tests/EnhancedICFFormProcessorTest.php
@@ -146,10 +146,15 @@ class EnhancedICFFormProcessorTest extends TestCase {
 
     public function test_only_configured_fields_are_validated() {
         $template = 'partial';
-        $config = [
-            'fields' => [
-                'name_input'  => [ 'type' => 'text', 'required' => true ],
-                'email_input' => [ 'type' => 'email', 'required' => true ],
+        $config   = [
+            'id'      => $template,
+            'version' => 1,
+            'title'   => 'Partial',
+            'email'   => [],
+            'success' => [ 'mode' => 'inline', 'redirect_url' => '' ],
+            'fields'  => [
+                [ 'key' => 'name',  'type' => 'text',  'required' => true ],
+                [ 'key' => 'email', 'type' => 'email', 'required' => true ],
             ],
         ];
         $path = __DIR__ . '/../templates/' . $template . '.json';
@@ -170,12 +175,17 @@ class EnhancedICFFormProcessorTest extends TestCase {
 
     public function test_template_without_phone_field() {
         $template = 'no_phone';
-        $config = [
-            'fields' => [
-                'name_input'    => [ 'type' => 'text', 'required' => true ],
-                'email_input'   => [ 'type' => 'email', 'required' => true ],
-                'zip_input'     => [ 'type' => 'text', 'required' => true ],
-                'message_input' => [ 'type' => 'textarea', 'required' => true ],
+        $config   = [
+            'id'      => $template,
+            'version' => 1,
+            'title'   => 'No Phone',
+            'email'   => [],
+            'success' => [ 'mode' => 'inline', 'redirect_url' => '' ],
+            'fields'  => [
+                [ 'key' => 'name',    'type' => 'text',     'required' => true ],
+                [ 'key' => 'email',   'type' => 'email',    'required' => true ],
+                [ 'key' => 'zip',     'type' => 'text',     'required' => true ],
+                [ 'key' => 'message', 'type' => 'textarea', 'required' => true ],
             ],
         ];
         $path = __DIR__ . '/../templates/' . $template . '.json';
@@ -190,11 +200,16 @@ class EnhancedICFFormProcessorTest extends TestCase {
 
     public function test_required_phone_missing() {
         $template = 'phone_only';
-        $config = [
-            'fields' => [
-                'name_input'  => [ 'type' => 'text' ],
-                'email_input' => [ 'type' => 'email' ],
-                'tel_input'   => [ 'type' => 'tel', 'required' => true ],
+        $config   = [
+            'id'      => $template,
+            'version' => 1,
+            'title'   => 'Phone Only',
+            'email'   => [],
+            'success' => [ 'mode' => 'inline', 'redirect_url' => '' ],
+            'fields'  => [
+                [ 'key' => 'name',  'type' => 'text' ],
+                [ 'key' => 'email', 'type' => 'email' ],
+                [ 'key' => 'phone', 'type' => 'tel', 'required' => true ],
             ],
         ];
         $path = __DIR__ . '/../templates/' . $template . '.json';
@@ -219,7 +234,14 @@ class EnhancedICFFormProcessorTest extends TestCase {
 
     public function test_optional_field_can_be_blank() {
         $template = 'opt';
-        $config = [ 'fields' => [ 'name_input' => [ 'type' => 'text' ] ] ];
+        $config   = [
+            'id'      => $template,
+            'version' => 1,
+            'title'   => 'Opt',
+            'email'   => [],
+            'success' => [ 'mode' => 'inline', 'redirect_url' => '' ],
+            'fields'  => [ [ 'key' => 'name', 'type' => 'text' ] ],
+        ];
         $path = __DIR__ . '/../templates/' . $template . '.json';
         file_put_contents( $path, json_encode( $config ) );
 
@@ -248,10 +270,15 @@ class EnhancedICFFormProcessorTest extends TestCase {
 
     public function test_checkbox_field_processed() {
         $template = 'checkbox';
-        $config = [
-            'fields' => [
-                'name_input' => [ 'type' => 'text', 'required' => true ],
-                'opts_input' => [ 'type' => 'checkbox', 'choices' => ['a','b'], 'required' => true ],
+        $config   = [
+            'id'      => $template,
+            'version' => 1,
+            'title'   => 'Checkbox',
+            'email'   => [],
+            'success' => [ 'mode' => 'inline', 'redirect_url' => '' ],
+            'fields'  => [
+                [ 'key' => 'name', 'type' => 'text', 'required' => true ],
+                [ 'key' => 'opts', 'type' => 'checkbox', 'choices' => ['a','b'], 'required' => true ],
             ],
         ];
         $path = __DIR__ . '/../templates/' . $template . '.json';

--- a/tests/EnhancedInternalContactFormTest.php
+++ b/tests/EnhancedInternalContactFormTest.php
@@ -133,11 +133,17 @@ class EnhancedInternalContactFormTest extends TestCase {
 
     public function test_render_form_renders_json_template() {
         $template = 'jsononly';
-        $config = [
-            'fields' => [
-                'name_input' => [
-                    'type' => 'text',
-                    'placeholder' => 'JSON Name'
+        $config   = [
+            'id'      => $template,
+            'version' => 1,
+            'title'   => 'JSON Only',
+            'email'   => [],
+            'success' => [ 'mode' => 'inline', 'redirect_url' => '' ],
+            'fields'  => [
+                [
+                    'key'         => 'name',
+                    'type'        => 'text',
+                    'placeholder' => 'JSON Name',
                 ],
             ],
         ];

--- a/tests/RendererAccessibilityTest.php
+++ b/tests/RendererAccessibilityTest.php
@@ -9,8 +9,8 @@ class RendererAccessibilityTest extends TestCase {
 
         $config = [
             'fields' => [
-                'name_input'  => [ 'type' => 'text', 'required' => true ],
-                'email_input' => [ 'type' => 'email' ],
+                [ 'key' => 'name',  'type' => 'text',  'required' => true ],
+                [ 'key' => 'email', 'type' => 'email' ],
             ],
         ];
 

--- a/tests/TemplateConfigTest.php
+++ b/tests/TemplateConfigTest.php
@@ -13,9 +13,13 @@ class TemplateConfigTest extends TestCase {
 
     public function test_plugin_config_loaded(): void {
         $result = eform_get_template_config( 'default' );
+        $this->assertSame( 'default', $result['id'] );
+        $this->assertSame( 'inline', $result['success']['mode'] );
+        $this->assertSame( 'Your Name', $result['fields'][0]['placeholder'] );
 
-        $this->assertSame( 'Your Name', $result['fields']['name_input']['placeholder'] );
-        $this->assertArrayHasKey( 'email_input', $result['fields'] );
+        $fields = eform_get_template_fields( 'default' );
+        $this->assertArrayHasKey( 'name', $fields );
+        $this->assertSame( 'Your Name', $fields['name']['placeholder'] );
     }
 
     public function test_missing_template_returns_empty(): void {
@@ -25,7 +29,15 @@ class TemplateConfigTest extends TestCase {
     public function test_cache_can_be_purged(): void {
         $template = 'temp';
         $path     = $this->pluginTemplatesDir . "/$template.json";
-        file_put_contents( $path, json_encode( [ 'fields' => [] ] ) );
+        $config   = [
+            'id'      => $template,
+            'version' => 1,
+            'title'   => 'Temp',
+            'email'   => [],
+            'success' => [],
+            'fields'  => [],
+        ];
+        file_put_contents( $path, json_encode( $config ) );
 
         eform_get_template_config( $template );
 


### PR DESCRIPTION
## Summary
- refactor bundled template JSON files to use id, version, title, email, success, and fields[] entries
- update TemplateCache and Renderer to parse new field array instead of `_input` keys
- adjust tests for revised template structure and field parsing

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689ca1757814832d9038bfbac0acd2cb