### PR TITLE
Add accessible error summary to forms

### DIFF
--- a/assets/forms.js
+++ b/assets/forms.js
@@ -2,9 +2,47 @@ document.addEventListener('DOMContentLoaded', function () {
     document.querySelectorAll('form input[name="js_ok"]').forEach(function (jsField) {
         let form = jsField.form;
         jsField.value = '1';
-        let invalid = form.querySelector('[aria-invalid="true"]');
-        if (invalid) {
-            invalid.focus();
+        let invalids = Array.from(form.querySelectorAll('[aria-invalid="true"]'));
+        if (invalids.length) {
+            let summary = form.querySelector('.form-errors');
+            if (summary) {
+                summary.querySelectorAll('li').forEach(function (li) {
+                    li.style.display = 'none';
+                });
+                let handled = new Set();
+                invalids.forEach(function (field) {
+                    let target = field.closest('fieldset') || field;
+                    let id = target.id;
+                    if (!id || handled.has(id)) {
+                        return;
+                    }
+                    handled.add(id);
+                    let anchor = summary.querySelector('a[href="#' + id + '"]');
+                    if (anchor) {
+                        let error = form.querySelector('#' + field.getAttribute('aria-describedby'));
+                        let label = target.tagName.toLowerCase() === 'fieldset'
+                            ? target.querySelector('legend')
+                            : form.querySelector('label[for="' + id + '"]');
+                        let text = '';
+                        if (label) {
+                            text += label.textContent.trim();
+                        }
+                        if (error) {
+                            text += (text ? ': ' : '') + error.textContent.trim();
+                        }
+                        anchor.textContent = text;
+                        anchor.parentElement.style.display = '';
+                    }
+                });
+                summary.setAttribute('tabindex', '-1');
+                summary.removeAttribute('hidden');
+                summary.focus();
+                setTimeout(function () {
+                    invalids[0].focus();
+                }, 0);
+            } else if (invalids[0]) {
+                invalids[0].focus();
+            }
         }
         form.addEventListener('submit', function () {
             jsField.value = '1';

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -34,9 +34,18 @@ class Renderer {
 
     public function render( FormData $form, string $template, array $config ) {
         echo '<div id="contact_form" class="contact_form">';
-        echo '<div aria-live="polite" class="form-errors" role="alert"></div>';
         echo '<form class="main_contact_form" id="main_contact_form" aria-label="Contact Form" method="post" action="">';
         list( $form_id, $instance_id ) = Enhanced_Internal_Contact_Form::render_hidden_fields( $template );
+        echo '<div aria-live="polite" class="form-errors" role="alert" tabindex="-1" hidden><ul>';
+        foreach ( $config['fields'] ?? [] as $summary_field ) {
+            if ( ! isset( $summary_field['key'] ) ) {
+                continue;
+            }
+            $summary_key = sanitize_key( $summary_field['key'] );
+            $summary_id  = $form_id . '-' . $summary_key . '-' . $instance_id;
+            echo '<li><a href="#' . esc_attr( $summary_id ) . '"></a></li>';
+        }
+        echo '</ul></div>';
 
         $this->row_stack = [];
         foreach ( $config['fields'] ?? [] as $field ) {
@@ -94,7 +103,7 @@ class Renderer {
             $required_marker = ! empty( $field['required'] ) ? '<span class="required">*</span>' : '';
 
             if ( in_array( $field['type'] ?? '', ['radio','checkbox'], true ) && ! empty( $field['choices'] ) ) {
-                echo '<fieldset>';
+                echo '<fieldset id="' . esc_attr( $input_id ) . '">';
                 echo '<legend>' . esc_html( $label ) . $required_marker . '</legend>';
                 $choices = $field['choices'];
                 $values  = $form->form_data[ $field_key ] ?? ( ( $field['type'] ?? '' ) === 'checkbox' ? [] : '' );

--- a/tests/RendererAccessibilityTest.php
+++ b/tests/RendererAccessibilityTest.php
@@ -50,5 +50,44 @@ class RendererAccessibilityTest extends TestCase {
         $this->assertNotNull( $valid_label );
         $this->assertSame( 'Email', trim( $valid_label->textContent ) );
         $this->assertNull( $xpath->query('.//span[@class="required"]', $valid_label)->item(0) );
+
+        $summary_anchor_invalid = $xpath->query('//div[contains(@class,"form-errors")]//a[@href="#' . $id . '"]')->item(0);
+        $this->assertNotNull( $summary_anchor_invalid );
+        $summary_anchor_valid = $xpath->query('//div[contains(@class,"form-errors")]//a[@href="#' . $valid_id . '"]')->item(0);
+        $this->assertNotNull( $summary_anchor_valid );
+    }
+
+    public function test_fieldset_has_id_and_summary_anchor() {
+        $form = new FormData();
+        $form->form_data = [];
+        $form->field_errors = [ 'color' => 'Required' ];
+
+        $config = [
+            'fields' => [
+                [
+                    'key'     => 'color',
+                    'type'    => 'radio',
+                    'required'=> true,
+                    'choices' => [ 'red', 'blue' ],
+                ],
+            ],
+        ];
+
+        $renderer = new Renderer();
+        ob_start();
+        $renderer->render( $form, 'default', $config );
+        $output = ob_get_clean();
+
+        $dom = new DOMDocument();
+        @$dom->loadHTML('<!DOCTYPE html><html><body>' . $output . '</body></html>');
+        $xpath = new DOMXPath( $dom );
+
+        $fieldset = $xpath->query('//fieldset')->item(0);
+        $this->assertNotNull( $fieldset );
+        $fieldset_id = $fieldset->getAttribute('id');
+        $this->assertNotEmpty( $fieldset_id );
+
+        $summary_anchor = $xpath->query('//div[contains(@class,"form-errors")]//a[@href="#' . $fieldset_id . '"]')->item(0);
+        $this->assertNotNull( $summary_anchor );
     }
 }


### PR DESCRIPTION
## Summary
- Render hidden error-summary container with anchors to each field/fieldset
- Populate and focus error summary after failed submissions, then move focus to first invalid control
- Test field and group anchors in summary

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a287627a5c832dbc88f50a0ca2f63d