### PR TITLE
Add routing and asset handling for Electronic Forms plugin

### DIFF
--- a/electronic_forms/assets/forms.css
+++ b/electronic_forms/assets/forms.css
@@ -1,0 +1,1 @@
+/* Placeholder CSS for Electronic Forms */

--- a/electronic_forms/assets/forms.js
+++ b/electronic_forms/assets/forms.js
@@ -1,0 +1,11 @@
+/*!
+ * Electronic Forms basic JS
+ * - sets js_ok=1 on DOM ready
+ * - (later) handles error-summary focus and submit lock
+ */
+(function () {
+  function onReady(fn){ if (document.readyState === 'loading') { document.addEventListener('DOMContentLoaded', fn); } else { fn(); } }
+  onReady(function () {
+    document.querySelectorAll('input[name="js_ok"]').forEach(function (el) { try { el.value = '1'; } catch(_){} });
+  });
+})();

--- a/electronic_forms/src/Config.php
+++ b/electronic_forms/src/Config.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class Config
+{
+    protected static array $data = [];
+
+    public static function bootstrap(): void
+    {
+        // Placeholder bootstrap; in real plugin this would load configuration.
+        self::$data = [];
+    }
+
+    public static function get(string $key, $default = null)
+    {
+        $segments = explode('.', $key);
+        $value = self::$data;
+        foreach ($segments as $seg) {
+            if (is_array($value) && array_key_exists($seg, $value)) {
+                $value = $value[$seg];
+            } else {
+                return $default;
+            }
+        }
+        return $value;
+    }
+}

--- a/electronic_forms/src/FormManager.php
+++ b/electronic_forms/src/FormManager.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class FormManager
+{
+    public function render(string $formId, array $opts = []): string
+    {
+        $formId = \sanitize_key($formId);
+        $cacheable = $opts['cacheable'] ?? true;
+        $cacheable = (bool) $cacheable;
+        $instanceId = bin2hex(random_bytes(16));
+        $timestamp = time();
+
+        // Enqueue assets only when rendering
+        $this->enqueueAssetsIfNeeded();
+
+        $clientValidation = (bool) Config::get('html5.client_validation', false);
+
+        $html = sprintf("<!-- eforms: form_id=%s cacheable=%s -->\n", \esc_html($formId), $cacheable ? 'true' : 'false');
+        $html .= '<form method="post"' . ($clientValidation ? '' : ' novalidate') . ' action="' . \esc_url(\home_url('/eforms/submit')) . '">';
+        $html .= sprintf('<input type="hidden" name="form_id" value="%s">', \esc_attr($formId));
+        $html .= sprintf('<input type="hidden" name="instance_id" value="%s">', \esc_attr($instanceId));
+        $html .= '<input type="hidden" name="eforms_hp" value="">';
+        $html .= sprintf('<input type="hidden" name="timestamp" value="%d">', $timestamp);
+        $html .= '<input type="hidden" name="js_ok" value="0">';
+        if (!$cacheable) {
+            $token = function_exists('wp_generate_uuid4') ? wp_generate_uuid4() : $instanceId;
+            $html .= sprintf('<input type="hidden" name="eforms_token" value="%s">', \esc_attr($token));
+        }
+        if ($cacheable) {
+            // Prime cookie token via 204 pixel
+            $html .= sprintf('<img src="%s" aria-hidden="true" alt="" width="1" height="1" style="position:absolute;left:-9999px;">',
+                \esc_url(\home_url('/eforms/prime?f=' . $formId))
+            );
+        }
+        $html .= '</form>';
+        return $html;
+    }
+
+    public function enqueueAssetsIfNeeded(): void
+    {
+        // Register
+        \wp_register_style(
+            'eforms-forms',
+            \plugins_url('assets/forms.css', \EForms\PLUGIN_DIR . '/eforms.php'),
+            [],
+            @filemtime(\EForms\ASSETS_DIR . '/forms.css') ?: \EForms\VERSION
+        );
+        \wp_register_script(
+            'eforms-forms',
+            \plugins_url('assets/forms.js', \EForms\PLUGIN_DIR . '/eforms.php'),
+            [],
+            @filemtime(\EForms\ASSETS_DIR . '/forms.js') ?: \EForms\VERSION,
+            ['in_footer' => true]
+        );
+        // Enqueue
+        if (!Config::get('assets.css_disable', false)) {
+            \wp_enqueue_style('eforms-forms');
+        }
+        \wp_enqueue_script('eforms-forms');
+    }
+}

