### PR TITLE
Add Electronic Forms plugin skeleton

### DIFF
--- a/electronic_forms/assets/forms.css
+++ b/electronic_forms/assets/forms.css
@@ -1,0 +1,3 @@
+/*
+ * Electronic Forms placeholder CSS
+ */

--- a/electronic_forms/eforms.php
+++ b/electronic_forms/eforms.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Plugin Name: Electronic Forms
+ * Description: Lightweight plugin for forms.
+ * Version: 0.1.0
+ * Requires PHP: 8.0
+ * Requires at least: 5.8
+ */
+declare(strict_types=1);
+
+namespace {
+    defined('ABSPATH') || exit;
+}
+
+namespace EForms {
+    const VERSION = '0.1.0';
+}
+
+namespace {
+    use EForms\Config;
+    use EForms\FormManager;
+
+    if (version_compare(PHP_VERSION, '8.0', '<')) {
+        add_action('admin_init', function () {
+            deactivate_plugins(plugin_basename(__FILE__));
+        });
+        add_action('admin_notices', function () {
+            echo '<div class="notice notice-error"><p>' . esc_html__('Electronic Forms requires PHP 8.0 or higher.', 'eforms') . '</p></div>';
+        });
+        return;
+    }
+
+    global $wp_version;
+    if (version_compare($wp_version, '5.8', '<')) {
+        add_action('admin_init', function () {
+            deactivate_plugins(plugin_basename(__FILE__));
+        });
+        add_action('admin_notices', function () {
+            echo '<div class="notice notice-error"><p>' . esc_html__('Electronic Forms requires WordPress 5.8 or higher.', 'eforms') . '</p></div>';
+        });
+        return;
+    }
+
+    spl_autoload_register(function (string $class): void {
+        if (strpos($class, 'EForms\\') !== 0) {
+            return;
+        }
+        $path = __DIR__ . '/src/' . str_replace('\\', '/', substr($class, 7)) . '.php';
+        if (is_file($path)) {
+            require $path;
+        }
+    });
+
+    Config::bootstrap();
+
+    function eform_render(string $formId, array $opts = []): string
+    {
+        $fm = new FormManager();
+        return $fm->render($formId, $opts);
+    }
+
+    add_shortcode('eform', function ($atts) {
+        $atts = shortcode_atts([
+            'id' => '',
+            'cacheable' => 'true',
+        ], $atts, 'eform');
+        $formId = sanitize_key($atts['id']);
+        $cacheable = filter_var($atts['cacheable'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        $fm = new FormManager();
+        return $fm->render($formId, ['cacheable' => $cacheable !== false]);
+    });
+}

--- a/electronic_forms/src/Config.php
+++ b/electronic_forms/src/Config.php
@@ -1,0 +1,173 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class Config
+{
+    private static array $data = [];
+    private static bool $bootstrapped = false;
+
+    public static function bootstrap(): void
+    {
+        if (self::$bootstrapped) {
+            return;
+        }
+
+        $defaults = [
+            'security' => [
+                'token_ledger' => ['enable' => true],
+                'token_ttl_seconds' => 600,
+                'submission_token' => ['required' => true],
+                'origin_mode' => 'soft',
+                'origin_missing_soft' => false,
+                'origin_missing_hard' => false,
+                'min_fill_seconds' => 4,
+                'max_form_age_seconds' => 600,
+                'js_hard_mode' => false,
+                'max_post_bytes' => 25000000,
+                'ua_maxlen' => 256,
+                'honeypot_response' => 'stealth_success',
+                'cookie_missing_policy' => 'soft',
+            ],
+            'spam' => [
+                'soft_fail_threshold' => 2,
+            ],
+            'throttle' => [
+                'enable' => false,
+                'per_ip' => [
+                    'max_per_minute' => 5,
+                    'cooldown_seconds' => 60,
+                    'hard_multiplier' => 3.0,
+                ],
+            ],
+            'challenge' => [
+                'mode' => 'off',
+                'provider' => 'turnstile',
+                'turnstile' => ['site_key' => null, 'secret_key' => null],
+                'hcaptcha' => ['site_key' => null, 'secret_key' => null],
+                'recaptcha' => ['site_key' => null, 'secret_key' => null],
+                'http_timeout_seconds' => 2,
+            ],
+            'html5' => [
+                'client_validation' => false,
+            ],
+            'email' => [
+                'policy' => 'strict',
+                'smtp' => [
+                    'timeout_seconds' => 10,
+                    'max_retries' => 2,
+                    'retry_backoff_seconds' => 2,
+                ],
+                'html' => false,
+                'from_address' => '',
+                'from_name' => '',
+                'reply_to_field' => '',
+                'envelope_sender' => '',
+                'dkim' => [
+                    'domain' => '',
+                    'selector' => '',
+                    'private_key_path' => '',
+                    'pass_phrase' => '',
+                ],
+                'disable_send' => false,
+                'staging_redirect_to' => null,
+                'suspect_subject_tag' => '[SUSPECT]',
+                'upload_max_attachments' => 5,
+                'debug' => [
+                    'enable' => false,
+                    'max_bytes' => 8192,
+                ],
+            ],
+            'logging' => [
+                'mode' => 'minimal',
+                'level' => 0,
+                'headers' => false,
+                'pii' => false,
+                'on_failure_canonical' => false,
+                'file_max_size' => 5000000,
+                'retention_days' => 30,
+                'fail2ban' => [
+                    'enable' => false,
+                    'target' => 'error_log',
+                    'file' => null,
+                    'file_max_size' => 5000000,
+                    'retention_days' => 30,
+                ],
+            ],
+            'privacy' => [
+                'ip_mode' => 'masked',
+                'ip_salt' => '',
+                'client_ip_header' => '',
+                'trusted_proxies' => [],
+            ],
+            'assets' => [
+                'css_disable' => false,
+            ],
+            'install' => [
+                'min_php' => '8.0',
+                'min_wp' => '5.8',
+                'uninstall' => [
+                    'purge_uploads' => false,
+                    'purge_logs' => false,
+                ],
+            ],
+            'validation' => [
+                'max_fields_per_form' => 150,
+                'max_options_per_group' => 100,
+                'max_items_per_multivalue' => 50,
+                'textarea_html_max_bytes' => 32768,
+            ],
+            'uploads' => [
+                'enable' => true,
+                'dir' => self::defaultUploadsDir(),
+                'allowed_tokens' => ['image', 'pdf'],
+                'allowed_mime' => [],
+                'allowed_ext' => [],
+                'max_file_bytes' => 5000000,
+                'max_files' => 10,
+                'total_field_bytes' => 10000000,
+                'total_request_bytes' => 20000000,
+                'max_email_bytes' => 10000000,
+                'delete_after_send' => true,
+                'retention_seconds' => 86400,
+                'max_image_px' => 50000000,
+                'original_maxlen' => 100,
+                'transliterate' => true,
+                'max_relative_path_chars' => 180,
+            ],
+        ];
+
+        $config = apply_filters('eforms_config', $defaults);
+        self::$data = self::clampTypes($config);
+        self::$bootstrapped = true;
+    }
+
+    public static function get(string $path, $default = null)
+    {
+        $segments = explode('.', $path);
+        $value = self::$data;
+        foreach ($segments as $seg) {
+            if (!is_array($value) || !array_key_exists($seg, $value)) {
+                return $default;
+            }
+            $value = $value[$seg];
+        }
+        return $value;
+    }
+
+    private static function clampTypes(array $config): array
+    {
+        // TODO: implement type validation/clamping
+        return $config;
+    }
+
+    private static function defaultUploadsDir(): string
+    {
+        if (function_exists('wp_upload_dir')) {
+            $u = wp_upload_dir();
+            return rtrim($u['basedir'], '/\\') . '/eforms-private';
+        }
+        return '';
+    }
+}

--- a/electronic_forms/src/FormManager.php
+++ b/electronic_forms/src/FormManager.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class FormManager
+{
+    public function render(string $formId, array $opts = []): string
+    {
+        $formId = \sanitize_key($formId);
+        $cacheable = $opts['cacheable'] ?? true;
+        $cacheable = (bool) $cacheable;
+        $instanceId = bin2hex(random_bytes(16));
+        $timestamp = time();
+
+        $html = sprintf("<!-- eforms stage1 placeholder: form_id=%s cacheable=%s -->", \esc_html($formId), $cacheable ? 'true' : 'false');
+        $html .= '<form method="post" novalidate>';
+        $html .= sprintf('<input type="hidden" name="form_id" value="%s">', \esc_attr($formId));
+        $html .= sprintf('<input type="hidden" name="instance_id" value="%s">', \esc_attr($instanceId));
+        $html .= '<input type="hidden" name="eforms_hp" value="">';
+        $html .= sprintf('<input type="hidden" name="timestamp" value="%d">', $timestamp);
+        $html .= '<input type="hidden" name="js_ok" value="0">';
+        if (!$cacheable) {
+            $token = function_exists('wp_generate_uuid4') ? wp_generate_uuid4() : $instanceId;
+            $html .= sprintf('<input type="hidden" name="eforms_token" value="%s">', \esc_attr($token));
+        }
+        $html .= '</form>';
+        return $html;
+    }
+
+    public function enqueueAssetsIfNeeded(): void
+    {
+        // no-op for now
+    }
+}

--- a/electronic_forms/src/Helpers.php
+++ b/electronic_forms/src/Helpers.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class Helpers
+{
+    public static function esc_html(string $v): string
+    {
+        return \esc_html($v);
+    }
+
+    public static function esc_attr(string $v): string
+    {
+        return \esc_attr($v);
+    }
+
+    public static function esc_url(string $v): string
+    {
+        return \esc_url($v);
+    }
+
+    public static function esc_url_raw(string $v): string
+    {
+        return \esc_url_raw($v);
+    }
+
+    public static function sanitize_id(string $v): string
+    {
+        return \sanitize_key($v);
+    }
+
+    public static function bytes_from_ini(?string $v): int
+    {
+        // TODO: implement K/M/G suffix parsing
+        return 0;
+    }
+}

--- a/electronic_forms/uninstall.php
+++ b/electronic_forms/uninstall.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+defined('WP_UNINSTALL_PLUGIN') || exit;
+
+require __DIR__ . '/src/Config.php';
+EForms\Config::bootstrap();
+
+if (!function_exists('wp_upload_dir')) {
+    if (defined('ABSPATH')) {
+        $file = ABSPATH . 'wp-admin/includes/file.php';
+        if (is_readable($file)) {
+            require_once $file;
+        }
+    }
+}
+
+if (!function_exists('wp_upload_dir')) {
+    // WordPress functions unavailable; abort gracefully.
+    return;
+}
+
+// TODO: honor Config uninstall flags (no deletions yet).


### PR DESCRIPTION
## Summary
- bootstrap plugin with version checks, autoloader, shortcode and helper tag
- implement immutable Config snapshot with defaults and stubs
- add FormManager placeholder rendering and uninstall hardening

## Testing
- `find electronic_forms -name '*.php' -print -exec php -l {} \;`


------
https://chatgpt.com/codex/tasks/task_e_68b64f38f684832da4ae45a30c1fefe4