### PR TITLE
Implement template validation, config clamps, and origin checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Electronic Forms
+
+Lightweight PHP form handler for WordPress.
+
+## Usage
+
+Add forms via shortcode:
+
+```php
+[eforms id="contact"]
+```
+
+Configure via filter:
+
+```php
+add_filter('eforms_config', function ($config) {
+    $config['security']['origin_mode'] = 'hard';
+    return $config;
+});
+```
+
+### Security
+
+* CSRF protection via Origin checks and per-request tokens.
+* Token ledger prevents duplicate submissions.
+
+### Logging
+
+Logging modes: `off`, `minimal`, `jsonl`. See `Config` for options.
+
+### Uploads
+
+Uploads are stored in `wp-content/uploads/eforms-private` with strict perms.
+
+## Tests
+
+Run the tiny PHPUnit suite:
+
+```bash
+phpunit
+```

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite name="EForms">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/src/Spec.php
+++ b/src/Spec.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+/**
+ * Registry describing built-in field types.
+ */
+class Spec
+{
+    private const REGISTRY = [
+        'name' => [
+            'is_multivalue' => false,
+            'html' => ['tag'=>'input','type'=>'text'],
+            'validate' => [],
+        ],
+        'email' => [
+            'is_multivalue' => false,
+            'html' => ['tag'=>'input','type'=>'email','inputmode'=>'email','attrs_mirror'=>[]],
+            'validate' => [],
+        ],
+        'textarea' => [
+            'is_multivalue' => false,
+            'html' => ['tag'=>'textarea','attrs_mirror'=>['maxlength'=>null,'minlength'=>null]],
+            'validate' => [],
+        ],
+        'tel_us' => [
+            'is_multivalue' => false,
+            'html' => ['tag'=>'input','type'=>'tel','inputmode'=>'tel','attrs_mirror'=>['maxlength'=>null]],
+            'validate' => [],
+        ],
+        'zip_us' => [
+            'is_multivalue' => false,
+            'html' => ['tag'=>'input','type'=>'text','inputmode'=>'numeric','pattern'=>'\d{5}','attrs_mirror'=>['maxlength'=>5]],
+            'validate' => ['pattern'=>'/^\d{5}$/'],
+        ],
+        'select' => [
+            'is_multivalue' => false,
+            'html' => ['tag'=>'select'],
+            'validate' => [],
+        ],
+        'radio' => [
+            'is_multivalue' => false,
+            'html' => ['tag'=>'fieldset'],
+            'validate' => [],
+        ],
+        'checkbox' => [
+            'is_multivalue' => true,
+            'html' => ['tag'=>'fieldset'],
+            'validate' => [],
+        ],
+        'file' => [
+            'is_multivalue' => false,
+            'html' => ['tag'=>'input','type'=>'file'],
+            'validate' => [],
+        ],
+        'files' => [
+            'is_multivalue' => true,
+            'html' => ['tag'=>'input','type'=>'file','multiple'=>true],
+            'validate' => [],
+        ],
+    ];
+
+    /**
+     * Returns descriptor for field type.
+     */
+    public static function descriptorFor(string $type): array
+    {
+        return self::REGISTRY[$type] ?? ['is_multivalue'=>false,'html'=>['tag'=>'input'],'validate'=>[]];
+    }
+
+    /**
+     * Map accept tokens for file controls.
+     */
+    public static function acceptTokenMap(): array
+    {
+        return [
+            'image' => 'image/jpeg,image/png,image/gif,image/webp',
+            'pdf'   => 'application/pdf',
+        ];
+    }
+}

--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -3,103 +3,239 @@ declare(strict_types=1);
 
 namespace EForms;
 
