### PR TITLE
Use wp_kses for fragment sanitization

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -10,51 +10,26 @@ class Renderer {
         if ( $html === '' ) {
             return '';
         }
-        $allowed = ['div','span','p','br','strong','em','h1','h2','h3','h4','h5','h6','ul','ol','li'];
-        $doc = new DOMDocument();
-        libxml_use_internal_errors(true);
-        $wrapper = '<div>' . $html . '</div>';
-        if ( ! @$doc->loadHTML( $wrapper, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD ) ) {
-            return '';
-        }
-        $body = $doc->getElementsByTagName('div')->item(0);
-        $this->sanitize_dom_node( $body, $allowed );
-        $out = '';
-        foreach ( $body->childNodes as $child ) {
-            $out .= $doc->saveHTML( $child );
-        }
-        return $out;
-    }
 
-    private function sanitize_dom_node( DOMNode $node, array $allowed ): void {
-        if ( $node->nodeType === XML_ELEMENT_NODE ) {
-            $tag = strtolower( $node->nodeName );
-            if ( ! in_array( $tag, $allowed, true ) ) {
-                $this->remove_node( $node );
-                return;
-            }
-            if ( $node->hasAttributes() ) {
-                $class = $node->attributes->getNamedItem('class');
-                foreach ( iterator_to_array( $node->attributes ) as $attr ) {
-                    if ( $attr->nodeName !== 'class' ) {
-                        $node->removeAttributeNode( $attr );
-                    }
-                }
-                if ( $class ) {
-                    $node->setAttribute('class', $class->nodeValue);
-                }
-            }
-        }
-        foreach ( iterator_to_array( $node->childNodes ) as $child ) {
-            $this->sanitize_dom_node( $child, $allowed );
-        }
-    }
+        $allowed = [
+            'div'   => [ 'class' => true ],
+            'span'  => [ 'class' => true ],
+            'p'     => [ 'class' => true ],
+            'br'    => [],
+            'strong'=> [ 'class' => true ],
+            'em'    => [ 'class' => true ],
+            'h1'    => [ 'class' => true ],
+            'h2'    => [ 'class' => true ],
+            'h3'    => [ 'class' => true ],
+            'h4'    => [ 'class' => true ],
+            'h5'    => [ 'class' => true ],
+            'h6'    => [ 'class' => true ],
+            'ul'    => [ 'class' => true ],
+            'ol'    => [ 'class' => true ],
+            'li'    => [ 'class' => true ],
+        ];
 
-    private function remove_node( DOMNode $node ): void {
-        while ( $node->firstChild ) {
-            $node->parentNode->insertBefore( $node->firstChild, $node );
-        }
-        $node->parentNode->removeChild( $node );
+        return wp_kses( $html, $allowed );
     }
 
     public function render( FormData $form, string $template, array $config ) {

--- a/tests/RendererSanitizeFragmentTest.php
+++ b/tests/RendererSanitizeFragmentTest.php
@@ -1,0 +1,41 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class RendererSanitizeFragmentTest extends TestCase {
+    public function test_before_and_after_html_are_sanitized() {
+        $form = new FormData();
+        $form->form_data = [];
+        $form->field_errors = [];
+
+        $config = [
+            'fields' => [
+                [
+                    'key' => 'name',
+                    'type' => 'text',
+                    'before_html' => '<div id="bad" class="good" onclick="evil()"><em>Hi</em></div><script>alert(1)</script>',
+                    'after_html'  => '<span data-test="nope" class="after">Bye</span><unknown>bad</unknown>',
+                ],
+            ],
+        ];
+
+        $renderer = new Renderer();
+        ob_start();
+        $renderer->render( $form, 'default', $config );
+        $output = ob_get_clean();
+
+        $dom = new DOMDocument();
+        @$dom->loadHTML('<!DOCTYPE html><html><body>' . $output . '</body></html>');
+        $xpath = new DOMXPath( $dom );
+
+        $before = $xpath->query('//div[@class="good"]')->item(0);
+        $this->assertNotNull( $before );
+        $this->assertFalse( $before->hasAttribute('id') );
+        $this->assertFalse( $before->hasAttribute('onclick') );
+        $this->assertNotNull( $xpath->query('.//em', $before)->item(0) );
+        $this->assertNull( $xpath->query('//script')->item(0) );
+
+        $after = $xpath->query('//span[@class="after"]')->item(0);
+        $this->assertNotNull( $after );
+        $this->assertFalse( $after->hasAttribute('data-test') );
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize `before_html` and `after_html` fragments in Renderer with `wp_kses`
- add `wp_kses` stub for tests and new coverage for fragment sanitization

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a25d848e7c832dafaf20fafbddd715