### PR TITLE
Implement advanced security checks and signal logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,18 @@ Forms include several security checks to deter automated submissions.
 Administrators may tailor these checks globally by defining constants or per
 template via JSON configuration.
 
-* `EFORM_MAX_FORM_AGE` &mdash; Maximum age in seconds for a form submission.
-  Submissions older than this value are rejected. Defaults to 24 hours.
+* `EFORMS_MIN_FILL_TIME` &mdash; Minimum seconds between page render and
+  submission. Defaults to 5 seconds.
+* `EFORMS_MAX_FILL_TIME` &mdash; Maximum seconds between page render and
+  submission. Defaults to 24 hours.
+* `EFORMS_NONCE_LIFETIME` &mdash; Lifetime in seconds for form nonces.
+  Defaults to 24 hours.
+* `EFORMS_MAX_POST_BYTES` &mdash; Maximum allowed POST body size. Requests
+  exceeding this limit are rejected.
+* `EFORMS_REFERRER_POLICY` &mdash; Referrer enforcement mode: `off`, `soft`,
+  `soft_path`, or `hard`.
+* `EFORMS_SOFT_FAIL_THRESHOLD` &mdash; Number of soft-fail points before the
+  request is flagged.
 * `EFORM_JS_CHECK` or template option `js_check` &mdash; Accepts `hard` (default)
   or `soft` to control whether the JavaScript verification field is required.
   In `soft` mode the form proceeds even if the `enhanced_js_check` field is

