### PR TITLE
Implement file upload handling with retention and limits

### DIFF
--- a/src/Uploads.php
+++ b/src/Uploads.php
@@ -20,4 +20,213 @@ class Uploads
         }
         return false;
     }
+
+    public static function gc(): void
+    {
+        $dir = rtrim((string) Config::get('uploads.dir', ''), '/');
+        $seconds = (int) Config::get('uploads.retention_seconds', 86400);
+        if ($dir === '' || $seconds <= 0 || !is_dir($dir)) {
+            return;
+        }
+        $cutoff = time() - $seconds;
+        foreach (glob($dir . '/[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]') ?: [] as $sub) {
+            foreach (glob($sub . '/*') ?: [] as $f) {
+                if (@filemtime($f) !== false && filemtime($f) < $cutoff) {
+                    @unlink($f);
+                }
+            }
+            if (count(glob($sub . '/*') ?: []) === 0) {
+                @rmdir($sub);
+            }
+        }
+    }
+
+    public static function normalizeAndValidate(array $tpl, array $files): array
+    {
+        $flat = self::flatten($files);
+        $errors = [];
+        $valid = [];
+        $totalRequest = 0;
+        $maxFile = (int) Config::get('uploads.max_file_bytes', 5000000);
+        $maxFieldBytes = (int) Config::get('uploads.total_field_bytes', 10000000);
+        $maxRequest = (int) Config::get('uploads.total_request_bytes', 20000000);
+        $maxFiles = (int) Config::get('uploads.max_files', 10);
+        $allowedGlobal = Config::get('uploads.allowed_tokens', ['image','pdf']);
+
+        foreach ($tpl['fields'] as $f) {
+            $type = $f['type'] ?? '';
+            if ($type !== 'file' && $type !== 'files') {
+                continue;
+            }
+            $k = $f['key'];
+            $items = $flat[$k] ?? [];
+            $accept = $f['accept'] ?? [];
+            if (!is_array($accept)) {
+                $accept = [];
+            }
+            $accept = array_intersect($accept, $allowedGlobal);
+            $fieldBytes = 0;
+            $fieldCount = 0;
+            foreach ($items as $it) {
+                $err = $it['error'];
+                $size = $it['size'];
+                $name = $it['original_name'];
+                if ($err !== UPLOAD_ERR_OK || $size <= 0 || $name === '') {
+                    continue;
+                }
+                if ($size > $maxFile) {
+                    $errors[$k][] = 'File too large.';
+                    continue;
+                }
+                $finfo = finfo_open(FILEINFO_MIME_TYPE);
+                $mime = $finfo ? (string) finfo_file($finfo, $it['tmp_name']) : '';
+                if ($finfo) finfo_close($finfo);
+                $ext = strtolower((string) pathinfo($name, PATHINFO_EXTENSION));
+                if (!self::allowedToken($accept, $mime, $ext)) {
+                    $errors[$k][] = 'Invalid file type.';
+                    continue;
+                }
+                $fieldBytes += $size;
+                $fieldCount++;
+                $totalRequest += $size;
+                [$slug, $extSafe, $originalSafe] = self::sanitizeOriginal($name, $ext);
+                $valid[$k][] = [
+                    'tmp_name' => $it['tmp_name'],
+                    'size' => $size,
+                    'mime' => $mime,
+                    'slug' => $slug,
+                    'ext' => $extSafe,
+                    'original_name' => $name,
+                    'original_name_safe' => $originalSafe,
+                ];
+            }
+            if (!empty($f['required']) && $fieldCount === 0) {
+                $errors[$k][] = 'This field is required.';
+            }
+            if ($fieldBytes > $maxFieldBytes) {
+                $errors[$k][] = 'Total upload size exceeded.';
+            }
+            if ($fieldCount > $maxFiles || ($type === 'file' && $fieldCount > 1)) {
+                $errors[$k][] = 'Too many files.';
+            }
+        }
+        if ($totalRequest > $maxRequest) {
+            $errors['_global'][] = 'Upload limit exceeded.';
+        }
+        return ['files' => $valid, 'errors' => $errors];
+    }
+
+    public static function store(array $files): array
+    {
+        $out = [];
+        $base = rtrim((string) Config::get('uploads.dir', ''), '/');
+        if ($base === '') {
+            return $out;
+        }
+        foreach ($files as $k => $list) {
+            foreach ($list as $item) {
+                $rel = self::buildPath($base, $item['tmp_name'], $item['slug'], $item['ext']);
+                $dest = $base . '/' . $rel;
+                $dir = dirname($dest);
+                if (!is_dir($dir)) {
+                    @mkdir($dir, 0700, true);
+                }
+                if (!@move_uploaded_file($item['tmp_name'], $dest)) {
+                    @rename($item['tmp_name'], $dest);
+                }
+                @chmod($dest, 0600);
+                $out[$k][] = [
+                    'path' => $rel,
+                    'size' => $item['size'],
+                    'mime' => $item['mime'],
+                    'original_name' => $item['original_name'],
+                    'original_name_safe' => $item['original_name_safe'],
+                ];
+            }
+        }
+        return $out;
+    }
+
+    private static function flatten(array $files): array
+    {
+        $out = [];
+        foreach ($files as $key => $f) {
+            if (!isset($f['name'])) continue;
+            if (is_array($f['name'])) {
+                $count = count($f['name']);
+                for ($i = 0; $i < $count; $i++) {
+                    $out[$key][] = [
+                        'tmp_name' => $f['tmp_name'][$i] ?? '',
+                        'original_name' => $f['name'][$i] ?? '',
+                        'size' => (int) ($f['size'][$i] ?? 0),
+                        'error' => (int) ($f['error'][$i] ?? UPLOAD_ERR_NO_FILE),
+                    ];
+                }
+            } else {
+                $out[$key][] = [
+                    'tmp_name' => $f['tmp_name'] ?? '',
+                    'original_name' => $f['name'] ?? '',
+                    'size' => (int) ($f['size'] ?? 0),
+                    'error' => (int) ($f['error'] ?? UPLOAD_ERR_NO_FILE),
+                ];
+            }
+        }
+        return $out;
+    }
+
+    private static function allowedToken(array $accept, string $mime, string $ext): bool
+    {
+        if (in_array('image', $accept, true) && str_starts_with($mime, 'image/')) {
+            return true;
+        }
+        if (in_array('pdf', $accept, true) && $mime === 'application/pdf' && $ext === 'pdf') {
+            return true;
+        }
+        return false;
+    }
+
+    private static function sanitizeOriginal(string $name, string $ext): array
+    {
+        $base = pathinfo($name, PATHINFO_FILENAME);
+        if (Config::get('uploads.transliterate', true)) {
+            $base = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $base) ?: $base;
+        }
+        $base = strtolower(preg_replace('/[^A-Za-z0-9_-]+/', '-', $base));
+        $base = trim($base, '-');
+        $max = (int) Config::get('uploads.original_maxlen', 100);
+        if (strlen($base) > $max) {
+            $base = substr($base, 0, $max);
+        }
+        if ($base === '') {
+            $base = 'file';
+        }
+        $extSafe = strtolower($ext);
+        $originalSafe = $base . ($extSafe !== '' ? '.' . $extSafe : '');
+        return [$base, $extSafe, $originalSafe];
+    }
+
+    private static function buildPath(string $baseDir, string $tmp, string $slug, string $ext): string
+    {
+        $date = gmdate('Ymd');
+        $sha = substr(hash_file('sha256', $tmp), 0, 16);
+        $seq = 1;
+        $maxRel = (int) Config::get('uploads.max_relative_path_chars', 180);
+        do {
+            $name = $slug . '-' . $sha . '-' . $seq . ($ext !== '' ? '.' . $ext : '');
+            $rel = $date . '/' . $name;
+            if (strlen($rel) > $maxRel) {
+                $allow = $maxRel - strlen($date . '/-' . $sha . '-' . $seq . ($ext !== '' ? '.' . $ext : ''));
+                if ($allow < 1) {
+                    $allow = 1;
+                }
+                $slug = substr($slug, 0, $allow);
+                continue;
+            }
+            $dest = $baseDir . '/' . $rel;
+            if (!file_exists($dest)) {
+                return $rel;
+            }
+            $seq++;
+        } while (true);
+    }
 }

