### PR TITLE
Include instance ID in field IDs and enforce template key rules

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -17,7 +17,7 @@ class Renderer {
         echo '<div id="contact_form" class="contact_form">';
         echo '<div aria-live="polite" class="form-errors"></div>';
         echo '<form class="main_contact_form" id="main_contact_form" aria-label="Contact Form" method="post" action="">';
-        $form_id = Enhanced_Internal_Contact_Form::render_hidden_fields( $template );
+        list( $form_id, $instance_id ) = Enhanced_Internal_Contact_Form::render_hidden_fields( $template );
 
         foreach ( $config['fields'] ?? [] as $post_key => $field ) {
             if ( isset( $field['key'] ) ) {
@@ -42,7 +42,7 @@ class Renderer {
             }
             echo '<div class="inputwrap" style="' . esc_attr( $field['style'] ?? '' ) . '">';
             $name      = $form_id . '[' . $field_key . ']';
-            $input_id  = $form_id . '-' . $field_key;
+            $input_id  = $form_id . '-' . $instance_id . '-' . $field_key;
             $error_id  = 'error-' . $input_id;
             $error_msg = $form->field_errors[ $field_key ] ?? '';
             $aria      = $error_msg ? sprintf( ' aria-describedby="%s" aria-invalid="true"', esc_attr( $error_id ) ) : '';

--- a/src/TemplateCache.php
+++ b/src/TemplateCache.php
@@ -99,6 +99,18 @@ function eform_load_config_from_paths( array $paths ): array {
 function eform_get_template_fields( string $template ): array {
     $config = eform_get_template_config( $template );
     $fields = [];
+    $reserved_keys    = [
+        'enhanced_form_id',
+        'enhanced_instance_id',
+        'enhanced_fields',
+        'submitted',
+        'enhanced_form_time',
+        'enhanced_template',
+        'enhanced_js_check',
+        'enhanced_url',
+        'enhanced_icf_form_nonce',
+    ];
+    $multi_value_types = [ 'checkbox' ];
 
     foreach ( $config['fields'] ?? [] as $post_key => $field ) {
         if ( isset( $field['key'] ) ) {
@@ -107,9 +119,16 @@ function eform_get_template_fields( string $template ): array {
         } else {
             $post_key = is_string( $post_key ) ? $post_key : (string) $post_key;
             $key      = sanitize_key( preg_replace( '/_input$/', '', $post_key ) );
+            $post_key = sanitize_key( $post_key );
         }
         if ( 'tel' === $key ) {
             $key = 'phone';
+        }
+        if ( in_array( $key, $reserved_keys, true ) ) {
+            continue;
+        }
+        if ( in_array( $field['type'] ?? '', $multi_value_types, true ) ) {
+            $post_key .= '[]';
         }
 
         $field['post_key'] = $post_key;

--- a/src/class-enhanced-icf.php
+++ b/src/class-enhanced-icf.php
@@ -89,6 +89,8 @@ class Enhanced_Internal_Contact_Form extends FormData {
 
     /**
      * Output hidden fields used across form templates.
+     *
+     * @return array{0:string,1:string} Array containing the form ID and instance ID.
      */
     public static function render_hidden_fields($template) {
         $form_id     = 'f_' . bin2hex( random_bytes( 5 ) );
@@ -102,7 +104,7 @@ class Enhanced_Internal_Contact_Form extends FormData {
         echo '<input type="hidden" name="enhanced_form_id" value="' . esc_attr( $form_id ) . '">';
         echo '<input type="hidden" name="enhanced_instance_id" value="' . esc_attr( $instance_id ) . '">';
 
-        return $form_id;
+        return [ $form_id, $instance_id ];
     }
 
     public function handle_shortcode( $atts, ?Enhanced_ICF_Form_Processor $processor = null ) {

--- a/tests/RendererInstanceIdTest.php
+++ b/tests/RendererInstanceIdTest.php
@@ -1,0 +1,27 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class RendererInstanceIdTest extends TestCase {
+    public function test_ids_include_instance_id(): void {
+        $form = new FormData();
+        $config = [
+            'fields' => [ [ 'key' => 'name', 'type' => 'text' ] ],
+        ];
+
+        $renderer = new Renderer();
+        ob_start();
+        $renderer->render( $form, 'default', $config );
+        $output = ob_get_clean();
+
+        $dom = new DOMDocument();
+        @$dom->loadHTML('<!DOCTYPE html><html><body>' . $output . '</body></html>');
+        $xpath = new DOMXPath( $dom );
+
+        $instance = $xpath->query('//input[@name="enhanced_instance_id"]')->item(0);
+        $this->assertNotNull( $instance );
+        $instance_id = $instance->getAttribute('value');
+        $input = $xpath->query('//input[@type="text" and @id]')->item(0);
+        $this->assertNotNull( $input );
+        $this->assertStringContainsString( $instance_id, $input->getAttribute('id') );
+    }
+}

--- a/tests/TemplateCacheFieldHandlingTest.php
+++ b/tests/TemplateCacheFieldHandlingTest.php
@@ -1,0 +1,35 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class TemplateCacheFieldHandlingTest extends TestCase {
+    private string $templatesDir;
+
+    protected function setUp(): void {
+        $this->templatesDir = dirname( __DIR__ ) . '/templates';
+        $GLOBALS['wp_cache'] = [];
+    }
+
+    public function test_multivalue_fields_and_reserved_keys(): void {
+        $template = 'field_handling';
+        $path     = $this->templatesDir . '/' . $template . '.json';
+        $config   = [
+            'id'      => $template,
+            'version' => 1,
+            'title'   => 'Field Handling',
+            'email'   => [],
+            'success' => [],
+            'fields'  => [
+                [ 'key' => 'options', 'type' => 'checkbox' ],
+                [ 'key' => 'enhanced_form_id', 'type' => 'text' ],
+            ],
+        ];
+        file_put_contents( $path, json_encode( $config ) );
+
+        $fields = eform_get_template_fields( $template );
+        $this->assertArrayHasKey( 'options', $fields );
+        $this->assertSame( 'options[]', $fields['options']['post_key'] );
+        $this->assertArrayNotHasKey( 'enhanced_form_id', $fields );
+
+        unlink( $path );
+    }
+}


### PR DESCRIPTION
## Summary
- ensure form fields use both form and instance identifiers in `id` attributes
- add reserved key protection and multivalue `[]` suffixes in template cache
- cover instance IDs and template cache field handling with new tests

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689ca56c59ac832d800408cce3fa4511