### PR TITLE
Implement Stage 3 form processing pipeline

### DIFF
--- a/eforms.php
+++ b/eforms.php
@@ -124,10 +124,9 @@ namespace {
                 echo 'Unsupported Media Type';
                 exit;
             }
-            // Placeholder only – full pipeline lands in Stage-3.
-            status_header(501);
-            header('Content-Type: text/plain; charset=utf-8');
-            echo 'Not implemented yet.';
+            // Delegate to FormManager for full submit pipeline.
+            $fm = new FormManager();
+            $fm->handleSubmit();
             exit;
         }
     });

--- a/src/Emailer.php
+++ b/src/Emailer.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class Emailer
+{
+    public static function send(array $tpl, array $canonical, array $meta): array
+    {
+        $to = $tpl['email']['to'] ?? '';
+        $subject = $tpl['email']['subject'] ?? 'Form Submission';
+        $subject = substr(preg_replace("/[\r\n]+/", ' ', $subject), 0, 255);
+        $site = parse_url(\home_url(), PHP_URL_HOST) ?: 'example.com';
+        $fromCfg = Config::get('email.from_address', '');
+        if (is_string($fromCfg) && preg_match('/@' . preg_quote($site, '/') . '$/i', $fromCfg)) {
+            $from = $fromCfg;
+        } else {
+            $from = 'no-reply@' . $site;
+        }
+        $headers = ['From: ' . $from];
+        $replyField = Config::get('email.reply_to_field', '');
+        if ($replyField && isset($canonical[$replyField]) && \is_email($canonical[$replyField])) {
+            $headers[] = 'Reply-To: ' . $canonical[$replyField];
+        }
+        $body = self::renderBody($tpl, $canonical, $meta);
+        $ok = \wp_mail($to, $subject, $body, $headers);
+        if ($ok) {
+            return ['ok'=>true];
+        }
+        return ['ok'=>false,'msg'=>'send_fail'];
+    }
+
+    private static function renderBody(array $tpl, array $canonical, array $meta): string
+    {
+        $file = __DIR__ . '/../templates/email/default.txt.php';
+        ob_start();
+        $include_fields = $tpl['email']['include_fields'] ?? [];
+        include $file;
+        return (string) ob_get_clean();
+    }
+}

--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -8,57 +8,200 @@ class FormManager
     public function render(string $formId, array $opts = []): string
     {
         $formId = \sanitize_key($formId);
-        $cacheable = $opts['cacheable'] ?? true;
-        $cacheable = (bool) $cacheable;
+        $tpl = $this->loadTemplateById($formId);
+        if (!$tpl) {
+            return '<div class="eforms-error">Form configuration error.</div>';
+        }
+        $pre = TemplateValidator::preflight($tpl);
+        if (!$pre['ok']) {
+            return '<div class="eforms-error">Form configuration error.</div>';
+        }
+        $cacheable = (bool) ($opts['cacheable'] ?? true);
         $instanceId = bin2hex(random_bytes(16));
         $timestamp = time();
-
-        // Enqueue assets only when rendering
+        $meta = [
+            'form_id' => $formId,
+            'instance_id' => $instanceId,
+            'timestamp' => $timestamp,
+            'cacheable' => $cacheable,
+            'client_validation' => (bool) Config::get('html5.client_validation', false),
+            'action' => \home_url('/eforms/submit'),
+            'hidden_token' => $cacheable ? null : (function_exists('\wp_generate_uuid4') ? \wp_generate_uuid4() : $instanceId),
+        ];
         $this->enqueueAssetsIfNeeded();
+        return Renderer::form($tpl, $meta, [], []);
+    }
 
