### PR TITLE
Add template schema validation

### DIFF
--- a/eforms.php
+++ b/eforms.php
@@ -30,6 +30,7 @@ spl_autoload_register( function ( $class ) {
         'Enhanced_Internal_Contact_Form' => 'src/class-enhanced-icf.php',
         'FieldRegistry'                => 'src/FieldRegistry.php',
         'ValueNormalizer'              => 'src/Normalizer.php',
+        'TemplateValidator'            => 'src/TemplateValidator.php',
         'Uploads'                      => 'src/Uploads.php',
     ];
     if ( isset( $map[ $class ] ) ) {

--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -1,0 +1,171 @@
+<?php
+// src/TemplateValidator.php
+
+class TemplateValidator {
+    public const ERR_UNKNOWN_KEY = 'EFORMS_ERR_SCHEMA_UNKNOWN_KEY';
+    public const ERR_ENUM = 'EFORMS_ERR_SCHEMA_ENUM';
+    public const ERR_REQUIRED_COMBO = 'EFORMS_ERR_SCHEMA_REQUIRED_COMBO';
+    public const ERR_ROW_GROUP_SHAPE = 'EFORMS_ERR_SCHEMA_ROW_GROUP_SHAPE';
+    public const ERR_ACCEPT_INTERSECTION = 'EFORMS_ERR_SCHEMA_ACCEPT_INTERSECTION';
+
+    /**
+     * Keys allowed on individual field definitions.
+     *
+     * This is intentionally permissive and covers all keys currently used by
+     * the plugin. Unknown keys are considered a schema violation.
+     */
+    private const ALLOWED_FIELD_KEYS = [
+        'key',
+        'type',
+        'label',
+        'required',
+        'placeholder',
+        'options',
+        'class',
+        'mode',
+        'tag',
+        'cols',
+        'rows',
+        'aria-label',
+        'aria-required',
+        'style',
+        'autocomplete',
+        'before_html',
+        'choices',
+        'post_key',
+        'pattern',
+        'min',
+        'max',
+        'step',
+        'matches',
+        'required_if',
+        'required_with',
+        'required_without',
+        'accept',
+    ];
+
+    /** Allowed field types. */
+    private const ALLOWED_TYPES = [
+        'text',
+        'name',
+        'email',
+        'tel',
+        'zip',
+        'textarea',
+        'row_group',
+        'checkbox',
+        'select',
+        'number',
+        'url',
+        'message',
+        'file',
+    ];
+
+    /** Allowed row_group modes. */
+    private const ROW_GROUP_MODES = ['start', 'end'];
+
+    /**
+     * Allowed MIME types/extensions for file inputs. The accept[] property must
+     * intersect with this list.
+     */
+    private const ALLOWED_ACCEPTS = [
+        'image/jpeg',
+        'image/png',
+        'application/pdf',
+    ];
+
+    /**
+     * Validate a template configuration.
+     *
+     * @param array $config Parsed template configuration.
+     * @return array{valid:bool,code:string,errors:array}
+     */
+    public function validate( array $config ): array {
+        $errors = [];
+        $fields = $config['fields'] ?? [];
+        $depth  = 0;
+
+        foreach ( $fields as $index => $field ) {
+            if ( ! is_array( $field ) ) {
+                continue;
+            }
+
+            // Unknown keys.
+            $unknown = array_diff( array_keys( $field ), self::ALLOWED_FIELD_KEYS );
+            if ( $unknown ) {
+                $errors[] = [
+                    'code'    => self::ERR_UNKNOWN_KEY,
+                    'index'   => $index,
+                    'unknown' => array_values( $unknown ),
+                ];
+            }
+
+            // Enumerated type.
+            if ( isset( $field['type'] ) && ! in_array( $field['type'], self::ALLOWED_TYPES, true ) ) {
+                $errors[] = [
+                    'code'  => self::ERR_ENUM,
+                    'index' => $index,
+                    'field' => 'type',
+                    'value' => $field['type'],
+                ];
+            }
+
+            // Row group handling.
+            if ( ( $field['type'] ?? '' ) === 'row_group' ) {
+                $mode = $field['mode'] ?? '';
+                if ( ! in_array( $mode, self::ROW_GROUP_MODES, true ) ) {
+                    $errors[] = [
+                        'code'  => self::ERR_ENUM,
+                        'index' => $index,
+                        'field' => 'mode',
+                        'value' => $mode,
+                    ];
+                }
+                if ( $mode === 'start' ) {
+                    $depth++;
+                    if ( empty( $field['tag'] ) ) {
+                        $errors[] = [
+                            'code'   => self::ERR_REQUIRED_COMBO,
+                            'index'  => $index,
+                            'fields' => [ 'mode', 'tag' ],
+                        ];
+                    }
+                } elseif ( $mode === 'end' ) {
+                    $depth--;
+                    if ( $depth < 0 ) {
+                        $errors[] = [
+                            'code'  => self::ERR_ROW_GROUP_SHAPE,
+                            'index' => $index,
+                        ];
+                        $depth = 0;
+                    }
+                }
+            }
+
+            // accept[] intersection for file inputs.
+            if ( isset( $field['accept'] ) ) {
+                $accept = $field['accept'];
+                if ( ! is_array( $accept ) ) {
+                    $accept = [ $accept ];
+                }
+                $intersection = array_intersect( $accept, self::ALLOWED_ACCEPTS );
+                if ( empty( $intersection ) ) {
+                    $errors[] = [
+                        'code'  => self::ERR_ACCEPT_INTERSECTION,
+                        'index' => $index,
+                    ];
+                }
+            }
+        }
+
+        if ( $depth !== 0 ) {
+            $errors[] = [ 'code' => self::ERR_ROW_GROUP_SHAPE ];
+        }
+
+        if ( ! empty( $errors ) ) {
+            return [ 'valid' => false, 'code' => $errors[0]['code'], 'errors' => $errors ];
+        }
+
+        return [ 'valid' => true, 'code' => '', 'errors' => [] ];
+    }
+}

--- a/src/class-enhanced-icf-processor.php
+++ b/src/class-enhanced-icf-processor.php
@@ -66,6 +66,12 @@ class Enhanced_ICF_Form_Processor {
 
         $field_map = eform_get_template_fields( $template );
 
+        $schema_validator = new TemplateValidator();
+        $schema_result    = $schema_validator->validate( $config );
+        if ( ! $schema_result['valid'] ) {
+            return $this->error_response( $schema_result['code'], [ 'errors' => $schema_result['errors'] ], $schema_result['code'] );
+        }
+
         $form_id    = Helpers::get_first_value( $submitted_data['form_id'] ?? '' );
         $form_scope = [];
         if ( $form_id && isset( $submitted_data[ $form_id ] ) && is_array( $submitted_data[ $form_id ] ) ) {

--- a/tests/TemplateValidatorPipelineTest.php
+++ b/tests/TemplateValidatorPipelineTest.php
@@ -1,0 +1,42 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class TemplateValidatorPipelineTest extends TestCase {
+    private string $templatesDir;
+
+    protected function setUp(): void {
+        $this->templatesDir = dirname( __DIR__ ) . '/templates';
+    }
+
+    public function test_invalid_template_triggers_error_code() {
+        $template = 'invalid_schema';
+        $path     = $this->templatesDir . '/' . $template . '.json';
+        $config   = [
+            'id'      => $template,
+            'version' => 1,
+            'title'   => 'Invalid',
+            'email'   => [],
+            'success' => [],
+            'fields'  => [ [ 'key' => 'name', 'type' => 'bogus' ] ],
+        ];
+        file_put_contents( $path, json_encode( $config ) );
+
+        $processor = new Enhanced_ICF_Form_Processor( new Logging() );
+        $data = [
+            '_wpnonce'   => 'valid',
+            'eforms_hp'  => '',
+            'timestamp'  => time() - 10,
+            'js_ok'      => '1',
+            'form_id'    => $template,
+            'instance_id'=> 'i_test',
+            $template    => [ 'name' => 'John' ],
+        ];
+
+        $result = $processor->process_form_submission( $template, $data );
+
+        $this->assertFalse( $result['success'] );
+        $this->assertSame( TemplateValidator::ERR_ENUM, $result['message'] );
+
+        unlink( $path );
+    }
+}

--- a/tests/TemplateValidatorTest.php
+++ b/tests/TemplateValidatorTest.php
@@ -1,0 +1,44 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class TemplateValidatorTest extends TestCase {
+    public function test_unknown_key_triggers_error() {
+        $validator = new TemplateValidator();
+        $config = [ 'fields' => [ [ 'key' => 'name', 'type' => 'text', 'bogus' => true ] ] ];
+        $result = $validator->validate( $config );
+        $this->assertFalse( $result['valid'] );
+        $this->assertSame( TemplateValidator::ERR_UNKNOWN_KEY, $result['code'] );
+    }
+
+    public function test_invalid_enum_triggers_error() {
+        $validator = new TemplateValidator();
+        $config = [ 'fields' => [ [ 'key' => 'name', 'type' => 'bogus' ] ] ];
+        $result = $validator->validate( $config );
+        $this->assertFalse( $result['valid'] );
+        $this->assertSame( TemplateValidator::ERR_ENUM, $result['code'] );
+    }
+
+    public function test_required_combo_triggers_error() {
+        $validator = new TemplateValidator();
+        $config = [ 'fields' => [ [ 'type' => 'row_group', 'mode' => 'start' ] ] ];
+        $result = $validator->validate( $config );
+        $this->assertFalse( $result['valid'] );
+        $this->assertSame( TemplateValidator::ERR_REQUIRED_COMBO, $result['code'] );
+    }
+
+    public function test_row_group_shape_triggers_error() {
+        $validator = new TemplateValidator();
+        $config = [ 'fields' => [ [ 'type' => 'row_group', 'mode' => 'start', 'tag' => 'div' ] ] ];
+        $result = $validator->validate( $config );
+        $this->assertFalse( $result['valid'] );
+        $this->assertSame( TemplateValidator::ERR_ROW_GROUP_SHAPE, $result['code'] );
+    }
+
+    public function test_accept_intersection_triggers_error() {
+        $validator = new TemplateValidator();
+        $config = [ 'fields' => [ [ 'key' => 'upload', 'type' => 'file', 'accept' => [ 'evil/type' ] ] ] ];
+        $result = $validator->validate( $config );
+        $this->assertFalse( $result['valid'] );
+        $this->assertSame( TemplateValidator::ERR_ACCEPT_INTERSECTION, $result['code'] );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -209,6 +209,7 @@ require_once __DIR__.'/../src/Renderer.php';
 require_once __DIR__.'/../src/FormManager.php';
 require_once __DIR__.'/../src/Normalizer.php';
 require_once __DIR__.'/../src/Validator.php';
+require_once __DIR__.'/../src/TemplateValidator.php';
 require_once __DIR__.'/../src/Emailer.php';
 require_once __DIR__.'/../src/Security.php';
 require_once __DIR__.'/../src/class-enhanced-icf-processor.php';


### PR DESCRIPTION
## Summary
- add TemplateValidator with schema checks for field definitions
- validate template configuration during form submission
- cover template validation with new unit tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a27a583b08832d90ebe899e81e1943