--- a/templates/upload_test.json
+++ b/templates/upload_test.json
@@ -1,0 +1,17 @@
+{
+  "id": "upload_test",
+  "version": "1",
+  "title": "Upload Test",
+  "success": { "mode": "inline", "message": "OK" },
+  "email": {
+    "to": "office@flooringartists.com",
+    "subject": "Upload",
+    "email_template": "default",
+    "include_fields": ["name", "file1"]
+  },
+  "fields": [
+    {"key":"name","type":"name","label":"Name"},
+    {"key":"file1","type":"file","label":"File","accept":["pdf"]}
+  ],
+  "submit_button_text": "Send"
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -158,6 +158,12 @@ add_filter('eforms_config', function (array $defaults) {
     if (getenv('EFORMS_LOG_LEVEL')) {
         $defaults['logging']['level'] = (int) getenv('EFORMS_LOG_LEVEL');
     }
+    if (getenv('EFORMS_UPLOAD_MAX_FILE_BYTES')) {
+        $defaults['uploads']['max_file_bytes'] = (int) getenv('EFORMS_UPLOAD_MAX_FILE_BYTES');
+    }
+    if (getenv('EFORMS_UPLOAD_RETENTION_SECONDS')) {
+        $defaults['uploads']['retention_seconds'] = (int) getenv('EFORMS_UPLOAD_RETENTION_SECONDS');
+    }
     return $defaults;
 });
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -168,6 +168,25 @@ assert_grep tmp/uploads/eforms-private/eforms.log '"severity":"error"' || ok=1
 assert_grep tmp/uploads/eforms-private/eforms.log '"code":"EFORMS_EMAIL_FAIL"' || ok=1
 record_result "logging: SMTP failure" $ok
 
+# 9) Upload valid
+run_test test_upload_valid
+ok=0
+assert_grep tmp/uploaded.txt 'test-file-' || ok=1
+record_result "upload: valid file stored" $ok
+
+# 9b) Upload too large
+EFORMS_UPLOAD_MAX_FILE_BYTES=100 run_test test_upload_reject
+ok=0
+assert_grep tmp/stdout.txt 'File too large\.' || ok=1
+! assert_grep tmp/uploaded.txt 'eforms-private' || ok=1
+record_result "upload: file too large rejected" $ok
+
+# 9c) Upload retention GC
+EFORMS_UPLOAD_RETENTION_SECONDS=1 run_test test_upload_gc
+ok=0
+assert_equal_file tmp/gc.txt 'empty' || ok=1
+record_result "upload: retention GC" $ok
+
 echo
 echo "Summary: $pass passed, $fail failed"
 exit $(( fail > 0 ))

--- a/tests/test_upload_gc.php
+++ b/tests/test_upload_gc.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+$base = __DIR__ . '/tmp/uploads/eforms-private';
+$dir = $base . '/20200101';
+@mkdir($dir, 0777, true);
+$file = $dir . '/old.txt';
+file_put_contents($file, 'x');
+touch($file, time() - 10);
+\EForms\Uploads::gc();
+$files = glob($dir . '/*');
+file_put_contents(__DIR__ . '/tmp/gc.txt', $files ? 'notempty' : 'empty');

--- a/tests/test_upload_reject.php
+++ b/tests/test_upload_reject.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_COOKIE['eforms_t_upload_test'] = 'tokU2';
+$tmp = __DIR__ . '/tmp/upload_big.pdf';
+file_put_contents($tmp, "%PDF-1.4\n%\xE2\xE3\xCF\xD3\n" . str_repeat('B', 200));
+$_FILES = [
+    'file1' => [
+        'name' => 'bigfile.pdf',
+        'type' => 'application/pdf',
+        'tmp_name' => $tmp,
+        'error' => UPLOAD_ERR_OK,
+        'size' => filesize($tmp),
+    ],
+];
+$_POST = [
+    'form_id' => 'upload_test',
+    'instance_id' => 'instU2',
+    'timestamp' => time(),
+    'eforms_hp' => '',
+    'name' => 'Zed',
+];
+register_shutdown_function(function () {
+    $files = glob(__DIR__ . '/tmp/uploads/eforms-private/*/*');
+    file_put_contents(__DIR__ . '/tmp/uploaded.txt', $files ? implode("\n", $files) : '');
+});
+$fm = new \EForms\FormManager();
+$fm->handleSubmit();

--- a/tests/test_upload_valid.php
+++ b/tests/test_upload_valid.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_COOKIE['eforms_t_upload_test'] = 'tokU1';
+$tmp = __DIR__ . '/tmp/upload.pdf';
+file_put_contents($tmp, "%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+$_FILES = [
+    'file1' => [
+        'name' => 'Tést File.pdf',
+        'type' => 'application/pdf',
+        'tmp_name' => $tmp,
+        'error' => UPLOAD_ERR_OK,
+        'size' => filesize($tmp),
+    ],
+];
+$_POST = [
+    'form_id' => 'upload_test',
+    'instance_id' => 'instU1',
+    'timestamp' => time(),
+    'eforms_hp' => '',
+    'name' => 'Zed',
+];
+register_shutdown_function(function () {
+    $files = glob(__DIR__ . '/tmp/uploads/eforms-private/*/*');
+    file_put_contents(__DIR__ . '/tmp/uploaded.txt', $files[0] ?? '');
+});
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();


### PR DESCRIPTION
## Summary
- Add comprehensive upload management: flatten `$_FILES`, validate token allow-lists, enforce byte and count limits, and persist files with sanitized names
- Support upload retention with garbage collection and integrate processing in `FormManager::handleSubmit`
- Include tests verifying valid uploads, size limit rejection, and retention cleanup

## Testing
- `bash tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bf175ee8e0832d9227d3cb513f0063