### PR TITLE
Add prime/submit endpoints and asset loading

### DIFF
--- a/electronic_forms/assets/forms.js
+++ b/electronic_forms/assets/forms.js
@@ -1,0 +1,11 @@
+/*!
+ * Electronic Forms basic JS
+ * - sets js_ok=1 on DOM ready
+ * - (later) handles error-summary focus and submit lock
+ */
+(function () {
+  function onReady(fn){ if (document.readyState === 'loading') { document.addEventListener('DOMContentLoaded', fn); } else { fn(); } }
+  onReady(function () {
+    document.querySelectorAll('input[name="js_ok"]').forEach(function (el) { try { el.value = '1'; } catch(_){} });
+  });
+})();

--- a/electronic_forms/eforms.php
+++ b/electronic_forms/eforms.php
@@ -14,6 +14,12 @@ namespace {
 
 namespace EForms {
     const VERSION = '0.1.0';
+    // Paths/URLs for assets & templates
+    const PLUGIN_DIR = __DIR__;
+    const TEMPLATES_DIR = __DIR__ . '/templates';
+    const ASSETS_DIR = __DIR__ . '/assets';
+    \define(__NAMESPACE__ . '\\PLUGIN_URL', \plugins_url('', __FILE__));
+    \define(__NAMESPACE__ . '\\ASSETS_URL', PLUGIN_URL . '/assets');
 }
 
 namespace {
@@ -52,6 +58,79 @@ namespace {
     });
 
     Config::bootstrap();
+
+    /**
+     * Rewrite rules + query vars for /eforms/prime and /eforms/submit.
+     */
+    \register_activation_hook(__FILE__, function () {
+        add_rewrite_rule('^eforms/prime$', 'index.php?eforms_prime=1', 'top');
+        add_rewrite_rule('^eforms/submit$', 'index.php?eforms_submit=1', 'top');
+        \flush_rewrite_rules();
+    });
+    \register_deactivation_hook(__FILE__, function () {
+        \flush_rewrite_rules();
+    });
+    \add_action('init', function () {
+        add_rewrite_rule('^eforms/prime$', 'index.php?eforms_prime=1', 'top');
+        add_rewrite_rule('^eforms/submit$', 'index.php?eforms_submit=1', 'top');
+    });
+    \add_filter('query_vars', function ($vars) {
+        $vars[] = 'eforms_prime';
+        $vars[] = 'eforms_submit';
+        return $vars;
+    });
+
+    /**
+     * Router for prime/submit.
+     */
+    \add_action('template_redirect', function () {
+        $isPrime = get_query_var('eforms_prime');
+        $isSubmit = get_query_var('eforms_submit');
+        if ($isPrime) {
+            // /eforms/prime?f={form_id}
+            $formId = isset($_GET['f']) ? sanitize_key((string)$_GET['f']) : '';
+            if ($formId === '') {
+                status_header(400);
+                header('Content-Type: text/plain; charset=utf-8');
+                echo 'Missing form id.';
+                exit;
+            }
+            $ttl = (int) Config::get('security.token_ttl_seconds', 600);
+            $cookie = 'eforms_t_' . $formId;
+            $value = function_exists('wp_generate_uuid4') ? wp_generate_uuid4() : bin2hex(random_bytes(16));
+            $params = [
+                'expires'  => time() + $ttl,
+                'path'     => '/',
+                'secure'   => is_ssl(),
+                'httponly' => true,
+                'samesite' => 'Lax',
+            ];
+            setcookie($cookie, $value, $params);
+            // No-store 204
+            \nocache_headers();
+            header('Cache-Control: no-store, max-age=0');
+            status_header(204);
+            exit;
+        }
+        if ($isSubmit) {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                header('Allow: POST');
+                status_header(405);
+                exit;
+            }
+            $ct = $_SERVER['CONTENT_TYPE'] ?? '';
+            if ($ct && !preg_match('~^(application/x-www-form-urlencoded|multipart/form-data)(;|$)~i', $ct)) {
+                status_header(415);
+                echo 'Unsupported Media Type';
+                exit;
+            }
+            // Placeholder only – full pipeline lands in Stage-3.
+            status_header(501);
+            header('Content-Type: text/plain; charset=utf-8');
+            echo 'Not implemented yet.';
+            exit;
+        }
+    });
 
     function eform_render(string $formId, array $opts = []): string
     {

--- a/electronic_forms/src/FormManager.php
+++ b/electronic_forms/src/FormManager.php
@@ -13,8 +13,13 @@ class FormManager
         $instanceId = bin2hex(random_bytes(16));
         $timestamp = time();
 
-        $html = sprintf("<!-- eforms stage1 placeholder: form_id=%s cacheable=%s -->", \esc_html($formId), $cacheable ? 'true' : 'false');
-        $html .= '<form method="post" novalidate>';
+        // Enqueue assets only when rendering
+        $this->enqueueAssetsIfNeeded();
+
+        $clientValidation = (bool) Config::get('html5.client_validation', false);
+
+        $html = sprintf("<!-- eforms: form_id=%s cacheable=%s -->\n", \esc_html($formId), $cacheable ? 'true' : 'false');
+        $html .= '<form method="post"' . ($clientValidation ? '' : ' novalidate') . ' action="' . \esc_url(\home_url('/eforms/submit')) . '">';
         $html .= sprintf('<input type="hidden" name="form_id" value="%s">', \esc_attr($formId));
         $html .= sprintf('<input type="hidden" name="instance_id" value="%s">', \esc_attr($instanceId));
         $html .= '<input type="hidden" name="eforms_hp" value="">';
@@ -24,12 +29,36 @@ class FormManager
             $token = function_exists('wp_generate_uuid4') ? wp_generate_uuid4() : $instanceId;
             $html .= sprintf('<input type="hidden" name="eforms_token" value="%s">', \esc_attr($token));
         }