-        $clientValidation = (bool) Config::get('html5.client_validation', false);
+    public function handleSubmit(): void
+    {
+        // runtime cap
+        $configCap = (int) Config::get('security.max_post_bytes', 25000000);
+        $postMax = Helpers::bytes_from_ini(ini_get('post_max_size'));
+        $mem = Helpers::bytes_from_ini(ini_get('memory_limit'));
+        $uploadMax = Helpers::bytes_from_ini(ini_get('upload_max_filesize'));
+        $cap = min($configCap, $postMax, $mem, $uploadMax);
+        $cl = $_SERVER['CONTENT_LENGTH'] ?? null;
+        if ($cl !== null && (int)$cl > $cap) {
+            \status_header(413);
+            exit;
+        }
+        $formId = \sanitize_key($_POST['form_id'] ?? '');
+        $tpl = $this->loadTemplateById($formId);
+        if (!$tpl) {
+            $this->renderErrorAndExit(['id'=>$formId,'title'=>''], $formId, 'Form configuration error.');
+        }
+        $pre = TemplateValidator::preflight($tpl);
+        if (!$pre['ok']) {
+            $this->renderErrorAndExit($tpl, $formId, 'Form configuration error.');
+        }
+        // security gates
+        $origin = Security::origin_evaluate();
+        if ($origin['hard_fail']) {
+            $this->renderErrorAndExit($tpl, $formId, 'Security check failed.');
+        }
+        $hasHidden = isset($_POST['eforms_token']) && $_POST['eforms_token'] !== '';
+        $postedToken = $_POST['eforms_token'] ?? null;
+        $tokenInfo = Security::token_validate($formId, $hasHidden, $postedToken);
+        if ($tokenInfo['hard_fail'] || !$tokenInfo['token_ok']) {
+            $this->renderErrorAndExit($tpl, $formId, 'Security token error.');
+        }
+        // Honeypot
+        if (!empty($_POST['eforms_hp'])) {
+            $this->successAndRedirect($tpl, $formId, $_POST['instance_id'] ?? '');
+            return;
+        }
+        $timestamp = (int) ($_POST['timestamp'] ?? 0);
+        $values = Validator::normalize($tpl, $_POST);
+        $desc = Validator::descriptors($tpl);
+        $val = Validator::validate($tpl, $desc, $values);
+        if (!empty($val['errors'])) {
+            $meta = [
+                'form_id' => $formId,
+                'instance_id' => $_POST['instance_id'] ?? '',
+                'timestamp' => $timestamp,
+                'cacheable' => !$hasHidden,
+                'client_validation' => (bool) Config::get('html5.client_validation', false),
+                'action' => \home_url('/eforms/submit'),
+                'hidden_token' => $hasHidden ? $postedToken : null,
+            ];
+            $this->enqueueAssetsIfNeeded();
+            $html = Renderer::form($tpl, $meta, $val['errors'], $values);
+            echo $html;
+            exit;
+        }
+        $canonical = Validator::coerce($tpl, $desc, $val['values']);
+        $token = $hasHidden ? (string)$postedToken : ($_COOKIE['eforms_t_' . $formId] ?? '');
+        $reserve = Security::ledger_reserve($formId, $token);
+        if (!$reserve['ok']) {
+            $this->renderErrorAndExit($tpl, $formId, 'Already submitted or expired.');
+        }
+        $metaInfo = [
+            'form_id' => $formId,
+            'instance_id' => $_POST['instance_id'] ?? '',
+            'submitted_at' => \gmdate('c'),
+            'ip' => $_SERVER['REMOTE_ADDR'] ?? '',
+        ];
+        $email = Emailer::send($tpl, $canonical, $metaInfo);
+        if (!$email['ok']) {
+            Logging::write('error', 'EFORMS_EMAIL_FAIL', ['form_id'=>$formId,'instance_id'=>$metaInfo['instance_id'],'msg'=>'send_fail']);
+            $meta = [
+                'form_id' => $formId,
+                'instance_id' => bin2hex(random_bytes(16)),
+                'timestamp' => time(),
+                'cacheable' => !$hasHidden,
+                'client_validation' => (bool) Config::get('html5.client_validation', false),
+                'action' => \home_url('/eforms/submit'),
+                'hidden_token' => $hasHidden ? (function_exists('\wp_generate_uuid4') ? \wp_generate_uuid4() : $postedToken) : null,
+            ];
+            $errors = ['_global' => ['Operational error. Please try again later.']];
+            $this->enqueueAssetsIfNeeded();
+            $html = Renderer::form($tpl, $meta, $errors, $values);
+            echo $html;
+            exit;
+        }
+        $this->successAndRedirect($tpl, $formId, $metaInfo['instance_id']);
+    }
 
