### PR TITLE
Use wp_nonce_field for form nonces

### DIFF
--- a/src/Security.php
+++ b/src/Security.php
@@ -14,7 +14,8 @@ class Security {
         $nonce       = Helpers::get_first_value( $submitted_data['_wpnonce'] ?? '' );
         $form_id     = Helpers::get_first_value( $submitted_data['form_id'] ?? '' );
         $instance_id = Helpers::get_first_value( $submitted_data['instance_id'] ?? '' );
-        if ( empty( $nonce ) || empty( $form_id ) || empty( $instance_id ) || ! wp_verify_nonce( $nonce, 'eforms_form_' . $form_id . ':' . $instance_id ) ) {
+        $action      = "eforms_form_{$form_id}:{$instance_id}";
+        if ( empty( $nonce ) || empty( $form_id ) || empty( $instance_id ) || ! wp_verify_nonce( $nonce, $action ) ) {
             return $this->build_error('Nonce Failed', 'Invalid submission detected.');
         }
         return [];

--- a/src/class-enhanced-icf.php
+++ b/src/class-enhanced-icf.php
@@ -92,7 +92,7 @@ class Enhanced_Internal_Contact_Form extends FormData {
         $form_id     = sanitize_key( $template );
         $instance_id = 'i_' . bin2hex( random_bytes( 5 ) );
 
-        echo '<input type="hidden" name="_wpnonce" value="valid">';
+        wp_nonce_field( "eforms_form_{$form_id}:{$instance_id}" );
         echo '<input type="hidden" name="timestamp" value="' . esc_attr( time() ) . '">';
         echo '<input type="hidden" name="form_id" value="' . esc_attr( $form_id ) . '">';
         echo '<input type="hidden" name="instance_id" value="' . esc_attr( $instance_id ) . '">';

--- a/tests/EnhancedICFFormProcessorErrorsTest.php
+++ b/tests/EnhancedICFFormProcessorErrorsTest.php
@@ -5,17 +5,18 @@ class EnhancedICFFormProcessorErrorsTest extends TestCase {
     public function test_process_form_submission_returns_errors_with_keys() {
         $processor = new Enhanced_ICF_Form_Processor(new Logging());
 
-        $form_id  = 'form123';
+        $form_id  = 'default';
         $submitted = [
-            'enhanced_icf_form_nonce' => 'valid',
-            'enhanced_url'           => '',
-            'enhanced_form_time'     => time() - 10,
-            'enhanced_js_check'      => '1',
-            'enhanced_form_id'       => $form_id,
-            $form_id                 => [
+            '_wpnonce'   => 'valid',
+            'eforms_hp'  => '',
+            'timestamp'  => time() - 10,
+            'js_ok'      => '1',
+            'form_id'    => $form_id,
+            'instance_id'=> 'i_test',
+            $form_id     => [
                 'name'    => 'Jo',
                 'email'   => 'not-an-email',
-                'phone'   => '123',
+                'tel'     => '123',
                 'zip'     => 'abcde',
                 'message' => 'short',
             ],
@@ -26,7 +27,7 @@ class EnhancedICFFormProcessorErrorsTest extends TestCase {
         $this->assertFalse($result['success']);
         $this->assertArrayHasKey('errors', $result);
         $this->assertArrayHasKey('email', $result['errors']);
-        $this->assertArrayHasKey('phone', $result['errors']);
+        $this->assertArrayHasKey('tel', $result['errors']);
         $this->assertArrayHasKey('message', $result['errors']);
         $this->assertSame('Please correct the highlighted fields', $result['message']);
     }

--- a/tests/RendererInstanceIdTest.php
+++ b/tests/RendererInstanceIdTest.php
@@ -17,10 +17,10 @@ class RendererInstanceIdTest extends TestCase {
         @$dom->loadHTML('<!DOCTYPE html><html><body>' . $output . '</body></html>');
         $xpath = new DOMXPath( $dom );
 
-        $instance = $xpath->query('//input[@name="enhanced_instance_id"]')->item(0);
+        $instance = $xpath->query('//input[@name="instance_id"]')->item(0);
         $this->assertNotNull( $instance );
         $instance_id = $instance->getAttribute('value');
-        $input = $xpath->query('//input[@type="text" and @id]')->item(0);
+        $input = $xpath->query('//input[@name="default[name]"]')->item(0);
         $this->assertNotNull( $input );
         $this->assertStringContainsString( $instance_id, $input->getAttribute('id') );
     }

--- a/tests/TemplateCacheFieldHandlingTest.php
+++ b/tests/TemplateCacheFieldHandlingTest.php
@@ -20,7 +20,7 @@ class TemplateCacheFieldHandlingTest extends TestCase {
             'success' => [],
             'fields'  => [
                 [ 'key' => 'options', 'type' => 'checkbox' ],
-                [ 'key' => 'enhanced_form_id', 'type' => 'text' ],
+                [ 'key' => 'form_id', 'type' => 'text' ],
             ],
         ];
         file_put_contents( $path, json_encode( $config ) );
@@ -28,7 +28,7 @@ class TemplateCacheFieldHandlingTest extends TestCase {
         $fields = eform_get_template_fields( $template );
         $this->assertArrayHasKey( 'options', $fields );
         $this->assertSame( 'options[]', $fields['options']['post_key'] );
-        $this->assertArrayNotHasKey( 'enhanced_form_id', $fields );
+        $this->assertArrayNotHasKey( 'form_id', $fields );
 
         unlink( $path );
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -149,7 +149,9 @@ function wp_mkdir_p($dir){
     }
     return true;
 }
-function wp_nonce_field(){ }
+function wp_nonce_field($action = -1){
+    echo '<input type="hidden" name="_wpnonce" value="valid">';
+}
 class WP_Post {
     public $post_content;
 }


### PR DESCRIPTION
## Summary
- generate form nonce via `wp_nonce_field` using `eforms_form_{form_id}:{instance_id}` action
- verify nonce with matching action string in `Security::check_nonce`
- update tests and bootstrap stubs for new nonce structure

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a2571d11f0832d91dfc3e1f15959d6