+/**
+ * Template structural validator. Performs strict preflight of template arrays
+ * and returns a normalized context used by other subsystems.
+ */
 class TemplateValidator
 {
+    public const EFORMS_ERR_SCHEMA_UNKNOWN_KEY   = 'EFORMS_ERR_SCHEMA_UNKNOWN_KEY';
+    public const EFORMS_ERR_SCHEMA_ENUM          = 'EFORMS_ERR_SCHEMA_ENUM';
+    public const EFORMS_ERR_SCHEMA_REQUIRED      = 'EFORMS_ERR_SCHEMA_REQUIRED';
+    public const EFORMS_ERR_SCHEMA_TYPE          = 'EFORMS_ERR_SCHEMA_TYPE';
+    public const EFORMS_ERR_SCHEMA_OBJECT        = 'EFORMS_ERR_SCHEMA_OBJECT';
+    public const EFORMS_ERR_SCHEMA_DUP_KEY       = 'EFORMS_ERR_SCHEMA_DUP_KEY';
+    public const EFORMS_ERR_ACCEPT_EMPTY         = 'EFORMS_ERR_ACCEPT_EMPTY';
+    public const EFORMS_ERR_ROW_GROUP_UNBALANCED = 'EFORMS_ERR_ROW_GROUP_UNBALANCED';
+
     /**
-     * Performs structural preflight on a template.
+     * Perform structural validation and return context.
      *
      * @param array $tpl
-     * @return array{ok:bool,errors:array}
+     * @return array{ok:bool,errors:array<int,array{code:string,path:string}>,context?:array}
      */
     public static function preflight(array $tpl): array
     {
         $errors = [];
-        $required = ['id','version','title','success','email','fields','submit_button_text'];
-        foreach ($required as $k) {
+
+        // Root unknown keys
+        $rootAllowed = ['id','version','title','success','email','fields','submit_button_text','rules'];
+        self::checkUnknown($tpl, $rootAllowed, '', $errors);
+
+        // Required + type
+        $reqRoot = ['id'=>'string','version'=>null,'success'=>'array','email'=>'array','fields'=>'array','submit_button_text'=>'string'];
+        foreach ($reqRoot as $k => $type) {
             if (!array_key_exists($k, $tpl)) {
-                $errors[] = "Missing $k";
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$k];
+                continue;
+            }
+            if ($type === 'string' && !is_string($tpl[$k])) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$k];
+            } elseif ($type === 'array' && !is_array($tpl[$k])) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_OBJECT,'path'=>$k];
             }
         }
-        if ($errors) {
-            return ['ok'=>false,'errors'=>$errors];
-        }
-        if (!is_string($tpl['id']) || $tpl['id'] === '') {
-            $errors[] = 'id';
-        }
-        if (!is_string($tpl['version']) && !is_numeric($tpl['version'])) {
-            $errors[] = 'version';
-        }
-        if (!is_string($tpl['title'])) {
-            $errors[] = 'title';
-        }
-        if (!is_array($tpl['success'])) {
-            $errors[] = 'success';
-        }
-        if (!is_array($tpl['email'])) {
-            $errors[] = 'email';
-        }
-        if (!is_array($tpl['fields'])) {
-            $errors[] = 'fields';
-        }
-        if (!is_string($tpl['submit_button_text'])) {
-            $errors[] = 'submit_button_text';
-        }
-        // success mode
-        if (is_array($tpl['success'])) {
-            $mode = $tpl['success']['mode'] ?? '';
-            if (!in_array($mode, ['inline','redirect'], true)) {
-                $errors[] = 'success.mode';
-            } elseif ($mode === 'redirect') {
-                if (!isset($tpl['success']['redirect_url']) || !is_string($tpl['success']['redirect_url'])) {
-                    $errors[] = 'success.redirect_url';
-                }
+
+        // success
+        $success = is_array($tpl['success'] ?? null) ? $tpl['success'] : [];
+        self::checkUnknown($success, ['mode','redirect_url','message'], 'success.', $errors);
+        $mode = $success['mode'] ?? null;
+        if (!in_array($mode, ['inline','redirect'], true)) {
+            $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>'success.mode'];
+        } elseif ($mode === 'redirect') {
+            if (empty($success['redirect_url']) || !is_string($success['redirect_url'])) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>'success.redirect_url'];
             }
         }
+
+        // email block
+        $email = is_array($tpl['email'] ?? null) ? $tpl['email'] : [];
+        self::checkUnknown($email, ['display_format_tel','to','subject'], 'email.', $errors);
+        if (isset($email['display_format_tel'])) {
+            $enum = ['xxx-xxx-xxxx','(xxx) xxx-xxxx','xxx.xxx.xxxx'];
+            if (!in_array($email['display_format_tel'], $enum, true)) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>'email.display_format_tel'];
+                unset($email['display_format_tel']);
+            }
+        }
+
         // fields
