### PR TITLE
Read success message from template config

### DIFF
--- a/src/class-enhanced-icf.php
+++ b/src/class-enhanced-icf.php
@@ -3,7 +3,6 @@
 
 class Enhanced_Internal_Contact_Form extends FormData {
     private $redirect_url='/?page_id=20'; // Set to empty string to disable redirect
-    private $success_message = '<div class="form-message success">Thank you! Your message has been sent.</div>';
     private $error_message = '';
     private $form_submitted = false;
     private $processed_template = ''; // Track which template was submitted
@@ -133,7 +132,8 @@ class Enhanced_Internal_Contact_Form extends FormData {
             if ( $this->error_message ) {
                 $form_html = $this->error_message . $form_html;
             } elseif ( $this->form_submitted ) {
-                $form_html = $this->success_message . $form_html;
+                $message   = $this->template_config['success']['message'] ?? 'Thank you! Your message has been sent.';
+                $form_html = '<div class="form-message success">' . esc_html( $message ) . '</div>' . $form_html;
             }
         }
 

--- a/templates/contact.json
+++ b/templates/contact.json
@@ -9,7 +9,8 @@
   },
   "success": {
     "mode": "inline",
-    "redirect_url": ""
+    "redirect_url": "",
+    "message": "Thank you! Your message has been sent."
   },
   "display_format_tel": true,
   "fields": [

--- a/templates/default.json
+++ b/templates/default.json
@@ -9,7 +9,8 @@
   },
   "success": {
     "mode": "inline",
-    "redirect_url": ""
+    "redirect_url": "",
+    "message": "Thank you! Your message has been sent."
   },
   "display_format_tel": true,
   "fields": [


### PR DESCRIPTION
## Summary
- Read success message from each template's `success.message` and escape output with `esc_html`.
- Remove hard-coded `$success_message` property.
- Add default success messages to bundled template configs.

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689e106bee88832d9b694db5467fe0a7