--- a/electronic_forms/src/Helpers.php
+++ b/electronic_forms/src/Helpers.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class Helpers
+{
+    public static function esc_html(string $v): string
+    {
+        return \esc_html($v);
+    }
+
+    public static function esc_attr(string $v): string
+    {
+        return \esc_attr($v);
+    }
+
+    public static function esc_url(string $v): string
+    {
+        return \esc_url($v);
+    }
+
+    public static function esc_url_raw(string $v): string
+    {
+        return \esc_url_raw($v);
+    }
+
+    public static function sanitize_id(string $v): string
+    {
+        return \sanitize_key($v);
+    }
+
+    public static function bytes_from_ini(?string $v): int
+    {
+        // "0"/null/"" -> PHP_INT_MAX (per spec)
+        if ($v === null) return PHP_INT_MAX;
+        $t = trim($v);
+        if ($t === '' || $t === '0') return PHP_INT_MAX;
+        // Accept forms like "128M", "1G", "512K", case-insensitive, with optional "B"
+        if (!preg_match('/^(\d+(?:\.\d+)?)([KMG])?B?$/i', $t, $m)) {
+            // Fallback: best-effort integer
+            $n = (int)$t;
+            return max(0, $n);
+        }
+        $num = (float)$m[1];
+        $unit = isset($m[2]) ? strtolower($m[2]) : '';
+        $mult = 1;
+        if ($unit === 'k') $mult = 1024;
+        elseif ($unit === 'm') $mult = 1024 * 1024;
+        elseif ($unit === 'g') $mult = 1024 * 1024 * 1024;
+        $bytes = (int) floor($num * $mult);
+        return max(0, $bytes);
+    }
+}

--- a/electronic_forms/templates/.htaccess
+++ b/electronic_forms/templates/.htaccess
@@ -1,0 +1,7 @@
+# Deny direct access to JSON form templates
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>

--- a/electronic_forms/templates/contact.json
+++ b/electronic_forms/templates/contact.json
@@ -1,0 +1,18 @@
+{
+  "id": "contact_us",
+  "version": "1",
+  "title": "Contact Us",
+  "success": { "mode": "inline", "message": "Thanks! We got your message." },
+  "email": {
+    "to": "admin@example.com",
+    "subject": "Contact Form",
+    "email_template": "default",
+    "include_fields": ["name","email","message"]
+  },
+  "fields": [
+    {"key":"name","type":"name","label":"Your Name","required":true,"before_html":"<h3>Hello,</h3>"},
+    {"key":"message","type":"textarea","label":"Message","required":true,"placeholder":"And continue here ..."},
+    {"key":"email","type":"email","label":"Email","autocomplete":"email","size":40,"required":true,"placeholder":"you@example.com"}
+  ],
+  "submit_button_text": "Send Your Request"
+}

--- a/electronic_forms/templates/index.html
+++ b/electronic_forms/templates/index.html
@@ -1,0 +1,1 @@
+<!doctype html><title></title>