-        if (is_array($tpl['fields'])) {
-            $seen = [];
-            $reserved = ['form_id','instance_id','eforms_token','eforms_hp','timestamp','js_ok','ip','submitted_at'];
-            $allowedTypes = ['name','email','textarea','tel_us','zip_us','select','radio','checkbox','row_group'];
-            foreach ($tpl['fields'] as $idx => $f) {
-                if (!is_array($f)) {
-                    $errors[] = "fields[$idx]";
-                    continue;
+        $fields = is_array($tpl['fields'] ?? null) ? $tpl['fields'] : [];
+        $seenKeys = [];
+        $rowStack = 0;
+        $hasUploads = false;
+        $normFields = [];
+        $reserved = ['form_id','instance_id','eforms_token','eforms_hp','timestamp','js_ok','ip','submitted_at'];
+        $allowedTypes = ['name','email','textarea','tel_us','zip_us','select','radio','checkbox','file','files','row_group'];
+        foreach ($fields as $idx => $f) {
+            $path = 'fields['.$idx.'].';
+            if (!is_array($f)) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_OBJECT,'path'=>rtrim($path,'.')];
+                continue;
+            }
+            $type = $f['type'] ?? null;
+            if (!in_array($type, $allowedTypes, true)) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>$path.'type'];
+                continue;
+            }
+            if ($type === 'row_group') {
+                self::checkUnknown($f, ['type','mode','tag','class'], $path, $errors);
+                $mode = $f['mode'] ?? null;
+                if (!in_array($mode, ['start','end'], true)) {
+                    $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>$path.'mode'];
                 }
-                $type = $f['type'] ?? '';
-                if (!in_array($type, $allowedTypes, true)) {
-                    $errors[] = "fields[$idx].type";
-                    continue;
+                $tag = $f['tag'] ?? 'div';
+                if (!in_array($tag, ['div','section'], true)) {
+                    $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>$path.'tag'];
                 }
-                if ($type === 'row_group') {
-                    if (isset($f['key'])) {
-                        $errors[] = "fields[$idx].key";
+                if ($mode === 'start') {
+                    $rowStack++;
+                } elseif ($mode === 'end') {
+                    if ($rowStack > 0) $rowStack--; else $rowStack = -1; // imbalance
+                }
+                $normFields[] = [
+                    'type' => 'row_group',
+                    'mode' => $mode,
+                    'tag' => $tag,
+                    'class' => self::sanitizeClass($f['class'] ?? ''),
+                ];
+                continue;
+            }
+
+            // Non row_group field
+            self::checkUnknown($f, ['type','key','label','required','options','multiple','accept','before_html','after_html','class'], $path, $errors);
+            $key = $f['key'] ?? null;
+            if (!is_string($key) || !preg_match('/^[a-z0-9_:-]{1,64}$/', $key)) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$path.'key'];
+                continue;
+            }
+            if (in_array($key, $reserved, true)) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>$path.'key'];
+                continue;
+            }
+            if (isset($seenKeys[$key])) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_DUP_KEY,'path'=>$path.'key'];
+                continue;
+            }
+            $seenKeys[$key] = true;
+
+            // options
+            if (isset($f['options'])) {
+                if (!is_array($f['options'])) {
+                    $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$path.'options'];
+                } else {
+                    $optSeen = [];
+                    foreach ($f['options'] as $oIdx => $opt) {
+                        $opath = $path.'options['.$oIdx.'].';
+                        self::checkUnknown($opt, ['key','label','disabled'], $opath, $errors);
+                        if (!isset($opt['key']) || !is_string($opt['key'])) {
+                            $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$opath.'key'];
+                            continue;
+                        }
+                        if (isset($optSeen[$opt['key']])) {
+                            $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_DUP_KEY,'path'=>$opath.'key'];
+                            continue;
+                        }
+                        $optSeen[$opt['key']] = true;
                     }