+        if ($cacheable) {
+            // Prime cookie token via 204 pixel
+            $html .= sprintf('<img src="%s" aria-hidden="true" alt="" width="1" height="1" style="position:absolute;left:-9999px;">',
+                \esc_url(\home_url('/eforms/prime?f=' . $formId))
+            );
+        }
         $html .= '</form>';
         return $html;
     }
 
     public function enqueueAssetsIfNeeded(): void
     {
-        // no-op for now
+        // Register
+        \wp_register_style(
+            'eforms-forms',
+            \plugins_url('assets/forms.css', \EForms\PLUGIN_DIR . '/eforms.php'),
+            [],
+            @filemtime(\EForms\ASSETS_DIR . '/forms.css') ?: \EForms\VERSION
+        );
+        \wp_register_script(
+            'eforms-forms',
+            \plugins_url('assets/forms.js', \EForms\PLUGIN_DIR . '/eforms.php'),
+            [],
+            @filemtime(\EForms\ASSETS_DIR . '/forms.js') ?: \EForms\VERSION,
+            ['in_footer' => true]
+        );
+        // Enqueue
+        if (!Config::get('assets.css_disable', false)) {
+            \wp_enqueue_style('eforms-forms');
+        }
+        \wp_enqueue_script('eforms-forms');
     }
 }

--- a/electronic_forms/src/Helpers.php
+++ b/electronic_forms/src/Helpers.php
@@ -32,7 +32,23 @@ class Helpers
 
     public static function bytes_from_ini(?string $v): int
     {
-        // TODO: implement K/M/G suffix parsing
-        return 0;
+        // "0"/null/"" -> PHP_INT_MAX (per spec)
+        if ($v === null) return PHP_INT_MAX;
+        $t = trim($v);
+        if ($t === '' || $t === '0') return PHP_INT_MAX;
+        // Accept forms like "128M", "1G", "512K", case-insensitive, with optional "B"
+        if (!preg_match('/^(\d+(?:\.\d+)?)([KMG])?B?$/i', $t, $m)) {
+            // Fallback: best-effort integer
+            $n = (int)$t;
+            return max(0, $n);
+        }
+        $num = (float)$m[1];
+        $unit = isset($m[2]) ? strtolower($m[2]) : '';
+        $mult = 1;
+        if ($unit === 'k') $mult = 1024;
+        elseif ($unit === 'm') $mult = 1024 * 1024;
+        elseif ($unit === 'g') $mult = 1024 * 1024 * 1024;
+        $bytes = (int) floor($num * $mult);
+        return max(0, $bytes);
     }
 }

--- a/electronic_forms/templates/.htaccess
+++ b/electronic_forms/templates/.htaccess
@@ -1,0 +1,7 @@
+# Deny direct access to JSON form templates
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>

