### PR TITLE
Harden template loading

### DIFF
--- a/src/TemplateCache.php
+++ b/src/TemplateCache.php
@@ -12,8 +12,13 @@
 function eform_get_template_config( string $template ): array {
     static $cache = [];
 
+    $file = $template . '.json';
+    if ( ! preg_match( '/^[a-z0-9-]+\.json$/', $file ) ) {
+        return [];
+    }
+
     $plugin_dir = rtrim( plugin_dir_path( __DIR__ ), '/\\' ) . '/templates';
-    $path       = $plugin_dir . '/' . $template . '.json';
+    $path       = $plugin_dir . '/' . $file;
 
     $version  = eform_config_version_token( [ $path ] );
     $cache_key = $template;
@@ -76,6 +81,10 @@ function eform_config_version_token( array $paths ): string {
  */
 function eform_load_config_from_paths( array $paths ): array {
     foreach ( $paths as $path ) {
+        $file = basename( $path );
+        if ( ! preg_match( '/^[a-z0-9-]+\.json$/', $file ) ) {
+            continue;
+        }
         if ( file_exists( $path ) && is_readable( $path ) ) {
             if ( 'json' === pathinfo( $path, PATHINFO_EXTENSION ) ) {
                 $content = file_get_contents( $path );

--- a/src/Uploads.php
+++ b/src/Uploads.php
@@ -95,7 +95,7 @@ class Uploads {
      * @param Logging $logger   Optional logger instance.
      * @return array|null Metadata about stored file or null on failure.
      */
-    public static function store_uploaded_file( array $item, string $field, array $accept = [], Logging $logger = null ) {
+    public static function store_uploaded_file( array $item, string $field, array $accept = [], ?Logging $logger = null ) {
         if ( ( $item['error'] ?? UPLOAD_ERR_NO_FILE ) !== UPLOAD_ERR_OK || (int) $item['size'] <= 0 ) {
             return null;
         }

--- a/templates/.htaccess
+++ b/templates/.htaccess
@@ -1,0 +1,1 @@
+Require all denied

--- a/templates/web.config
+++ b/templates/web.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer>
+        <authorization>
+            <add accessType="Deny" users="*" />
+        </authorization>
+    </system.webServer>
+</configuration>

--- a/tests/EnhancedICFFormProcessorTest.php
+++ b/tests/EnhancedICFFormProcessorTest.php
@@ -221,7 +221,7 @@ class EnhancedICFFormProcessorTest extends TestCase {
     }
 
     public function test_template_without_phone_field() {
-        $template = 'no_phone';
+        $template = 'no-phone';
         $config   = [
             'id'      => $template,
             'version' => 1,
@@ -238,15 +238,15 @@ class EnhancedICFFormProcessorTest extends TestCase {
         $path = __DIR__ . '/../templates/' . $template . '.json';
         file_put_contents( $path, json_encode( $config ) );
 
-        $data   = $this->build_submission('no_phone');
-        $result = $this->processor->process_form_submission('no_phone', $data);
+        $data   = $this->build_submission('no-phone');
+        $result = $this->processor->process_form_submission('no-phone', $data);
         $this->assertSame('inline', $result['success']['mode']);
 
         unlink( $path );
     }
 
     public function test_required_phone_missing() {
-        $template = 'phone_only';
+        $template = 'phone-only';
         $config   = [
             'id'      => $template,
             'version' => 1,
@@ -262,8 +262,8 @@ class EnhancedICFFormProcessorTest extends TestCase {
         $path = __DIR__ . '/../templates/' . $template . '.json';
         file_put_contents( $path, json_encode( $config ) );
 
-        $data   = $this->build_submission('phone_only', overrides: ['phone' => '']);
-        $result = $this->processor->process_form_submission('phone_only', $data);
+        $data   = $this->build_submission('phone-only', overrides: ['phone' => '']);
+        $result = $this->processor->process_form_submission('phone-only', $data);
         $this->assertFalse($result['success']);
         $this->assertSame('Please correct the highlighted fields', $result['message']);
         $this->assertSame(['phone' => 'Phone is required.'], $result['errors']);

--- a/tests/TemplateCacheFieldHandlingTest.php
+++ b/tests/TemplateCacheFieldHandlingTest.php
@@ -10,7 +10,7 @@ class TemplateCacheFieldHandlingTest extends TestCase {
     }
 
     public function test_multivalue_fields_and_reserved_keys(): void {
-        $template = 'field_handling';
+        $template = 'field-handling';
         $path     = $this->templatesDir . '/' . $template . '.json';
         $config   = [
             'id'      => $template,

--- a/tests/TemplateConfigTest.php
+++ b/tests/TemplateConfigTest.php
@@ -26,6 +26,11 @@ class TemplateConfigTest extends TestCase {
         $this->assertSame( [], eform_get_template_config( 'missing' ) );
     }
 
+    public function test_invalid_template_slug_rejected(): void {
+        $this->assertSame( [], eform_get_template_config( '../secret' ) );
+        $this->assertSame( [], eform_get_template_config( 'Default' ) );
+    }
+
     public function test_cache_can_be_purged(): void {
         $template = 'temp';
         $path     = $this->pluginTemplatesDir . "/$template.json";

--- a/tests/TemplateValidatorPipelineTest.php
+++ b/tests/TemplateValidatorPipelineTest.php
@@ -9,7 +9,7 @@ class TemplateValidatorPipelineTest extends TestCase {
     }
 
     public function test_invalid_template_triggers_error_code() {
-        $template = 'invalid_schema';
+        $template = 'invalid-schema';
         $path     = $this->templatesDir . '/' . $template . '.json';
         $config   = [
             'id'      => $template,


### PR DESCRIPTION
## Summary
- block direct web access to shipped templates via `.htaccess` and `web.config`
- validate template filenames against `/^[a-z0-9-]+\.json$/` before reading
- cover invalid template names in tests

## Testing
- `composer install`
- `./vendor/bin/phpunit --display-deprecations`

------
https://chatgpt.com/codex/tasks/task_e_68a294bec82c832daad0342c7f7d2524