-                    $mode = $f['mode'] ?? '';
-                    if (!in_array($mode, ['start','end'], true)) {
-                        $errors[] = "fields[$idx].mode";
-                    }
-                    $tag = $f['tag'] ?? 'div';
-                    if (!in_array($tag, ['div','section'], true)) {
-                        $errors[] = "fields[$idx].tag";
-                    }
-                    continue;
                 }
-                $key = $f['key'] ?? '';
-                if (!is_string($key) || !preg_match('/^[a-z0-9_:-]{1,64}$/', $key)) {
-                    $errors[] = "fields[$idx].key";
-                    continue;
+            }
+
+            // accept intersection for files
+            if (in_array($type, ['file','files'], true)) {
+                $hasUploads = true;
+                $accept = $f['accept'] ?? [];
+                if (!is_array($accept)) {
+                    $accept = [];
                 }
-                if (in_array($key, $reserved, true)) {
-                    $errors[] = "fields[$idx].key_reserved";
-                    continue;
+                $global = Config::get('uploads.allowed_tokens', ['image','pdf']);
+                $intersection = array_intersect($accept, $global);
+                if ($accept && empty($intersection)) {
+                    $errors[] = ['code'=>self::EFORMS_ERR_ACCEPT_EMPTY,'path'=>$path.'accept'];
                 }
-                if (isset($seen[$key])) {
-                    $errors[] = "fields[$idx].key_duplicate";
-                    continue;
-                }
-                $seen[$key] = true;
+            }
+
+            $normFields[] = [
+                'type' => $type,
+                'key' => $key,
+                'label' => $f['label'] ?? null,
+                'required' => !empty($f['required']),
+                'options' => $f['options'] ?? null,
+                'multiple' => !empty($f['multiple']),
+                'accept' => $f['accept'] ?? null,
+                'class' => self::sanitizeClass($f['class'] ?? ''),
+            ];
+        }
+        if ($rowStack !== 0) {
+            $errors[] = ['code'=>self::EFORMS_ERR_ROW_GROUP_UNBALANCED,'path'=>'fields'];
+        }
+
+        $ctx = [
+            'has_uploads' => $hasUploads,
+            'descriptors' => self::buildDescriptors($normFields),
+            'version' => $tpl['version'] ?? '',
+            'id' => $tpl['id'] ?? '',
+            'email' => $email,
+            'success' => $success,
+            'rules' => $tpl['rules'] ?? [],
+            'fields' => $normFields,
+            'max_input_vars_estimate' => count($normFields) * 3,
+        ];
+
+        return ['ok'=>empty($errors), 'errors'=>$errors, 'context'=>$ctx];
+    }
+
+    private static function checkUnknown(array $obj, array $allowed, string $prefix, array &$errors): void
+    {
+        foreach ($obj as $k => $_) {
+            if (!in_array($k, $allowed, true)) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_UNKNOWN_KEY,'path'=>$prefix.$k];
             }
         }
-        return ['ok'=>empty($errors), 'errors'=>$errors];
+    }
+
+    private static function sanitizeClass(string $class): string
+    {
+        $tokens = preg_split('/\s+/', trim($class)) ?: [];
+        $keep = [];
+        foreach ($tokens as $t) {
+            if ($t === '') continue;
+            if (!preg_match('/^[A-Za-z0-9_-]{1,32}$/', $t)) continue;
+            if (!in_array($t, $keep, true)) $keep[] = $t;
+        }
+        $out = implode(' ', $keep);
+        if (strlen($out) > 128) {
+            $out = substr($out, 0, 128);
+        }
+        return $out;
+    }
+
+    private static function buildDescriptors(array $fields): array
+    {
+        $desc = [];
+        foreach ($fields as $f) {
+            if ($f['type'] === 'row_group') continue;
+            $d = Spec::descriptorFor($f['type']);
+            if ($f['type'] === 'select' && !empty($f['multiple'])) {
+                $d['is_multivalue'] = true;
+                $d['html']['multiple'] = true;
+            }
+            if ($f['type'] === 'files') {
+                $d['is_multivalue'] = true;
+                $d['html']['multiple'] = true;
+            }
+            $desc[$f['key']] = $d;
+        }
+        return $desc;
     }
 }

