### PR TITLE
Implement tokenized emails, attachments and HTML toggle

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -86,8 +86,8 @@ function home_url($path = ''){
 function apply_filters($tag,$value){
     return $value;
 }
-function wp_mail($to,$subject,$message,$headers){
-    $GLOBALS['_last_mail'] = compact('to','subject','message','headers');
+function wp_mail($to,$subject,$message,$headers,$attachments = []){
+    $GLOBALS['_last_mail'] = compact('to','subject','message','headers','attachments');
     return true;
 }
 function eform_get_safe_fields($data){
@@ -216,3 +216,4 @@ require_once __DIR__.'/../src/Security.php';
 require_once __DIR__.'/../src/class-enhanced-icf-processor.php';
 require_once __DIR__.'/../src/class-enhanced-icf.php';
 require_once __DIR__.'/../src/TemplateCache.php';
+require_once __DIR__.'/../src/Uploads.php';


### PR DESCRIPTION
## Summary
- derive no-reply `From:` domain from `home_url()`
- add token rendering for fields and `submitted_at`
- support optional HTML emails and attachment limits

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a29151e2c4832db0db8e1a70a4f182