--- a/src/Security.php
+++ b/src/Security.php
@@ -7,7 +7,7 @@ class Security {
     private int $soft_threshold;
 
     public function __construct(?int $soft_threshold = null) {
-        $this->soft_threshold = $soft_threshold ?? ( defined('EFORMS_SECURITY_SOFT_FAIL_THRESHOLD') ? (int) EFORMS_SECURITY_SOFT_FAIL_THRESHOLD : 3 );
+        $this->soft_threshold = $soft_threshold ?? ( defined('EFORMS_SOFT_FAIL_THRESHOLD') ? (int) EFORMS_SOFT_FAIL_THRESHOLD : 3 );
     }
 
     private function record_signal(string $key, $value, int $increment = 0): void {
@@ -27,47 +27,49 @@ class Security {
         $form_id     = Helpers::get_first_value( $submitted_data['form_id'] ?? '' );
         $instance_id = Helpers::get_first_value( $submitted_data['instance_id'] ?? '' );
         $action      = "eforms_form_{$form_id}:{$instance_id}";
-        if ( empty( $nonce ) || empty( $form_id ) || empty( $instance_id ) || ! wp_verify_nonce( $nonce, $action ) ) {
-            $this->record_signal('nonce', 'fail');
-            return $this->build_error('Nonce Failed', 'Invalid submission detected.');
+        $ttl         = defined( 'EFORMS_NONCE_LIFETIME' ) ? (int) EFORMS_NONCE_LIFETIME : 86400;
+        if ( empty( $nonce ) || empty( $form_id ) || empty( $instance_id ) || ! wp_verify_nonce( $nonce, $action, $ttl ) ) {
+            $this->record_signal( 'nonce_ok', false );
+            return $this->build_error( 'Nonce Failed', 'Invalid submission detected.' );
         }
-        $this->record_signal('nonce', 'pass');
+        $this->record_signal( 'nonce_ok', true );
         return [];
     }
 
     public function check_honeypot(array $submitted_data): array {
         $honeypot_field = $submitted_data['eforms_hp'] ?? '';
         if ( is_array( $honeypot_field ) ) {
-            $this->record_signal('honeypot', 'fail');
-            return $this->build_error('Bot Alert: Honeypot Filled', 'Bot test failed.');
+            $this->record_signal( 'honeypot_empty', false );
+            return $this->build_error( 'Bot Alert: Honeypot Filled', 'Bot test failed.' );
         }
         $honeypot = Helpers::get_first_value( $honeypot_field );
         if ( ! empty( $honeypot ) ) {
-            $this->record_signal('honeypot', 'fail');
-            return $this->build_error('Bot Alert: Honeypot Filled', 'Bot test failed.');
+            $this->record_signal( 'honeypot_empty', false );
+            return $this->build_error( 'Bot Alert: Honeypot Filled', 'Bot test failed.' );
         }
-        $this->record_signal('honeypot', 'pass');
+        $this->record_signal( 'honeypot_empty', true );
         return [];
     }
 
     public function check_submission_time(array $submitted_data): array {
         $submit_time_field = $submitted_data['timestamp'] ?? 0;
         if ( is_array( $submit_time_field ) ) {
-            $this->record_signal('submission_time', 'array');
+            $this->record_signal( 'fill_time_ok', false );
             return $this->build_error('Bot Alert: Fast Submission', 'Submission too fast. Please try again.');
         }
         $submit_time  = intval( Helpers::get_first_value( $submit_time_field ) );
         $current_time = time();
-        if ( $current_time - $submit_time < 5 ) {
-            $this->record_signal('submission_time', 'fast');
+        $min_time     = defined( 'EFORMS_MIN_FILL_TIME' ) ? (int) EFORMS_MIN_FILL_TIME : 5;
+        if ( $current_time - $submit_time < $min_time ) {
+            $this->record_signal( 'fill_time_ok', false );
             return $this->build_error('Bot Alert: Fast Submission', 'Submission too fast. Please try again.');
         }
-        $max_age = defined( 'EFORM_MAX_FORM_AGE' ) ? (int) EFORM_MAX_FORM_AGE : 86400;
-        if ( $current_time - $submit_time > $max_age ) {
-            $this->record_signal('submission_time', 'expired');
+        $max_time = defined( 'EFORMS_MAX_FILL_TIME' ) ? (int) EFORMS_MAX_FILL_TIME : 86400;
+        if ( $current_time - $submit_time > $max_time ) {
+            $this->record_signal( 'fill_time_ok', false );
             return $this->build_error('Form Expired', 'Form has expired. Please refresh and try again.');
         }
-        $this->record_signal('submission_time', 'pass');
+        $this->record_signal( 'fill_time_ok', true );
         return [];
     }
 
@@ -75,17 +77,17 @@ class Security {
         $js_check = Helpers::get_first_value( $submitted_data['js_ok'] ?? '' );
         if ( 'soft' === $mode ) {
             if ( empty( $js_check ) || $js_check !== '1' ) {
-                $this->record_signal('js', 'missing', 1);
+                $this->record_signal( 'js_ok', false, 1 );
             } else {
-                $this->record_signal('js', 'pass');
+                $this->record_signal( 'js_ok', true );
             }
             return [];
         }
         if ( empty( $js_check ) || $js_check !== '1' ) {
-            $this->record_signal('js', 'fail');
+            $this->record_signal( 'js_ok', false );
             return $this->build_error('Bot Alert: JS Check Missing', 'JavaScript must be enabled.');
         }
-        $this->record_signal('js', 'pass');
+        $this->record_signal( 'js_ok', true );
         return [];
     }
 
@@ -99,28 +101,72 @@ class Security {
         return substr( $ref, 0, 2000 );
     }
 
-    public function get_signals(?array $server = null, ?string $policy = null): array {
-        $server = $server ?? $_SERVER;
-        $ua = $this->normalize_user_agent( $server['HTTP_USER_AGENT'] ?? '' );
-        $this->signals['user_agent'] = $ua;
-        if ( '' === $ua ) {
-            $this->record_signal('ua_status', 'missing', 1);
+    public function check_post_size( ?array $server = null ): array {
+        $server    = $server ?? $_SERVER;
+        $max_bytes = defined( 'EFORMS_MAX_POST_BYTES' ) ? (int) EFORMS_MAX_POST_BYTES : PHP_INT_MAX;
+        $size      = isset( $server['CONTENT_LENGTH'] ) ? (int) $server['CONTENT_LENGTH'] : 0;
+        if ( $size > $max_bytes ) {
+            $this->record_signal( 'post_size_ok', false, 1 );
+            return $this->build_error( 'POST Size Exceeded', 'Submission too large.' );
         }
+        $this->record_signal( 'post_size_ok', true );
+        return [];
+    }
 
-        $referrer = $this->normalize_referrer( $server['HTTP_REFERER'] ?? '' );
-        $this->signals['referrer'] = $referrer;
+    public function check_referrer( ?array $server = null, ?string $policy = null ): array {
+        $server = $server ?? $_SERVER;
+        $ref    = $this->normalize_referrer( $server['HTTP_REFERER'] ?? '' );
+        $this->signals['referrer'] = $ref;
 
-        $policy = $policy !== null ? sanitize_key( $policy ) : ( defined('EFORMS_SECURITY_REFERRER_POLICY') ? sanitize_key( EFORMS_SECURITY_REFERRER_POLICY ) : 'none' );
+        $policy = $policy !== null ? sanitize_key( $policy ) : ( defined( 'EFORMS_REFERRER_POLICY' ) ? sanitize_key( EFORMS_REFERRER_POLICY ) : 'off' );
         $this->signals['referrer_policy'] = $policy;
 
-        if ( 'require' === $policy && '' === $referrer ) {
-            $this->record_signal('referrer_status', 'missing', 1);
-        } elseif ( 'sameorigin' === $policy ) {
-            $host = isset( $server['HTTP_HOST'] ) ? strtolower( $server['HTTP_HOST'] ) : '';
-            $ref_host = $referrer ? strtolower( parse_url( $referrer, PHP_URL_HOST ) ?? '' ) : '';
-            if ( $host !== $ref_host ) {
-                $this->record_signal('referrer_status', 'mismatch', 1);
-            }
+        if ( 'off' === $policy ) {
+            $this->record_signal( 'referrer_ok', true );
+            return [];
+        }
+
+        $host     = isset( $server['HTTP_HOST'] ) ? strtolower( $server['HTTP_HOST'] ) : '';
+        $ref_host = $ref ? strtolower( parse_url( $ref, PHP_URL_HOST ) ?? '' ) : '';
+        $ref_path = $ref ? ( parse_url( $ref, PHP_URL_PATH ) ?? '' ) : '';
+        $req_path = isset( $server['REQUEST_URI'] ) ? ( parse_url( $server['REQUEST_URI'], PHP_URL_PATH ) ?? '' ) : '';
+
+        $same_host = ( '' !== $ref && $host === $ref_host );
+        $same_path = ( $same_host && $ref_path === $req_path );
+
+        if ( 'soft' === $policy ) {
+            $ok = '' !== $ref;
+            $this->record_signal( 'referrer_ok', $ok, $ok ? 0 : 1 );
+            return [];
+        }
+
+        if ( 'soft_path' === $policy ) {
+            $ok = $same_path;
+            $this->record_signal( 'referrer_ok', $ok, $ok ? 0 : 1 );
+            return [];
+        }
+
+        // hard
+        $ok = $same_path;
+        $this->record_signal( 'referrer_ok', $ok, $ok ? 0 : 1 );
+        if ( ! $ok ) {
+            return $this->build_error( 'Referrer Check Failed', 'Invalid submission detected.' );
+        }
+        return [];
+    }
+
+    public function get_signals( ?array $server = null ): array {
+        $server = $server ?? $_SERVER;
+        $ua     = $this->normalize_user_agent( $server['HTTP_USER_AGENT'] ?? '' );
+        $this->signals['user_agent'] = $ua;
+        if ( '' === $ua ) {
+            $this->record_signal( 'ua_missing', true, 1 );
+        } else {
+            $this->record_signal( 'ua_missing', false );
+        }
+
+        if ( ! isset( $this->signals['referrer'] ) ) {
+            $this->signals['referrer'] = $this->normalize_referrer( $server['HTTP_REFERER'] ?? '' );
         }
 
         return [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,7 +17,8 @@ function sanitize_email($email){
 function sanitize_textarea_field($str){
     return strip_tags($str);
 }
-function wp_verify_nonce($nonce,$action){
+function wp_verify_nonce($nonce,$action,$ttl=86400){
+    $GLOBALS['_last_nonce_ttl'] = $ttl;
     return $nonce === 'valid';
 }
 function wp_strip_all_tags($str){


### PR DESCRIPTION
## Summary
- rename security constants and add configurable nonce lifetime, fill times, post size cap and referrer policies
- record detailed security signals and include them in logs
- document new security options and expand test coverage

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a288cffd14832d99cedcb461ebb528