--- a/src/schema/template.schema.json
+++ b/src/schema/template.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["id","version","success","email","fields","submit_button_text"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {"type": "string"},
+    "version": {"type": ["string","number"]},
+    "title": {"type": "string"},
+    "submit_button_text": {"type": "string"},
+    "success": {
+      "type": "object",
+      "required": ["mode"],
+      "properties": {
+        "mode": {"enum": ["inline","redirect"]},
+        "redirect_url": {"type": "string"},
+        "message": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "email": {
+      "type": "object",
+      "properties": {
+        "display_format_tel": {"enum": ["xxx-xxx-xxxx","(xxx) xxx-xxxx","xxx.xxx.xxxx"]}
+      },
+      "additionalProperties": false
+    },
+    "fields": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/field"}
+    },
+    "rules": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/rule"}
+    }
+  },
+  "definitions": {
+    "field": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {"enum": ["name","email","textarea","tel_us","zip_us","select","radio","checkbox","file","files","row_group"]},
+        "key": {"type": "string"},
+        "label": {"type": "string"},
+        "required": {"type": "boolean"},
+        "options": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/option"}
+        },
+        "multiple": {"type": "boolean"},
+        "accept": {"type": "array", "items": {"type": "string"}},
+        "mode": {"enum": ["start","end"]},
+        "tag": {"enum": ["div","section"]},
+        "class": {"type": "string"}
+      }
+    },
+    "option": {
+      "type": "object",
+      "required": ["key","label"],
+      "additionalProperties": false,
+      "properties": {
+        "key": {"type": "string"},
+        "label": {"type": "string"},
+        "disabled": {"type": "boolean"}
+      }
+    },
+    "rule": {
+      "type": "object",
+      "required": ["rule"],
+      "additionalProperties": false,
+      "properties": {
+        "rule": {"enum": ["required_if","required_if_any","required_unless","matches","one_of","mutually_exclusive"]},
+        "field": {"type": "string"},
+        "fields": {"type": "array", "items": {"type": "string"}},
+        "other": {"type": "string"},
+        "equals": {"type": "string"},
+        "equals_any": {"type": "array", "items": {"type": "string"}}
+      }
+    }
+  }
+}

--- a/tests/HelpersBytesFromIniTest.php
+++ b/tests/HelpersBytesFromIniTest.php
@@ -1,0 +1,15 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use EForms\Helpers;
+
+class HelpersBytesFromIniTest extends TestCase
+{
+    public function testConversions(): void
+    {
+        $this->assertEquals(PHP_INT_MAX, Helpers::bytes_from_ini('0'));
+        $this->assertEquals(131072, Helpers::bytes_from_ini('128K'));
+        $this->assertEquals(2097152, Helpers::bytes_from_ini('2M'));
+        $this->assertEquals(1610612736, Helpers::bytes_from_ini('1.5G'));
+        $this->assertEquals(0, Helpers::bytes_from_ini('junk'));
+    }
+}

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -1,0 +1,109 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use EForms\Validator;
+
+class RulesTest extends TestCase
+{
+    private function run(array $tpl, array $post): array
+    {
+        $desc = Validator::descriptors($tpl);
+        $values = Validator::normalize($tpl, $post);
+        $res = Validator::validate($tpl, $desc, $values);
+        return $res['errors'];
+    }
+
+    public function testRequiredIf(): void
+    {
+        $tpl = [
+            'fields' => [
+                ['type'=>'text','key'=>'a'],
+                ['type'=>'text','key'=>'b'],
+            ],
+            'rules' => [
+                ['rule'=>'required_if','field'=>'a','other'=>'b','equals'=>'x']
+            ],
+        ];
+        $errors = $this->run($tpl, ['b'=>'x']);
+        $this->assertArrayHasKey('a', $errors);
+    }
+
+    public function testRequiredIfAny(): void
+    {
+        $tpl = [
+            'fields' => [
+                ['type'=>'text','key'=>'a'],
+                ['type'=>'text','key'=>'b'],
+                ['type'=>'text','key'=>'c'],
+            ],
+            'rules' => [
+                ['rule'=>'required_if_any','field'=>'a','fields'=>['b','c'],'equals_any'=>['yes','y']]
+            ],
+        ];
+        $errors = $this->run($tpl, ['b'=>'y']);
+        $this->assertArrayHasKey('a', $errors);
+    }
+
+    public function testRequiredUnless(): void
+    {
+        $tpl = [
+            'fields' => [
+                ['type'=>'text','key'=>'a'],
+                ['type'=>'text','key'=>'b'],
+            ],
+            'rules' => [
+                ['rule'=>'required_unless','field'=>'a','other'=>'b','equals'=>'skip']
+            ],
+        ];
+        $errors = $this->run($tpl, ['b'=>'no']);
+        $this->assertArrayHasKey('a', $errors);
+    }
+
+    public function testMatches(): void
+    {
+        $tpl = [
+            'fields' => [
+                ['type'=>'text','key'=>'a'],
+                ['type'=>'text','key'=>'b'],
+            ],
+            'rules' => [
+                ['rule'=>'matches','field'=>'a','other'=>'b']
+            ],
+        ];
+        $errors = $this->run($tpl, ['a'=>'one','b'=>'two']);
+        $this->assertArrayHasKey('a', $errors);
+    }
+
+    public function testOneOf(): void
+    {
+        $tpl = [
+            'fields' => [
+                ['type'=>'text','key'=>'a'],
+                ['type'=>'text','key'=>'b'],
+                ['type'=>'text','key'=>'c'],
+            ],
+            'rules' => [
+                ['rule'=>'one_of','fields'=>['a','b','c']]
+            ],
+        ];
+        $errors = $this->run($tpl, []);
+        $this->assertArrayHasKey('a', $errors);
+        $this->assertArrayHasKey('b', $errors);
+        $this->assertArrayHasKey('c', $errors);
+    }
+
+    public function testMutuallyExclusive(): void
+    {
+        $tpl = [
+            'fields' => [
+                ['type'=>'text','key'=>'a'],
+                ['type'=>'text','key'=>'b'],
+            ],
+            'rules' => [
+                ['rule'=>'mutually_exclusive','fields'=>['a','b']]
+            ],
+        ];
+        $errors = $this->run($tpl, ['a'=>'one','b'=>'two']);
+        $this->assertArrayHasKey('a', $errors);
+        $this->assertArrayHasKey('b', $errors);
+    }
+}