-        $html = sprintf("<!-- eforms: form_id=%s cacheable=%s -->\n", \esc_html($formId), $cacheable ? 'true' : 'false');
-        $html .= '<form method="post"' . ($clientValidation ? '' : ' novalidate') . ' action="' . \esc_url(\home_url('/eforms/submit')) . '">';
-        $html .= sprintf('<input type="hidden" name="form_id" value="%s">', \esc_attr($formId));
-        $html .= sprintf('<input type="hidden" name="instance_id" value="%s">', \esc_attr($instanceId));
-        $html .= '<input type="hidden" name="eforms_hp" value="">';
-        $html .= sprintf('<input type="hidden" name="timestamp" value="%d">', $timestamp);
-        $html .= '<input type="hidden" name="js_ok" value="0">';
-        if (!$cacheable) {
-            $token = function_exists('wp_generate_uuid4') ? wp_generate_uuid4() : $instanceId;
-            $html .= sprintf('<input type="hidden" name="eforms_token" value="%s">', \esc_attr($token));
+    private function loadTemplateById(string $formId): ?array
+    {
+        if ($formId === '') return null;
+        $dir = rtrim(TEMPLATES_DIR, '/');
+        $files = glob($dir . '/*.json');
+        foreach ($files as $file) {
+            if (!preg_match('~/[a-z0-9-]+\.json$~', $file)) {
+                continue;
+            }
+            $json = json_decode((string) file_get_contents($file), true);
+            if (is_array($json) && ($json['id'] ?? '') === $formId) {
+                return $json;
+            }
         }
-        if ($cacheable) {
-            // Prime cookie token via 204 pixel
-            $html .= sprintf('<img src="%s" aria-hidden="true" alt="" width="1" height="1" style="position:absolute;left:-9999px;">',
-                \esc_url(\home_url('/eforms/prime?f=' . $formId))
-            );
+        return null;
+    }
+
+    private function renderErrorAndExit(array $tpl, string $formId, string $msg): void
+    {
+        $meta = [
+            'form_id' => $formId,
+            'instance_id' => $_POST['instance_id'] ?? bin2hex(random_bytes(16)),
+            'timestamp' => time(),
+            'cacheable' => true,
+            'client_validation' => (bool) Config::get('html5.client_validation', false),
+            'action' => \home_url('/eforms/submit'),
+            'hidden_token' => null,
+        ];
+        $errors = ['_global' => [$msg]];
+        $this->enqueueAssetsIfNeeded();
+        $html = Renderer::form($tpl, $meta, $errors, []);
+        echo $html;
+        exit;
+    }
+
+    private function successAndRedirect(array $tpl, string $formId, string $instanceId): void
+    {
+        \nocache_headers();
+        if (($tpl['success']['mode'] ?? '') === 'redirect') {
+            $url = $tpl['success']['redirect_url'] ?? \home_url('/');
+            \wp_safe_redirect($url, 303);
+            exit;
         }
-        $html .= '</form>';
-        return $html;
+        $cookie = 'eforms_s_' . $formId;
+        $value = $formId . ':' . $instanceId;
+        \setcookie($cookie, $value, [
+            'expires' => time() + 60,
+            'path' => '/',
+            'secure' => \is_ssl(),
+            'httponly' => false,
+            'samesite' => 'Lax',
+        ]);
+        $ref = \wp_get_referer();
+        if (!$ref) {
+            $ref = \home_url('/');
+        }
+        $ref = \add_query_arg('eforms_success', $formId, $ref);
+        \header('Vary: Cookie');
+        \wp_safe_redirect($ref, 303);
+        exit;
     }
 
     public function enqueueAssetsIfNeeded(): void
     {
-        // Register
-        \wp_register_style(
+        wp_register_style(
             'eforms-forms',
-            \plugins_url('assets/forms.css', \EForms\PLUGIN_DIR . '/eforms.php'),
+            plugins_url('assets/forms.css', PLUGIN_DIR . '/eforms.php'),
             [],
-            @filemtime(\EForms\ASSETS_DIR . '/forms.css') ?: \EForms\VERSION
+            @filemtime(ASSETS_DIR . '/forms.css') ?: VERSION
         );
-        \wp_register_script(
+        wp_register_script(
             'eforms-forms',
-            \plugins_url('assets/forms.js', \EForms\PLUGIN_DIR . '/eforms.php'),
+            plugins_url('assets/forms.js', PLUGIN_DIR . '/eforms.php'),
             [],
-            @filemtime(\EForms\ASSETS_DIR . '/forms.js') ?: \EForms\VERSION,
+            @filemtime(ASSETS_DIR . '/forms.js') ?: VERSION,
             ['in_footer' => true]
         );
-        // Enqueue
         if (!Config::get('assets.css_disable', false)) {
-            \wp_enqueue_style('eforms-forms');
+            wp_enqueue_style('eforms-forms');
         }
-        \wp_enqueue_script('eforms-forms');
+        wp_enqueue_script('eforms-forms');
     }
 }

--- a/src/Logging.php
+++ b/src/Logging.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class Logging
+{
+    public static function write(string $severity, string $code, array $ctx = []): void
+    {
+        if (Config::get('logging.mode', 'minimal') === 'off') {
+            return;
+        }
+        $level = (int) Config::get('logging.level', 0);
+        $sevLevel = 0;
+        if ($severity === 'warn') $sevLevel = 1;
+        elseif ($severity === 'info') $sevLevel = 2;
+        if ($sevLevel > $level) {
+            return;
+        }
+        $form = $ctx['form_id'] ?? '';
+        $inst = $ctx['instance_id'] ?? '';
+        $msg = $ctx['msg'] ?? '';
+        $meta = $ctx;
+        unset($meta['form_id'],$meta['instance_id'],$meta['msg']);
+        $line = sprintf('eforms severity=%s code=%s form=%s inst=%s msg="%s" meta=%s',
+            $severity, $code, $form, $inst, $msg, json_encode($meta));
+        error_log($line);
+    }
+}

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -1,0 +1,181 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class Renderer
+{
+    private static function makeId(string $formId, string $key): string
+    {
+        $id = 'eforms-' . $formId . '-' . $key;
+        if (strlen($id) > 128) {
+            $hash = substr(md5($id), 0, 8);
+            $start = substr($id, 0, 60);
+            $end = substr($id, -60);
+            $id = $start . '-' . $hash . '-' . $end;
+            if (strlen($id) > 128) {
+                $id = substr($id, 0, 119) . '-' . $hash;
+            }
+        }
+        return $id;
+    }
+
+    private static function sanitizeFragment(string $html): string
+    {
+        $allowed = [
+            'a' => ['href' => []],
+            'strong' => [],
+            'em' => [],
+            'span' => ['class' => []],
+            'p' => [],
+            'br' => [],
+        ];
+        return \wp_kses($html, $allowed);
+    }
+
+    public static function form(array $tpl, array $meta, array $errors, array $values): string
+    {
+        $formId = $meta['form_id'];
+        // Success message check
+        $successHtml = '';
+        if (isset($_GET['eforms_success']) && \sanitize_key((string)$_GET['eforms_success']) === $formId) {
+            $cookieName = 'eforms_s_' . $formId;
+            $cookieVal = $_COOKIE[$cookieName] ?? '';
+            if ($cookieVal && str_starts_with($cookieVal, $formId . ':')) {
+                $msg = $tpl['success']['message'] ?? 'Success';
+                $successHtml = '<div class="eforms-success">' . \esc_html($msg) . '</div>';
+                \setcookie($cookieName, '', time() - 3600, '/');
+                return $successHtml;
+            }
+        }
+
+        $clientValidation = $meta['client_validation'] ?? false;
+        $html = '';
+        if (!empty($errors)) {
+            $html .= '<div role="alert" tabindex="-1" class="eforms-error-summary"><ul>';
+            foreach ($errors as $k => $msgs) {
+                if ($k === '_global') {
+                    foreach ($msgs as $m) {
+                        $html .= '<li>' . \esc_html($m) . '</li>';
+                    }
+                    continue;
+                }
+                $id = self::makeId($formId, $k);
+                $html .= '<li><a href="#' . \esc_attr($id) . '">' . \esc_html($k) . '</a>';
+                if ($msgs) {
+                    $html .= ': ' . \esc_html($msgs[0]);
+                }
+                $html .= '</li>';
+            }
+            $html .= '</ul></div>';
+        }
+
+        $html .= '<form method="post"' . ($clientValidation ? '' : ' novalidate') . ' action="' . \esc_url($meta['action']) . '">';
+        // hidden meta
+        $html .= '<input type="hidden" name="form_id" value="' . \esc_attr($formId) . '">';
+        $html .= '<input type="hidden" name="instance_id" value="' . \esc_attr($meta['instance_id']) . '">';
+        $html .= '<input type="hidden" name="eforms_hp" value="">';
+        $html .= '<input type="hidden" name="timestamp" value="' . (int)$meta['timestamp'] . '">';
+        $html .= '<input type="hidden" name="js_ok" value="0">';
+        if (!$meta['cacheable']) {
+            $token = $meta['hidden_token'] ?? '';
+            $html .= '<input type="hidden" name="eforms_token" value="' . \esc_attr($token) . '">';
+        } else {
+            $html .= '<img src="' . \esc_url(\home_url('/eforms/prime?f=' . $formId)) . '" aria-hidden="true" alt="" width="1" height="1" style="position:absolute;left:-9999px;">';
+        }
+
+        foreach ($tpl['fields'] as $f) {
+            $type = $f['type'];
+            if ($type === 'row_group') {
+                $tag = $f['tag'] ?? 'div';
+                $class = isset($f['class']) ? ' class="' . \esc_attr($f['class']) . '"' : '';
+                if (($f['mode'] ?? '') === 'start') {
+                    $html .= "<{$tag}{$class}>";
+                } else {
+                    $html .= "</{$tag}>";
+                }
+                continue;
+            }
+            $key = $f['key'];
+            $id = self::makeId($formId, $key);
+            $label = $f['label'] ?? ucwords(str_replace(['_','-'], ' ', $key));
+            $value = $values[$key] ?? '';
+            $fieldErrors = $errors[$key] ?? [];
+            $errId = 'error-' . $id;
+            $errAttr = '';
+            if ($fieldErrors) {
+                $errAttr = ' aria-describedby="' . \esc_attr($errId) . '" aria-invalid="true"';
+            }
+            $before = isset($f['before_html']) ? self::sanitizeFragment($f['before_html']) : '';
+            $after = isset($f['after_html']) ? self::sanitizeFragment($f['after_html']) : '';
+            $html .= $before;
+            switch ($type) {
+                case 'textarea':
+                    $html .= '<label for="' . \esc_attr($id) . '">' . \esc_html($label) . '</label>';
+                    $html .= '<textarea id="' . \esc_attr($id) . '" name="' . \esc_attr($key) . '"';
+                    if (!empty($f['required'])) $html .= ' required';
+                    $html .= $errAttr . '>' . \esc_textarea((string)$value) . '</textarea>';
+                    break;
+                case 'select':
+                    $html .= '<label for="' . \esc_attr($id) . '">' . \esc_html($label) . '</label>';
+                    $html .= '<select id="' . \esc_attr($id) . '" name="' . \esc_attr($key) . '"';
+                    if (!empty($f['required'])) $html .= ' required';
+                    $html .= $errAttr . '>';
+                    foreach ($f['options'] ?? [] as $opt) {
+                        $disabled = !empty($opt['disabled']);
+                        $html .= '<option value="' . \esc_attr($opt['key']) . '"' . ($disabled ? ' disabled' : '');
+                        if ((string)$value === (string)$opt['key']) $html .= ' selected';
+                        $html .= '>' . \esc_html($opt['label']) . '</option>';
+                    }
+                    $html .= '</select>';
+                    break;
+                case 'radio':
+                case 'checkbox':
+                    $html .= '<fieldset';
+                    if (!empty($f['required'])) $html .= ' required';
+                    if ($fieldErrors) $html .= ' aria-describedby="' . \esc_attr($errId) . '" aria-invalid="true"';
+                    $html .= '><legend>' . \esc_html($label) . '</legend>';
+                    foreach ($f['options'] ?? [] as $opt) {
+                        $idOpt = self::makeId($formId, $key . '-' . $opt['key']);
+                        $html .= '<label><input type="' . ($type === 'radio' ? 'radio' : 'checkbox') . '" name="' . \esc_attr($key) . '" value="' . \esc_attr($opt['key']) . '" id="' . \esc_attr($idOpt) . '"';
+                        if ((string)$value === (string)$opt['key']) $html .= ' checked';
+                        if (!empty($opt['disabled'])) $html .= ' disabled';
+                        if (!empty($f['required'])) $html .= ' required';
+                        $html .= '> ' . \esc_html($opt['label']) . '</label>';
+                    }
+                    $html .= '</fieldset>';
+                    break;
+                case 'email':
+                case 'name':
+                case 'tel_us':
+                case 'zip_us':
+                default:
+                    $inputType = 'text';
+                    $extra = '';
+                    if ($type === 'email') {
+                        $inputType = 'email';
+                        $extra .= ' inputmode="email" spellcheck="false" autocapitalize="off"';
+                    } elseif ($type === 'tel_us') {
+                        $inputType = 'tel';
+                        $extra .= ' inputmode="tel"';
+                    } elseif ($type === 'zip_us') {
+                        $inputType = 'text';
+                        $extra .= ' inputmode="numeric" pattern="\d{5}" maxlength="5"';
+                    }
+                    $html .= '<label for="' . \esc_attr($id) . '">' . \esc_html($label) . '</label>';
+                    $html .= '<input type="' . \esc_attr($inputType) . '" id="' . \esc_attr($id) . '" name="' . \esc_attr($key) . '" value="' . \esc_attr((string)$value) . '"';
+                    if (!empty($f['required'])) $html .= ' required';
+                    $html .= $extra . $errAttr . '>';
+                    break;
+            }
+            if ($fieldErrors) {
+                $html .= '<span id="' . \esc_attr($errId) . '" class="eforms-error">' . \esc_html($fieldErrors[0]) . '</span>';
+            }
+            $html .= $after;
+        }
+        $btn = $tpl['submit_button_text'] ?? 'Submit';
+        $html .= '<button type="submit">' . \esc_html($btn) . '</button>';
+        $html .= '</form>';
+        return $html;
+    }
+}

--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class TemplateValidator
+{
+    /**
+     * Performs structural preflight on a template.
+     *
+     * @param array $tpl
+     * @return array{ok:bool,errors:array}
+     */
+    public static function preflight(array $tpl): array
+    {
+        $errors = [];
+        $required = ['id','version','title','success','email','fields','submit_button_text'];
+        foreach ($required as $k) {
+            if (!array_key_exists($k, $tpl)) {
+                $errors[] = "Missing $k";
+            }
+        }
+        if ($errors) {
+            return ['ok'=>false,'errors'=>$errors];
+        }
+        if (!is_string($tpl['id']) || $tpl['id'] === '') {
+            $errors[] = 'id';
+        }
+        if (!is_string($tpl['version']) && !is_numeric($tpl['version'])) {
+            $errors[] = 'version';
+        }
+        if (!is_string($tpl['title'])) {
+            $errors[] = 'title';
+        }
+        if (!is_array($tpl['success'])) {
+            $errors[] = 'success';
+        }
+        if (!is_array($tpl['email'])) {
+            $errors[] = 'email';
+        }
+        if (!is_array($tpl['fields'])) {
+            $errors[] = 'fields';
+        }
+        if (!is_string($tpl['submit_button_text'])) {
+            $errors[] = 'submit_button_text';
+        }
+        // success mode
+        if (is_array($tpl['success'])) {
+            $mode = $tpl['success']['mode'] ?? '';
+            if (!in_array($mode, ['inline','redirect'], true)) {
+                $errors[] = 'success.mode';
+            } elseif ($mode === 'redirect') {
+                if (!isset($tpl['success']['redirect_url']) || !is_string($tpl['success']['redirect_url'])) {
+                    $errors[] = 'success.redirect_url';
+                }
+            }
+        }
+        // fields
+        if (is_array($tpl['fields'])) {
+            $seen = [];
+            $reserved = ['form_id','instance_id','eforms_token','eforms_hp','timestamp','js_ok','ip','submitted_at'];
+            $allowedTypes = ['name','email','textarea','tel_us','zip_us','select','radio','checkbox','row_group'];
+            foreach ($tpl['fields'] as $idx => $f) {
+                if (!is_array($f)) {
+                    $errors[] = "fields[$idx]";
+                    continue;
+                }
+                $type = $f['type'] ?? '';
+                if (!in_array($type, $allowedTypes, true)) {
+                    $errors[] = "fields[$idx].type";
+                    continue;
+                }
+                if ($type === 'row_group') {
+                    if (isset($f['key'])) {
+                        $errors[] = "fields[$idx].key";
+                    }
+                    $mode = $f['mode'] ?? '';
+                    if (!in_array($mode, ['start','end'], true)) {
+                        $errors[] = "fields[$idx].mode";
+                    }
+                    $tag = $f['tag'] ?? 'div';
+                    if (!in_array($tag, ['div','section'], true)) {
+                        $errors[] = "fields[$idx].tag";
+                    }
+                    continue;
+                }
+                $key = $f['key'] ?? '';
+                if (!is_string($key) || !preg_match('/^[a-z0-9_:-]{1,64}$/', $key)) {
+                    $errors[] = "fields[$idx].key";
+                    continue;
+                }
+                if (in_array($key, $reserved, true)) {
+                    $errors[] = "fields[$idx].key_reserved";
+                    continue;
+                }
+                if (isset($seen[$key])) {
+                    $errors[] = "fields[$idx].key_duplicate";
+                    continue;
+                }
+                $seen[$key] = true;
+            }
+        }
+        return ['ok'=>empty($errors), 'errors'=>$errors];
+    }
+}

--- a/src/Uploads.php
+++ b/src/Uploads.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class Uploads
+{
+    public static function enabled(): bool
+    {
+        return (bool) Config::get('uploads.enable', false);
+    }
+
+    public static function hasUploadFields(array $tpl): bool
+    {
+        foreach ($tpl['fields'] as $f) {
+            if (($f['type'] ?? '') === 'file') {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class Validator
+{
+    public static function descriptors(array $tpl): array
+    {
+        $desc = [];
+        foreach ($tpl['fields'] as $f) {
+            if (($f['type'] ?? '') === 'row_group') {
+                continue;
+            }
+            $desc[$f['key']] = $f;
+        }
+        return $desc;
+    }
+
+    public static function normalize(array $tpl, array $post): array
+    {
+        $values = [];
+        foreach ($tpl['fields'] as $f) {
+            if (($f['type'] ?? '') === 'row_group') continue;
+            $k = $f['key'];
+            $v = $post[$k] ?? '';
+            if (is_array($v)) {
+                $v = '';
+            }
+            $values[$k] = trim((string)$v);
+        }
+        return $values;
+    }
+
+    public static function validate(array $tpl, array $desc, array $values): array
+    {
+        $errors = [];
+        $canonical = [];
+        foreach ($desc as $k => $f) {
+            $v = $values[$k] ?? '';
+            if (!empty($f['required']) && $v === '') {
+                $errors[$k][] = 'This field is required.';
+            }
+            if ($v !== '') {
+                switch ($f['type']) {
+                    case 'email':
+                        if (!\is_email($v)) {
+                            $errors[$k][] = 'Invalid email.';
+                        }
+                        break;
+                    case 'zip_us':
+                        if (!preg_match('/^\d{5}$/', $v)) {
+                            $errors[$k][] = 'Invalid ZIP.';
+                        }
+                        break;
+                    case 'tel_us':
+                        $digits = preg_replace('/\D+/', '', $v);
+                        if (strlen($digits) < 10) {
+                            $errors[$k][] = 'Invalid phone.';
+                        }
+                        break;
+                    case 'select':
+                    case 'radio':
+                    case 'checkbox':
+                        $opts = array_column($f['options'] ?? [], 'key');
+                        $enabled = [];
+                        foreach ($f['options'] ?? [] as $opt) {
+                            if (empty($opt['disabled'])) {
+                                $enabled[] = $opt['key'];
+                            }
+                        }
+                        if ($v !== '' && !in_array($v, $enabled, true)) {
+                            $errors[$k][] = 'Invalid choice.';
+                        }
+                        break;
+                }
+            }
+            $canonical[$k] = $v;
+        }
+        return ['errors'=>$errors,'values'=>$canonical];
+    }
+
+    public static function coerce(array $tpl, array $desc, array $values): array
+    {
+        $out = [];
+        foreach ($desc as $k => $f) {
+            $v = $values[$k] ?? '';
+            switch ($f['type']) {
+                case 'email':
+                    if ($v !== '' && strpos($v, '@') !== false) {
+                        [$local,$domain] = explode('@', $v, 2);
+                        $v = $local . '@' . strtolower($domain);
+                    }
+                    break;
+                case 'tel_us':
+                    $digits = preg_replace('/\D+/', '', $v);
+                    if (strlen($digits) === 11 && str_starts_with($digits, '1')) {
+                        $digits = substr($digits, 1);
+                    }
+                    $v = $digits;
+                    break;
+            }
+            $out[$k] = $v;
+        }
+        return $out;
+    }
+}

--- a/templates/email/default.txt.php
+++ b/templates/email/default.txt.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+defined('ABSPATH') || exit;
+
+echo 'Form: ' . ($meta['form_id'] ?? '') . "\n";
+echo 'Instance: ' . ($meta['instance_id'] ?? '') . "\n";
+echo 'Submitted: ' . ($meta['submitted_at'] ?? '') . "\n\n";
+foreach ($include_fields as $key) {
+    $val = $canonical[$key] ?? ($meta[$key] ?? '');
+    echo $key . ': ' . $val . "\n";
+}


### PR DESCRIPTION
## Summary
- Delegate submit endpoint to new FormManager::handleSubmit() pipeline
- Add template preflight validation and full form renderer
- Implement security, validation, email, logging, and token ledger utilities

## Testing
- `find . -name '*.php' -print | xargs -n 1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68bb924dc1cc832d9effb1bada5744e3