### PR TITLE
Honor email config and secure headers

### DIFF
--- a/src/class-enhanced-icf-processor.php
+++ b/src/class-enhanced-icf-processor.php
@@ -100,7 +100,7 @@ class Enhanced_ICF_Form_Processor {
 
         $data = $this->validator->coerce_submission( $field_map, $data );
 
-        if ( ! $this->emailer->dispatch_email( $data ) ) {
+        if ( ! $this->emailer->dispatch_email( $data, $config ) ) {
             $details = [ 'form_data' => $data ];
             return $this->error_response( 'Email Sending Failure', $details, 'Something went wrong. Please try again later.' );
         }

--- a/templates/contact.json
+++ b/templates/contact.json
@@ -4,12 +4,14 @@
   "title": "Contact Form",
   "email": {
     "to": "",
-    "subject": ""
+    "subject": "",
+    "include_fields": ["name", "email", "phone", "zip", "message"]
   },
   "success": {
     "mode": "inline",
     "redirect_url": ""
   },
+  "display_format_tel": true,
   "fields": [
     {
       "key": "name",

--- a/templates/default.json
+++ b/templates/default.json
@@ -4,12 +4,14 @@
   "title": "Default Contact Form",
   "email": {
     "to": "",
-    "subject": ""
+    "subject": "",
+    "include_fields": ["name", "email", "phone", "zip", "message"]
   },
   "success": {
     "mode": "inline",
     "redirect_url": ""
   },
+  "display_format_tel": true,
   "fields": [
     {
       "key": "name",

--- a/tests/EmailerTest.php
+++ b/tests/EmailerTest.php
@@ -1,0 +1,63 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class EmailerTest extends TestCase {
+    protected function setUp(): void {
+        unset($GLOBALS['_last_mail']);
+    }
+
+    public function test_plain_text_and_field_inclusion_and_tel_formatting(): void {
+        $emailer = new Emailer('127.0.0.1');
+        $config = [
+            'email' => ['include_fields' => ['name', 'phone']],
+            'display_format_tel' => true,
+        ];
+        $data = [
+            'name'  => 'John Doe',
+            'email' => 'john@example.com',
+            'phone' => '1234567890',
+            'zip'   => '99999',
+        ];
+        $this->assertTrue($emailer->dispatch_email($data, $config));
+        $mail = $GLOBALS['_last_mail'];
+        $this->assertStringContainsString('Name: John Doe', $mail['message']);
+        $this->assertStringContainsString('Phone: 123-456-7890', $mail['message']);
+        $this->assertStringNotContainsString('Zip', $mail['message']);
+        $this->assertContains('Content-Type: text/plain; charset=UTF-8', $mail['headers']);
+    }
+
+    public function test_html_email_enabled_via_constant(): void {
+        if (!defined('EFORM_ALLOW_HTML_EMAIL')) {
+            define('EFORM_ALLOW_HTML_EMAIL', true);
+        }
+        $emailer = new Emailer('127.0.0.1');
+        $data = [
+            'name'    => 'Jane',
+            'email'   => 'jane@example.com',
+            'message' => "Hello world",
+        ];
+        $this->assertTrue($emailer->dispatch_email($data, []));
+        $mail = $GLOBALS['_last_mail'];
+        $this->assertContains('Content-Type: text/html; charset=UTF-8', $mail['headers']);
+        $this->assertStringContainsString('<table', $mail['message']);
+    }
+
+    public function test_header_sanitization_and_validation(): void {
+        $emailer = new Emailer('127.0.0.1');
+        $data = [
+            'name'  => "Jane\r\nDoe",
+            'email' => "bad@example.com\r\nBcc:evil@example.com",
+        ];
+        $this->assertTrue($emailer->dispatch_email($data, []));
+        $mail = $GLOBALS['_last_mail'];
+        $this->assertContains('From: Jane Doe <noreply@flooringartists.com>', $mail['headers']);
+        $hasReply = false;
+        foreach ($mail['headers'] as $h) {
+            $this->assertStringNotContainsString('Bcc', $h);
+            if (strpos($h, 'Reply-To:') === 0) {
+                $hasReply = true;
+            }
+        }
+        $this->assertFalse($hasReply, 'Reply-To header should be omitted for invalid email');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,6 +43,7 @@ function apply_filters($tag,$value){
     return $value;
 }
 function wp_mail($to,$subject,$message,$headers){
+    $GLOBALS['_last_mail'] = compact('to','subject','message','headers');
     return true;
 }
 function eform_get_safe_fields($data){


### PR DESCRIPTION
## Summary
- default email output to plain text, enable HTML only via `EFORM_ALLOW_HTML_EMAIL`
- sanitize and validate From/Reply-To headers using whitelisted fields
- respect `email.include_fields` and `display_format_tel` settings

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689d24adede4832dbf23efaa1894ebaf