--- a/tests/SecurityOriginTest.php
+++ b/tests/SecurityOriginTest.php
@@ -1,0 +1,75 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use EForms\Security;
+use EForms\Config;
+
+class SecurityOriginTest extends TestCase
+{
+    private function resetConfig(): void
+    {
+        $ref = new ReflectionClass(Config::class);
+        $p = $ref->getProperty('bootstrapped');
+        $p->setAccessible(true);
+        $p->setValue(false);
+        $p = $ref->getProperty('data');
+        $p->setAccessible(true);
+        $p->setValue([]);
+        Config::bootstrap();
+    }
+
+    public function testSameOrigin(): void
+    {
+        putenv('EFORMS_ORIGIN_MODE');
+        putenv('EFORMS_ORIGIN_MISSING_HARD');
+        $this->resetConfig();
+        $_SERVER['HTTP_ORIGIN'] = 'http://hub.local';
+        $res = Security::origin_evaluate();
+        $this->assertEquals('same', $res['state']);
+        $this->assertFalse($res['hard_fail']);
+    }
+
+    public function testCrossSoft(): void
+    {
+        putenv('EFORMS_ORIGIN_MODE=soft');
+        putenv('EFORMS_ORIGIN_MISSING_HARD');
+        $this->resetConfig();
+        $_SERVER['HTTP_ORIGIN'] = 'http://evil.local';
+        $res = Security::origin_evaluate();
+        $this->assertEquals('cross', $res['state']);
+        $this->assertEquals(1, $res['soft_signal']);
+        $this->assertFalse($res['hard_fail']);
+    }
+
+    public function testCrossHard(): void
+    {
+        putenv('EFORMS_ORIGIN_MODE=hard');
+        putenv('EFORMS_ORIGIN_MISSING_HARD');
+        $this->resetConfig();
+        $_SERVER['HTTP_ORIGIN'] = 'http://evil.local';
+        $res = Security::origin_evaluate();
+        $this->assertEquals('cross', $res['state']);
+        $this->assertTrue($res['hard_fail']);
+    }
+
+    public function testUnknownHard(): void
+    {
+        putenv('EFORMS_ORIGIN_MODE=hard');
+        putenv('EFORMS_ORIGIN_MISSING_HARD');
+        $this->resetConfig();
+        $_SERVER['HTTP_ORIGIN'] = 'file://foo';
+        $res = Security::origin_evaluate();
+        $this->assertEquals('unknown', $res['state']);
+        $this->assertTrue($res['hard_fail']);
+    }
+
+    public function testMissingHard(): void
+    {
+        putenv('EFORMS_ORIGIN_MODE=soft');
+        putenv('EFORMS_ORIGIN_MISSING_HARD=1');
+        $this->resetConfig();
+        unset($_SERVER['HTTP_ORIGIN']);
+        $res = Security::origin_evaluate();
+        $this->assertEquals('missing', $res['state']);
+        $this->assertTrue($res['hard_fail']);
+    }
+}

