### PR TITLE
Log honeypot submissions and support hard fail mode

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -47,7 +47,7 @@ class Config
         $sec['js_hard_mode'] = (bool)$sec['js_hard_mode'];
         $sec['max_post_bytes'] = self::clampInt($sec['max_post_bytes'], 0, PHP_INT_MAX);
         $sec['ua_maxlen'] = self::clampInt($sec['ua_maxlen'], 0, 10000);
-        $sec['honeypot_response'] = in_array($sec['honeypot_response'], ['stealth_success','error','redirect'], true) ? $sec['honeypot_response'] : $defaults['security']['honeypot_response'];
+        $sec['honeypot_response'] = in_array($sec['honeypot_response'], ['stealth_success','hard_fail'], true) ? $sec['honeypot_response'] : $defaults['security']['honeypot_response'];
         $sec['cookie_missing_policy'] = in_array($sec['cookie_missing_policy'], ['soft','hard','off','challenge'], true) ? $sec['cookie_missing_policy'] : $defaults['security']['cookie_missing_policy'];
         $sec['token_ledger']['enable'] = (bool)($sec['token_ledger']['enable'] ?? true);
         $sec['submission_token']['required'] = (bool)($sec['submission_token']['required'] ?? true);

--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -95,7 +95,20 @@ class FormManager
             }
         }
         // Honeypot
+        $token = $hasHidden ? (string)$postedToken : $cookieToken;
         if (!empty($_POST['eforms_hp'])) {
+            Security::ledger_reserve($formId, $token);
+            $mode = Config::get('security.honeypot_response', 'stealth_success');
+            $stealth = ($mode === 'stealth_success');
+            Logging::write('warn', 'EFORMS_ERR_HONEYPOT', [
+                'form_id' => $formId,
+                'instance_id' => $_POST['instance_id'] ?? '',
+                'stealth' => $stealth,
+            ]);
+            \header('X-EForms-Stealth: 1');
+            if ($mode === 'hard_fail') {
+                $this->renderErrorAndExit($tpl, $formId, 'Security check failed.');
+            }
             $this->successAndRedirect($tpl, $formId, $_POST['instance_id'] ?? '');
             return;
         }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -152,6 +152,12 @@ add_filter('eforms_config', function (array $defaults) {
     if (getenv('EFORMS_COOKIE_MISSING_POLICY')) {
         $defaults['security']['cookie_missing_policy'] = getenv('EFORMS_COOKIE_MISSING_POLICY');
     }
+    if (getenv('EFORMS_HONEYPOT_RESPONSE')) {
+        $defaults['security']['honeypot_response'] = getenv('EFORMS_HONEYPOT_RESPONSE');
+    }
+    if (getenv('EFORMS_LOG_LEVEL')) {
+        $defaults['logging']['level'] = (int) getenv('EFORMS_LOG_LEVEL');
+    }
     return $defaults;
 });
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -110,7 +110,19 @@ ok=0
 assert_grep tmp/redirect.txt '"status":303' || ok=1
 assert_grep tmp/redirect.txt '\\?eforms_success=contact_us' || ok=1
 ! assert_grep tmp/mail.json 'bot-foo|alice@example.com|zed@example.com' || ok=1
+assert_grep tmp/php_error.log 'EFORMS_ERR_HONEYPOT' || ok=1
+assert_grep tmp/php_error.log '"stealth":true' || ok=1
 record_result "honeypot: stealth success, no email" $ok
+
+# 3b) Honeypot hard fail
+run_test test_honeypot_hard
+ok=0
+assert_grep tmp/stdout.txt 'Security check failed\.' || ok=1
+! assert_grep tmp/redirect.txt '"status":303' || ok=1
+! assert_grep tmp/mail.json 'bot-foo|alice@example.com|zed@example.com' || ok=1
+assert_grep tmp/php_error.log 'EFORMS_ERR_HONEYPOT' || ok=1
+assert_grep tmp/php_error.log '"stealth":false' || ok=1
+record_result "honeypot: hard fail" $ok
 
 # 4) Validation missing required
 run_test test_validation_required

--- a/tests/test_honeypot_hard.php
+++ b/tests/test_honeypot_hard.php
@@ -1,18 +1,18 @@
 <?php
 declare(strict_types=1);
+putenv('EFORMS_HONEYPOT_RESPONSE=hard_fail');
 putenv('EFORMS_LOG_LEVEL=1');
 require __DIR__ . '/bootstrap.php';
 
-// Honeypot: non-empty should result in PRG 303 and no email
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = 'tokHP';
+$_COOKIE['eforms_t_contact_us'] = 'tokHPH';
 
 $_POST = [
     'form_id' => 'contact_us',
-    'instance_id' => 'instHP',
+    'instance_id' => 'instHPH',
     'timestamp' => time(),
-    'eforms_hp' => 'bot-foo',
+    'eforms_hp' => 'bot-hard',
     'name' => '',
     'email' => '',
     'message' => '',
@@ -22,4 +22,3 @@ $fm = new \EForms\FormManager();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();
-


### PR DESCRIPTION
## Summary
- burn and log tokens on honeypot hits, emit stealth header, and honor `security.honeypot_response`
- allow `hard_fail` honeypot response in configuration
- cover hard-fail honeypot behavior with new test

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68be5199cdb0832d8012cf2c845410bf