### PR TITLE
Add basic file upload rendering and multivalue validation

### DIFF
--- a/assets/forms.js
+++ b/assets/forms.js
@@ -6,6 +6,25 @@
 (function () {
   function onReady(fn){ if (document.readyState === 'loading') { document.addEventListener('DOMContentLoaded', fn); } else { fn(); } }
   onReady(function () {
-    document.querySelectorAll('input[name="js_ok"]').forEach(function (el) { try { el.value = '1'; } catch(_){} });
+    document.querySelectorAll('input[name="js_ok"]').forEach(function (el) {
+      try { el.value = '1'; } catch(_){}
+    });
+    var summary = document.querySelector('.eforms-error-summary');
+    if (summary) {
+      try { summary.focus(); } catch(e){}
+      var firstInvalid = document.querySelector('[aria-invalid="true"]');
+      if (firstInvalid && typeof firstInvalid.focus === 'function') {
+        firstInvalid.focus();
+      }
+    }
+    document.querySelectorAll('form').forEach(function (f) {
+      var submitting = false;
+      f.addEventListener('submit', function (e) {
+        if (submitting) { e.preventDefault(); return false; }
+        submitting = true;
+        var btn = f.querySelector('button[type="submit"]');
+        if (btn) { btn.disabled = true; }
+      });
+    });
   });
 })();

--- a/src/Uploads.php
+++ b/src/Uploads.php
@@ -13,7 +13,8 @@ class Uploads
     public static function hasUploadFields(array $tpl): bool
     {
         foreach ($tpl['fields'] as $f) {
-            if (($f['type'] ?? '') === 'file') {
+            $t = $f['type'] ?? '';
+            if ($t === 'file' || $t === 'files') {
                 return true;
             }
         }


### PR DESCRIPTION
## Summary
- support multivalue checkbox and select inputs in validator
- render file and multiple file inputs with accept hints
- add enctype handling and JS enhancements (error focus, submit lock)

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68be08e4b318832d9ae34181090c30f2