### PR TITLE
Add virtual quote form template with new fields

### DIFF
--- a/includes/field-registry.php
+++ b/includes/field-registry.php
@@ -38,6 +38,54 @@ class FieldRegistry {
             'sanitize_cb'  => 'sanitize_textarea_field',
             'validate_cb'  => [self::class, 'validate_message'],
         ],
+        'first_name' => [
+            'post_key'     => 'first_name_input',
+            'required'     => false,
+            'sanitize_cb'  => 'sanitize_text_field',
+            'validate_cb'  => [self::class, 'validate_name'],
+        ],
+        'last_name' => [
+            'post_key'     => 'last_name_input',
+            'required'     => false,
+            'sanitize_cb'  => 'sanitize_text_field',
+            'validate_cb'  => [self::class, 'validate_name'],
+        ],
+        'street_address' => [
+            'post_key'     => 'street_address_input',
+            'required'     => false,
+            'sanitize_cb'  => 'sanitize_text_field',
+            'validate_cb'  => [self::class, 'validate_text'],
+        ],
+        'city' => [
+            'post_key'     => 'city_input',
+            'required'     => false,
+            'sanitize_cb'  => 'sanitize_text_field',
+            'validate_cb'  => [self::class, 'validate_text'],
+        ],
+        'state' => [
+            'post_key'     => 'state_input',
+            'required'     => false,
+            'sanitize_cb'  => 'sanitize_text_field',
+            'validate_cb'  => [self::class, 'validate_state'],
+        ],
+        'floor_size' => [
+            'post_key'     => 'floor_size_input',
+            'required'     => false,
+            'sanitize_cb'  => [self::class, 'sanitize_digits'],
+            'validate_cb'  => [self::class, 'validate_positive_number'],
+        ],
+        'steps' => [
+            'post_key'     => 'steps_input',
+            'required'     => false,
+            'sanitize_cb'  => 'sanitize_text_field',
+            'validate_cb'  => [self::class, 'validate_yes_no'],
+        ],
+        'railings' => [
+            'post_key'     => 'railings_input',
+            'required'     => false,
+            'sanitize_cb'  => 'sanitize_text_field',
+            'validate_cb'  => [self::class, 'validate_yes_no'],
+        ],
     ];
 
     /**
@@ -103,6 +151,9 @@ class FieldRegistry {
     }
 
     public static function validate_name(string $value, array $field): string {
+        if ($value === '' && empty($field['required'])) {
+            return '';
+        }
         if (strlen($value) < 3) {
             return 'Name too short.';
         }
@@ -140,6 +191,43 @@ class FieldRegistry {
         $plain = wp_strip_all_tags($value);
         if (strlen($plain) < 20) {
             return 'Message too short.';
+        }
+        return '';
+    }
+
+    public static function validate_text(string $value, array $field): string {
+        if ($field['required'] && trim($value) === '') {
+            return 'Field is required.';
+        }
+        return '';
+    }
+
+    public static function validate_state(string $value, array $field): string {
+        if ($field['required'] && trim($value) === '') {
+            return 'Field is required.';
+        }
+        if ($value !== '' && strtoupper($value) !== 'CO') {
+            return 'Invalid state.';
+        }
+        return '';
+    }
+
+    public static function validate_positive_number(string $value, array $field): string {
+        if ($field['required'] && $value === '') {
+            return 'Field is required.';
+        }
+        if ($value !== '' && !preg_match('/^\\d+$/', $value)) {
+            return 'Invalid number.';
+        }
+        return '';
+    }
+
+    public static function validate_yes_no(string $value, array $field): string {
+        if ($field['required'] && $value === '') {
+            return 'Field is required.';
+        }
+        if ($value !== '' && !in_array($value, ['yes','no'], true)) {
+            return 'Invalid value.';
         }
         return '';
     }

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -73,6 +73,30 @@ if ( ! function_exists( 'eform_field' ) ) {
                 'placeholder' => 'Please describe your project and let us know if there is any urgency',
                 'is_textarea' => true,
             ],
+            'first_name' => [
+                'template'    => '<input class="form_field" type="text" name="first_name_input" autocomplete="given-name"%1$s aria-label="First Name" placeholder="%2$s" value="%3$s">',
+                'placeholder' => 'First Name',
+            ],
+            'last_name' => [
+                'template'    => '<input class="form_field" type="text" name="last_name_input" autocomplete="family-name"%1$s aria-label="Last Name" placeholder="%2$s" value="%3$s">',
+                'placeholder' => 'Last Name',
+            ],
+            'street_address' => [
+                'template'    => '<input class="form_field" type="text" name="street_address_input" autocomplete="street-address"%1$s aria-label="Street Address" placeholder="%2$s" value="%3$s">',
+                'placeholder' => 'Street Address',
+            ],
+            'city' => [
+                'template'    => '<input class="form_field" type="text" name="city_input" autocomplete="address-level2"%1$s aria-label="City" placeholder="%2$s" value="%3$s">',
+                'placeholder' => 'City',
+            ],
+            'state' => [
+                'template'    => '<input class="form_field" type="text" name="state_input" autocomplete="address-level1" value="CO" readonly%1$s aria-label="State">',
+                'placeholder' => 'State',
+            ],
+            'floor_size' => [
+                'template'    => '<input class="form_field" type="number" name="floor_size_input"%1$s aria-label="Existing Hardwood Floor size (sqft)" placeholder="%2$s" value="%3$s">',
+                'placeholder' => 'Existing Hardwood Floor size (sqft)',
+            ],
         ];
 
         if ( ! isset( $field_map[ $field ] ) ) {

--- a/templates/form-virtual-quote.php
+++ b/templates/form-virtual-quote.php
@@ -1,0 +1,62 @@
+<?php
+// templates/form-virtual-quote.php
+global $eform_registry, $eform_form, $eform_current_template;
+?>
+<div id="contact_form" class="contact_form">
+    <form class="virtual_quote_form" id="virtual_quote_form" aria-label="Virtual Quote Form" method="post" action="">
+        <?php Enhanced_Internal_Contact_Form::render_hidden_fields('virtual-quote'); ?>
+        <div class="inputwrap">
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'first_name', [ 'required' => true ] ); ?>
+            <?php eform_field_error( $eform_form, 'first_name' ); ?>
+        </div>
+        <div class="inputwrap">
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'last_name', [ 'required' => true ] ); ?>
+            <?php eform_field_error( $eform_form, 'last_name' ); ?>
+        </div>
+        <div class="inputwrap">
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'email', [ 'required' => true ] ); ?>
+            <?php eform_field_error( $eform_form, 'email' ); ?>
+        </div>
+        <div class="inputwrap">
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'phone', [ 'required' => true ] ); ?>
+            <?php eform_field_error( $eform_form, 'phone' ); ?>
+        </div>
+        <div class="inputwrap">
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'street_address', [ 'required' => true ] ); ?>
+            <?php eform_field_error( $eform_form, 'street_address' ); ?>
+        </div>
+        <div class="inputwrap">
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'city', [ 'required' => true ] ); ?>
+            <?php eform_field_error( $eform_form, 'city' ); ?>
+        </div>
+        <div class="inputwrap">
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'state', [ 'required' => true ] ); ?>
+            <?php eform_field_error( $eform_form, 'state' ); ?>
+        </div>
+        <div class="inputwrap">
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'zip', [ 'required' => true ] ); ?>
+            <?php eform_field_error( $eform_form, 'zip' ); ?>
+        </div>
+        <div class="inputwrap">
+            <?php eform_field( $eform_registry, $eform_form, $eform_current_template, 'floor_size', [ 'required' => true ] ); ?>
+            <?php eform_field_error( $eform_form, 'floor_size' ); ?>
+        </div>
+        <?php $eform_registry->register_field( $eform_current_template, 'steps', [ 'required' => true ] ); ?>
+        <div class="inputwrap">
+            <span>Are there any steps?</span>
+            <label><input type="radio" name="steps_input" value="yes" <?php echo ( $eform_form->form_data['steps'] ?? '' ) === 'yes' ? 'checked' : ''; ?> required> Yes</label>
+            <label><input type="radio" name="steps_input" value="no" <?php echo ( $eform_form->form_data['steps'] ?? '' ) === 'no' ? 'checked' : ''; ?> required> No</label>
+            <?php eform_field_error( $eform_form, 'steps' ); ?>
+        </div>
+        <?php $eform_registry->register_field( $eform_current_template, 'railings', [ 'required' => true ] ); ?>
+        <div class="inputwrap">
+            <span>Are there any railings sitting directly on the floor?</span>
+            <label><input type="radio" name="railings_input" value="yes" <?php echo ( $eform_form->form_data['railings'] ?? '' ) === 'yes' ? 'checked' : ''; ?> required> Yes</label>
+            <label><input type="radio" name="railings_input" value="no" <?php echo ( $eform_form->form_data['railings'] ?? '' ) === 'no' ? 'checked' : ''; ?> required> No</label>
+            <?php eform_field_error( $eform_form, 'railings' ); ?>
+        </div>
+        <input type="hidden" name="submitted" value="1" aria-hidden="true">
+        <button type="submit" name="enhanced_form_submit_virtual-quote" aria-label="Send Request" value="Send Request">Send Request</button>
+    </form>
+</div>
+


### PR DESCRIPTION
## Summary
- add FieldRegistry entries and validation helpers for quote-specific fields
- support new fields in template tags and add virtual-quote form template

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6897e6dec1a4832d9ed0947c7cb55c47