### PR TITLE
Refactor logging directory and file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Enhanced iContact Form
 
-This plugin includes logging for form activity. Log entries are written to
-`WP_CONTENT_DIR/uploads/logs/forms.log`, which is outside the plugin directory
-and typically not directly accessible via the web. The plugin will create this
-location if it does not exist and enforce restrictive permissions (`0640`) on
-the log file. When the log file exceeds 5MB it is rotated with a timestamped
-suffix and a new log is started. Administrators may adjust the limit by defining
+This plugin includes logging for form activity. Log entries are written to a
+JSONL file (`forms.jsonl`) in `../eform-logs` relative to `WP_CONTENT_DIR`. This
+directory resides outside the web root and the plugin automatically creates
+`.htaccess` and `index.html` files to block direct access. Administrators may
+override the location by defining `EFORM_LOG_DIR` or filtering
+`eform_log_dir`. The log file is created with restrictive permissions (`0640`)
+and entries are appended atomically.
+
+When the log file exceeds 5MB it is rotated with a timestamped suffix and a new
+log is started. Administrators may adjust the limit by defining
 `EFORM_LOG_FILE_MAX_SIZE` (bytes) or using the `eform_log_file_max_size` filter.
 Rotated log files older than 30 days are automatically deleted; customize this
 window by defining `EFORM_LOG_RETENTION_DAYS` or filtering


### PR DESCRIPTION
## Summary
- store logs in `../eform-logs/forms.jsonl` outside the web root
- append log entries atomically and rotate using constants
- create deny files to prevent direct access to log directory

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a25ed22090832da00c493c416fbca0