--- a/electronic_forms/templates/quote_request.json
+++ b/electronic_forms/templates/quote_request.json
@@ -1,0 +1,23 @@
+{
+  "id": "quote_request",
+  "version": "1",
+  "title": "Quote Request",
+  "success": {"mode":"redirect","redirect_url":"/?page_id=15"},
+  "email": {
+    "to":"office@flooringartists.com",
+    "subject":"Quote Request",
+    "email_template":"default",
+    "include_fields":["name","email","tel_us","zip_us","message","ip"],
+    "display_format_tel":"xxx-xxx-xxxx"
+  },
+  "fields": [
+    {"key":"name","type":"name","label":"Your Name","required":true,"placeholder":"Your Name","autocomplete":"name"},
+    {"key":"email","type":"email","label":"Email","required":true,"placeholder":"your@email.com","autocomplete":"email"},
+    {"type":"row_group","mode":"start","tag":"div","class":"columns_nomargins"},
+    {"key":"tel_us","type":"tel_us","label":"Phone","required":true,"placeholder":"Phone","autocomplete":"tel"},
+    {"key":"zip_us","type":"zip_us","label":"Zip","required":true,"placeholder":"Project Zip Code","autocomplete":"postal-code"},
+    {"type":"row_group","mode":"end"},
+    {"key":"message","type":"textarea","label":"Message","required":true}
+  ],
+  "submit_button_text":"Send"
+}

--- a/electronic_forms/templates/web.config
+++ b/electronic_forms/templates/web.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <security>
+      <requestFiltering>
+        <hiddenSegments>
+          <add segment="." />
+        </hiddenSegments>
+      </requestFiltering>
+    </security>
+  </system.webServer>
+</configuration>

--- a/electronic_forms/uninstall.php
+++ b/electronic_forms/uninstall.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+defined('WP_UNINSTALL_PLUGIN') || exit;
+
+require __DIR__ . '/src/Config.php';
+EForms\Config::bootstrap();
+
+if (!function_exists('wp_upload_dir')) {
+    if (defined('ABSPATH')) {
+        $file = ABSPATH . 'wp-admin/includes/file.php';
+        if (is_readable($file)) {
+            require_once $file;
+        }
+    }
+}
+
+if (!function_exists('wp_upload_dir')) {
+    // WordPress functions unavailable; abort gracefully.
+    return;
+}
+
+// Honor uninstall flags
+$purgeUploads = (bool) EForms\Config::get('install.uninstall.purge_uploads', false);
+$purgeLogs    = (bool) EForms\Config::get('install.uninstall.purge_logs', false);
+$baseDir      = (string) EForms\Config::get('uploads.dir', '');
+if ($baseDir && ($purgeUploads || $purgeLogs)) {
+    // Both uploads and logs live under /eforms-private in this build.
+    $target = rtrim($baseDir, '/\\');
+    // Safety: ensure it’s inside wp_upload_dir()
+    $uploads = wp_upload_dir();
+    $root = rtrim($uploads['basedir'], '/\\');
+    if (str_starts_with($target, $root)) {
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($target, \FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $path) {
+            /** @var SplFileInfo $path */
+            if ($path->isDir()) {
+                @rmdir($path->getRealPath());
+            } else {
+                @unlink($path->getRealPath());
+            }
+        }
+        @rmdir($target);
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce plugin constants, rewrite rules, and routing for `/eforms/prime` and `/eforms/submit`
- Render forms with asset enqueuing, optional HTML5 validation, and prime-cookie pixel
- Add helper for INI-style byte parsing and uninstall cleanup options
- Include basic JS and JSON templates for sample forms

## Testing
- `for f in electronic_forms/eforms.php electronic_forms/src/FormManager.php electronic_forms/src/Helpers.php electronic_forms/src/Config.php electronic_forms/uninstall.php; do php -l $f; done`
- `node --check electronic_forms/assets/forms.js && echo 'JS OK'`
- `python3 -m json.tool electronic_forms/templates/contact.json > /dev/null && echo 'contact.json OK'`
- `python3 -m json.tool electronic_forms/templates/quote_request.json > /dev/null && echo 'quote_request.json OK'`


------
https://chatgpt.com/codex/tasks/task_e_68b65205f9c8832d9d07ad1a39f4d05e