### PR TITLE
Improve renderer sanitization and row group handling

### DIFF
--- a/tests/RendererRowGroupTest.php
+++ b/tests/RendererRowGroupTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Config;
+use EForms\Renderer;
+use EForms\TemplateValidator;
+
+final class RendererRowGroupTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $boot = $ref->getProperty('bootstrapped');
+        $boot->setAccessible(true);
+        $boot->setValue(false);
+        $data = $ref->getProperty('data');
+        $data->setAccessible(true);
+        $data->setValue([]);
+        putenv('EFORMS_LOG_LEVEL=1');
+        Config::bootstrap();
+    }
+
+    public function testRowGroupAutoCloseAndLogging(): void
+    {
+        $tpl = [
+            'id' => 't1',
+            'version' => '1',
+            'title' => 't',
+            'success' => ['mode' => 'inline'],
+            'email' => ['to' => 'a@example.com', 'subject' => 's', 'email_template' => '', 'include_fields' => []],
+            'fields' => [
+                ['type' => 'row_group', 'mode' => 'start', 'tag' => 'section', 'class' => 'custom'],
+                ['type' => 'name', 'key' => 'name', 'label' => 'Name'],
+            ],
+            'submit_button_text' => 'Send',
+            'rules' => [],
+        ];
+        $meta = [
+            'form_id' => 'f1',
+            'instance_id' => 'i1',
+            'timestamp' => time(),
+            'cacheable' => true,
+            'client_validation' => false,
+            'action' => '#',
+            'hidden_token' => null,
+            'enctype' => 'application/x-www-form-urlencoded',
+        ];
+        $logFile = Config::get('uploads.dir', sys_get_temp_dir()) . '/eforms.log';
+        @unlink($logFile);
+        $html = Renderer::form($tpl, $meta, [], []);
+        $this->assertStringContainsString('<section class="eforms-row custom">', $html);
+        $this->assertStringContainsString('</section><button', $html);
+        $log = file_get_contents($logFile);
+        $this->assertStringContainsString(TemplateValidator::EFORMS_ERR_ROW_GROUP_UNBALANCED, (string)$log);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -73,7 +73,7 @@ function esc_html($s) { return (string)$s; }
 function esc_attr($s) { return (string)$s; }
 function esc_url($s) { return (string)$s; }
 function esc_textarea($s) { return (string)$s; }
-function wp_kses($html, $allowed) { return $html; }
+function wp_kses($html, $allowed, $allowed_protocols = []) { return $html; }
 function wp_kses_post($html) { return $html; }
 function sanitize_key($key) { return preg_replace('/[^a-z0-9_\-]/', '', strtolower((string)$key)); }
 function shortcode_atts($pairs, $atts, $shortcode = '') {


### PR DESCRIPTION
## Summary
- expand allowed HTML tags/attributes and restrict `<a>` schemes to http/https/mailto
- add base `eforms-row` class and auto-close unbalanced row_group wrappers with logging
- cover row group behavior with a new unit test

## Testing
- `./tests/run.sh`
- `phpunit --bootstrap tests/bootstrap.php tests/RendererRowGroupTest.php`
- `phpunit -c phpunit.xml.dist` *(fails: RulesTest::run must be public)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1b0f1cb0832da792d46dff50c6e6