### PR TITLE
feat: enhance email handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ template via JSON configuration.
   In `soft` mode the form proceeds even if the `enhanced_js_check` field is
   missing.
 
+## Email Customization
+
+The `From` address defaults to `noreply` at the site's domain derived from `home_url()`. Override the user or domain by defining `EFORMS_FROM_USER` and `EFORMS_FROM_DOMAIN`.
+
+The IP address is included in outbound messages only when the template's `email.include_fields` contains `ip` and `EFORMS_IP_MODE` permits. Set `EFORMS_IP_MODE` to `anonymize` (default), `full`, or `none`.
+
+Define `EFORMS_STAGING_REDIRECT` to add an `X-Staging-Redirect` header for staging environments. When a submission is marked suspect and `EFORMS_SUSPECT_TAG` is defined, an `X-Tag` header is appended with that tag.
+
 ## Running Tests
 
 Install dependencies and execute the test suite:

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -79,6 +79,9 @@ function get_option($name,$default=''){
     if($name==='admin_email'){return 'admin@example.com';}
     return $default;
 }
+function home_url($path = ''){
+    return 'https://example.test';
+}
 function apply_filters($tag,$value){
     return $value;
 }


### PR DESCRIPTION
## Summary
- derive From domain from home_url or override constants
- conditionally include IP and support anonymization modes
- add staging redirect and suspect tagging headers
- document email customization and extend tests

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a260d4759c832daa66b292b99351bc