--- a/electronic_forms/templates/contact.json
+++ b/electronic_forms/templates/contact.json
@@ -1,0 +1,18 @@
+{
+  "id": "contact_us",
+  "version": "1",
+  "title": "Contact Us",
+  "success": { "mode": "inline", "message": "Thanks! We got your message." },
+  "email": {
+    "to": "admin@example.com",
+    "subject": "Contact Form",
+    "email_template": "default",
+    "include_fields": ["name","email","message"]
+  },
+  "fields": [
+    {"key":"name","type":"name","label":"Your Name","required":true,"before_html":"<h3>Hello,</h3>"},
+    {"key":"message","type":"textarea","label":"Message","required":true,"placeholder":"And continue here ..."},
+    {"key":"email","type":"email","label":"Email","autocomplete":"email","size":40,"required":true,"placeholder":"you@example.com"}
+  ],
+  "submit_button_text": "Send Your Request"
+}

--- a/electronic_forms/templates/index.html
+++ b/electronic_forms/templates/index.html
@@ -1,0 +1,1 @@
+<!doctype html><title></title>

--- a/electronic_forms/templates/quote_request.json
+++ b/electronic_forms/templates/quote_request.json
@@ -1,0 +1,23 @@
+{
+  "id": "quote_request",
+  "version": "1",
+  "title": "Quote Request",
+  "success": {"mode":"redirect","redirect_url":"/?page_id=15"},
+  "email": {
+    "to":"office@flooringartists.com",
+    "subject":"Quote Request",
+    "email_template":"default",
+    "include_fields":["name","email","tel_us","zip_us","message","ip"],
+    "display_format_tel":"xxx-xxx-xxxx"
+  },
+  "fields": [
+    {"key":"name","type":"name","label":"Your Name","required":true,"placeholder":"Your Name","autocomplete":"name"},
+    {"key":"email","type":"email","label":"Email","required":true,"placeholder":"your@email.com","autocomplete":"email"},
+    {"type":"row_group","mode":"start","tag":"div","class":"columns_nomargins"},
+    {"key":"tel_us","type":"tel_us","label":"Phone","required":true,"placeholder":"Phone","autocomplete":"tel"},
+    {"key":"zip_us","type":"zip_us","label":"Zip","required":true,"placeholder":"Project Zip Code","autocomplete":"postal-code"},
+    {"type":"row_group","mode":"end"},
+    {"key":"message","type":"textarea","label":"Message","required":true}
+  ],
+  "submit_button_text":"Send"
+}

--- a/electronic_forms/templates/web.config
+++ b/electronic_forms/templates/web.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <security>
+      <requestFiltering>
+        <hiddenSegments>
+          <add segment="." />
+        </hiddenSegments>
+      </requestFiltering>
+    </security>
+  </system.webServer>
+</configuration>

--- a/electronic_forms/uninstall.php
+++ b/electronic_forms/uninstall.php
@@ -20,4 +20,29 @@ if (!function_exists('wp_upload_dir')) {
     return;
 }
 
-// TODO: honor Config uninstall flags (no deletions yet).
+// Honor uninstall flags
+$purgeUploads = (bool) EForms\Config::get('install.uninstall.purge_uploads', false);
+$purgeLogs    = (bool) EForms\Config::get('install.uninstall.purge_logs', false);
+$baseDir      = (string) EForms\Config::get('uploads.dir', '');
+if ($baseDir && ($purgeUploads || $purgeLogs)) {
+    // Both uploads and logs live under /eforms-private in this build.
+    $target = rtrim($baseDir, '/\\');
+    // Safety: ensure it’s inside wp_upload_dir()
+    $uploads = wp_upload_dir();
+    $root = rtrim($uploads['basedir'], '/\\');
+    if (str_starts_with($target, $root)) {
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($target, \FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $path) {
+            /** @var SplFileInfo $path */
+            if ($path->isDir()) {
+                @rmdir($path->getRealPath());
+            } else {
+                @unlink($path->getRealPath());
+            }
+        }
+        @rmdir($target);
+    }
+}


### PR DESCRIPTION
## Summary
- add asset & template constants and request routing for `/eforms/prime` and `/eforms/submit`
- render forms with asset enqueue, prime pixel, and optional HTML5 validation
- handle uninstall cleanup and parse `php.ini` size strings
- include basic JS file and sample form templates

## Testing
- `php -l electronic_forms/eforms.php`
- `php -l electronic_forms/src/FormManager.php`
- `php -l electronic_forms/src/Helpers.php`
- `php -l electronic_forms/uninstall.php`
- `node --check electronic_forms/assets/forms.js`

------
https://chatgpt.com/codex/tasks/task_e_68ba20dc8bf0832d8ce0c0c1f272e202