--- a/tests/TemplateValidatorTest.php
+++ b/tests/TemplateValidatorTest.php
@@ -1,0 +1,74 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use EForms\TemplateValidator;
+
+class TemplateValidatorTest extends TestCase
+{
+    private function baseTpl(): array
+    {
+        return [
+            'id' => 'f1',
+            'version' => '1',
+            'title' => 'T',
+            'success' => ['mode' => 'inline'],
+            'email' => [],
+            'fields' => [
+                ['type' => 'name', 'key' => 'name'],
+                ['type' => 'email', 'key' => 'email'],
+            ],
+            'submit_button_text' => 'Send',
+        ];
+    }
+
+    public function testGoodTemplatePasses(): void
+    {
+        $tpl = $this->baseTpl();
+        $res = TemplateValidator::preflight($tpl);
+        $this->assertTrue($res['ok']);
+    }
+
+    public function testUnknownRootKey(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['foo'] = 1;
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_UNKNOWN_KEY, $codes);
+    }
+
+    public function testDuplicateFieldKey(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][] = ['type' => 'email', 'key' => 'email'];
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_DUP_KEY, $codes);
+    }
+
+    public function testBadEnum(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['success']['mode'] = 'bogus';
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_ENUM, $codes);
+    }
+
+    public function testEmptyAcceptIntersection(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][] = ['type' => 'file', 'key' => 'up', 'accept' => ['foo']];
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_ACCEPT_EMPTY, $codes);
+    }
+
+    public function testUnbalancedRowGroups(): void
+    {
+        $tpl = $this->baseTpl();
+        array_unshift($tpl['fields'], ['type' => 'row_group', 'mode' => 'start', 'tag' => 'div']);
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_ROW_GROUP_UNBALANCED, $codes);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -74,6 +74,7 @@ function esc_attr($s) { return (string)$s; }
 function esc_url($s) { return (string)$s; }
 function esc_textarea($s) { return (string)$s; }
 function wp_kses($html, $allowed) { return $html; }
+function wp_kses_post($html) { return $html; }
 function sanitize_key($key) { return preg_replace('/[^a-z0-9_\-]/', '', strtolower((string)$key)); }
 function shortcode_atts($pairs, $atts, $shortcode = '') {
     $atts = (array)$atts;
@@ -107,6 +108,7 @@ function plugins_url($path = '', $plugin_file = '') {
 function wp_upload_dir() {
     return ['basedir' => __DIR__ . '/tmp/uploads', 'baseurl' => 'http://hub.local/wp-content/uploads'];
 }
+function wp_http_validate_url($url) { return filter_var((string)$url, FILTER_VALIDATE_URL) ? $url : false; }
 function wp_generate_uuid4() { return bin2hex(random_bytes(16)); }
 function wp_mail($to, $subject, $message, $headers = []) {
     global $TEST_ARTIFACTS;


### PR DESCRIPTION
## Summary
- Add strict template preflight with error codes and option/row group checks
- Clamp configuration values and add defaults helper
- Improve origin evaluation in Security and add descriptor registry
- Ship JSON schema, README and PHPUnit tests

## Testing
- `phpunit tests/TemplateValidatorTest.php tests/HelpersBytesFromIniTest.php tests/SecurityOriginTest.php tests/RulesTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68be0ff660f4832d9a0299e588fc0e56