### PR TITLE
Add labels and fieldset semantics to form renderer

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -15,7 +15,7 @@ class Renderer {
      */
     public function render( FormData $form, string $template, array $config ) {
         echo '<div id="contact_form" class="contact_form">';
-        echo '<div aria-live="polite"></div>';
+        echo '<div aria-live="polite" class="form-errors"></div>';
         echo '<form class="main_contact_form" id="main_contact_form" aria-label="Contact Form" method="post" action="">';
         $form_id = Enhanced_Internal_Contact_Form::render_hidden_fields( $template );
 
@@ -35,7 +35,7 @@ class Renderer {
             $required  = isset( $field['required'] ) ? ' required aria-required="true"' : '';
             $attr_str  = '';
             foreach ( $field as $attr => $val ) {
-                if ( in_array( $attr, [ 'type', 'required', 'style', 'key' ], true ) ) {
+                if ( in_array( $attr, [ 'type', 'required', 'style', 'key', 'label', 'choices' ], true ) ) {
                     continue;
                 }
                 $attr_str .= sprintf( ' %s="%s"', esc_attr( $attr ), esc_attr( $val ) );
@@ -46,11 +46,44 @@ class Renderer {
             $error_id  = 'error-' . $input_id;
             $error_msg = $form->field_errors[ $field_key ] ?? '';
             $aria      = $error_msg ? sprintf( ' aria-describedby="%s" aria-invalid="true"', esc_attr( $error_id ) ) : '';
+
+            $label = $field['label'] ?? ucwords( str_replace( '_', ' ', $field_key ) );
+            $required_marker = isset( $field['required'] ) ? '<span class="required">*</span>' : '';
+
             $render_type = FieldRegistry::get_renderer( $field['type'] ?? 'text' );
-            if ( $render_type === 'textarea' ) {
+            if ( in_array( $field['type'] ?? '', [ 'radio', 'checkbox' ], true ) && ! empty( $field['choices'] ) ) {
+                echo '<fieldset>';
+                echo '<legend>' . esc_html( $label ) . $required_marker . '</legend>';
+                $choices = $field['choices'];
+                $values  = $form->form_data[ $field_key ] ?? ( ( $field['type'] ?? '' ) === 'checkbox' ? [] : '' );
+                foreach ( $choices as $choice_key => $choice ) {
+                    if ( is_array( $choice ) ) {
+                        $choice_value = (string) ( $choice['value'] ?? '' );
+                        $choice_label = (string) ( $choice['label'] ?? $choice_value );
+                    } else {
+                        $choice_value = (string) $choice;
+                        $choice_label = ucwords( str_replace( '_', ' ', $choice_value ) );
+                    }
+                    $option_id = $input_id . '-' . sanitize_key( $choice_value ) . '-' . $choice_key;
+                    $checked   = '';
+                    if ( ( $field['type'] ?? '' ) === 'checkbox' ) {
+                        $checked = in_array( $choice_value, (array) $values, true ) ? ' checked' : '';
+                    } else {
+                        $checked = ( (string) $values === $choice_value ) ? ' checked' : '';
+                    }
+                    $option_name = $name . ( ( $field['type'] ?? '' ) === 'checkbox' ? '[]' : '' );
+                    echo '<div class="choice">';
+                    echo '<input id="' . esc_attr( $option_id ) . '" type="' . esc_attr( $field['type'] ) . '" name="' . esc_attr( $option_name ) . '" value="' . esc_attr( $choice_value ) . '"' . $checked . $required . $attr_str . $aria . '>';
+                    echo '<label for="' . esc_attr( $option_id ) . '">' . esc_html( $choice_label ) . '</label>';
+                    echo '</div>';
+                }
+                echo '</fieldset>';
+            } elseif ( $render_type === 'textarea' ) {
+                echo '<label for="' . esc_attr( $input_id ) . '">' . esc_html( $label ) . $required_marker . '</label>';
                 echo '<textarea id="' . esc_attr( $input_id ) . '" name="' . esc_attr( $name ) . '"' . $required . $attr_str . $aria . '>' . esc_textarea( $value ) . '</textarea>';
             } else {
                 $type = $field['type'] ?? 'text';
+                echo '<label for="' . esc_attr( $input_id ) . '">' . esc_html( $label ) . $required_marker . '</label>';
                 echo '<input id="' . esc_attr( $input_id ) . '" type="' . esc_attr( $type ) . '" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '"' . $required . $attr_str . $aria . '>';
             }
             echo '<span id="' . esc_attr( $error_id ) . '" class="field-error">' . esc_html( $error_msg ) . '</span>';

--- a/tests/RendererAccessibilityTest.php
+++ b/tests/RendererAccessibilityTest.php
@@ -24,7 +24,7 @@ class RendererAccessibilityTest extends TestCase {
         @$dom->loadHTML('<!DOCTYPE html><html><body>' . $output . '</body></html>');
         $xpath = new DOMXPath( $dom );
 
-        $live = $xpath->query('//div[@aria-live="polite"]')->item(0);
+        $live = $xpath->query('//div[@aria-live="polite" and contains(@class,"form-errors")]')->item(0);
         $this->assertNotNull( $live );
 
         $invalid = $xpath->query('//*[@aria-invalid="true"]')->item(0);
@@ -37,8 +37,18 @@ class RendererAccessibilityTest extends TestCase {
         $this->assertNotNull( $error );
         $this->assertSame( 'Required', $error->textContent );
 
+        $label = $xpath->query('//label[@for="' . $id . '"]')->item(0);
+        $this->assertNotNull( $label );
+        $this->assertSame( 'Name', trim( $label->childNodes->item(0)->textContent ) );
+        $this->assertNotNull( $xpath->query('.//span[@class="required"]', $label)->item(0) );
+
         $valid = $xpath->query('//input[@type="email"]')->item(0);
         $this->assertFalse( $valid->hasAttribute('aria-invalid') );
         $this->assertFalse( $valid->hasAttribute('aria-describedby') );
+        $valid_id = $valid->getAttribute('id');
+        $valid_label = $xpath->query('//label[@for="' . $valid_id . '"]')->item(0);
+        $this->assertNotNull( $valid_label );
+        $this->assertSame( 'Email', trim( $valid_label->textContent ) );
+        $this->assertNull( $xpath->query('.//span[@class="required"]', $valid_label)->item(0) );
     }
 }

--- a/tests/RendererGroupFieldsetTest.php
+++ b/tests/RendererGroupFieldsetTest.php
@@ -1,0 +1,57 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class RendererGroupFieldsetTest extends TestCase {
+    public function test_radio_and_checkbox_groups_use_fieldset_and_legend() {
+        $form = new FormData();
+        $form->form_data = [];
+        $form->field_errors = [];
+
+        $config = [
+            'fields' => [
+                [
+                    'key' => 'preferred',
+                    'type' => 'radio',
+                    'label' => 'Preferred',
+                    'choices' => ['yes','no'],
+                    'required' => true,
+                ],
+                [
+                    'key' => 'options',
+                    'type' => 'checkbox',
+                    'label' => 'Options',
+                    'choices' => ['a','b'],
+                ],
+            ],
+        ];
+
+        $renderer = new Renderer();
+
+        ob_start();
+        $renderer->render( $form, 'default', $config );
+        $output = ob_get_clean();
+
+        $dom = new DOMDocument();
+        @$dom->loadHTML('<!DOCTYPE html><html><body>' . $output . '</body></html>');
+        $xpath = new DOMXPath( $dom );
+
+        $radio_fieldset = $xpath->query('//fieldset[legend[contains(text(),"Preferred")]]')->item(0);
+        $this->assertNotNull( $radio_fieldset );
+        $legend = $xpath->query('./legend', $radio_fieldset)->item(0);
+        $this->assertNotNull( $legend );
+        $this->assertNotNull( $xpath->query('.//span[@class="required"]', $legend)->item(0) );
+        $radio_input = $xpath->query('.//input[@type="radio"]', $radio_fieldset)->item(0);
+        $this->assertNotNull( $radio_input );
+        $radio_id = $radio_input->getAttribute('id');
+        $this->assertNotEmpty( $radio_id );
+        $this->assertNotNull( $xpath->query('//label[@for="' . $radio_id . '"]')->item(0) );
+
+        $checkbox_fieldset = $xpath->query('//fieldset[legend[contains(text(),"Options")]]')->item(0);
+        $this->assertNotNull( $checkbox_fieldset );
+        $checkbox_input = $xpath->query('.//input[@type="checkbox"]', $checkbox_fieldset)->item(0);
+        $this->assertNotNull( $checkbox_input );
+        $checkbox_id = $checkbox_input->getAttribute('id');
+        $this->assertNotEmpty( $checkbox_id );
+        $this->assertNotNull( $xpath->query('//label[@for="' . $checkbox_id . '"]')->item(0) );
+    }
+}


### PR DESCRIPTION
## Summary
- render label elements tied to inputs, with required markers
- wrap radio and checkbox groups in fieldsets with legends
- add global error container and tests for accessibility

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689ca4048e58832da3f2dad518f9f0c9