### PR TITLE
feat: add html email and attachment support

### DIFF
--- a/src/Emailer.php
+++ b/src/Emailer.php
@@ -8,8 +8,10 @@ class Emailer
     public static function send(array $tpl, array $canonical, array $meta): array
     {
         $to = $tpl['email']['to'] ?? '';
-        $subject = $tpl['email']['subject'] ?? 'Form Submission';
-        $subject = substr(preg_replace("/[\r\n]+/", ' ', $subject), 0, 255);
+        $meta = self::sanitizeMeta($meta);
+        $subjectRaw = $tpl['email']['subject'] ?? 'Form Submission';
+        $subjectRaw = self::expandTokens($subjectRaw, $canonical, $meta);
+        $subject = substr(preg_replace("/[\r\n]+/", ' ', $subjectRaw), 0, 255);
         $site = parse_url(\home_url(), PHP_URL_HOST) ?: 'example.com';
         $fromCfg = Config::get('email.from_address', '');
         if (is_string($fromCfg) && preg_match('/@' . preg_quote($site, '/') . '$/i', $fromCfg)) {
@@ -17,25 +19,101 @@ class Emailer
         } else {
             $from = 'no-reply@' . $site;
         }
+        $html = (bool) Config::get('email.html', false);
         $headers = ['From: ' . $from];
+        if ($html) {
+            $headers[] = 'Content-Type: text/html; charset=UTF-8';
+        }
         $replyField = Config::get('email.reply_to_field', '');
         if ($replyField && isset($canonical[$replyField]) && \is_email($canonical[$replyField])) {
             $headers[] = 'Reply-To: ' . $canonical[$replyField];
         }
-        $body = self::renderBody($tpl, $canonical, $meta);
-        $ok = \wp_mail($to, $subject, $body, $headers);
+        [$attachments, $overflow] = self::collectAttachments($tpl, $canonical);
+        $body = self::renderBody($tpl, $canonical, $meta, $html);
+        if (!empty($overflow)) {
+            $note = implode(', ', $overflow);
+            if ($html) {
+                $body .= '<p>Omitted attachments: ' . htmlspecialchars($note, ENT_QUOTES) . '</p>';
+            } else {
+                $body .= "\nOmitted attachments: $note\n";
+            }
+        }
+        $ok = \wp_mail($to, $subject, $body, $headers, $attachments);
         if ($ok) {
             return ['ok'=>true];
         }
         return ['ok'=>false,'msg'=>'send_fail'];
     }
 
-    private static function renderBody(array $tpl, array $canonical, array $meta): string
+    private static function renderBody(array $tpl, array $canonical, array $meta, bool $html): string
     {
-        $file = __DIR__ . '/../templates/email/default.txt.php';
-        ob_start();
+        $file = __DIR__ . '/../templates/email/' . ($html ? 'default.html.php' : 'default.txt.php');
+        $allowedMeta = ['submitted_at','ip','form_id','instance_id'];
         $include_fields = $tpl['email']['include_fields'] ?? [];
+        $include_fields = array_values(array_filter($include_fields, function ($k) use ($canonical, $meta, $allowedMeta) {
+            if (isset($canonical[$k]) || isset($canonical['_uploads'][$k])) {
+                return true;
+            }
+            return in_array($k, $allowedMeta, true) && isset($meta[$k]);
+        }));
+        ob_start();
         include $file;
-        return (string) ob_get_clean();
+        $out = (string) ob_get_clean();
+        return self::expandTokens($out, $canonical, $meta);
+    }
+
+    private static function sanitizeMeta(array $meta): array
+    {
+        $allowed = ['submitted_at','ip','form_id','instance_id'];
+        return array_intersect_key($meta, array_flip($allowed));
+    }
+
+    private static function expandTokens(string $str, array $canonical, array $meta): string
+    {
+        return preg_replace_callback('/\{\{\s*(field\.[a-z0-9_-]+|submitted_at|ip|form_id)\s*\}\}/i', function ($m) use ($canonical, $meta) {
+            $token = strtolower($m[1]);
+            if (str_starts_with($token, 'field.')) {
+                $key = substr($token, 6);
+                if (isset($canonical['_uploads'][$key])) {
+                    $names = array_column($canonical['_uploads'][$key], 'original_name_safe');
+                    return implode(', ', $names);
+                }
+                return (string) ($canonical[$key] ?? '');
+            }
+            return (string) ($meta[$token] ?? '');
+        }, $str);
+    }
+
+    private static function collectAttachments(array $tpl, array $canonical): array
+    {
+        $attachments = [];
+        $overflow = [];
+        $maxCount = (int) Config::get('email.upload_max_attachments', 5);
+        $maxBytes = (int) Config::get('uploads.max_email_bytes', 10000000);
+        $base = rtrim((string) Config::get('uploads.dir', ''), '/');
+        if ($base === '' || empty($canonical['_uploads'])) {
+            return [$attachments, $overflow];
+        }
+        $count = 0;
+        $total = 0;
+        foreach ($tpl['fields'] as $f) {
+            $type = $f['type'] ?? '';
+            if (($type !== 'file' && $type !== 'files') || empty($f['email_attach'])) {
+                continue;
+            }
+            $k = $f['key'] ?? '';
+            foreach ($canonical['_uploads'][$k] ?? [] as $item) {
+                $path = $base . '/' . $item['path'];
+                $size = (int) ($item['size'] ?? 0);
+                if ($count >= $maxCount || $total + $size > $maxBytes) {
+                    $overflow[] = $item['original_name_safe'];
+                    continue;
+                }
+                $attachments[] = $path;
+                $count++;
+                $total += $size;
+            }
+        }
+        return [$attachments, $overflow];
     }
 }

--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -113,7 +113,7 @@ class TemplateValidator
             }
 
             // Non row_group field
-            self::checkUnknown($f, ['type','key','label','required','options','multiple','accept','before_html','after_html','class','placeholder','autocomplete','size','max_length','min','max','pattern'], $path, $errors);
+            self::checkUnknown($f, ['type','key','label','required','options','multiple','accept','before_html','after_html','class','placeholder','autocomplete','size','max_length','min','max','pattern','email_attach'], $path, $errors);
             $key = $f['key'] ?? null;
             if (!is_string($key) || !preg_match('/^[a-z0-9_:-]{1,64}$/', $key)) {
                 $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$path.'key'];
@@ -162,6 +162,9 @@ class TemplateValidator
                 $intersection = array_intersect($accept, $global);
                 if ($accept && empty($intersection)) {
                     $errors[] = ['code'=>self::EFORMS_ERR_ACCEPT_EMPTY,'path'=>$path.'accept'];
+                }
+                if (isset($f['email_attach']) && !is_bool($f['email_attach'])) {
+                    $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$path.'email_attach'];
                 }
             }
 

--- a/templates/contact.json
+++ b/templates/contact.json
@@ -5,7 +5,7 @@
   "success": { "mode": "inline", "message": "Thanks! We got your message." },
   "email": {
     "to": "office@flooringartists.com",
-    "subject": "Contact Form",
+    "subject": "Contact Form - {{field.name}}",
     "email_template": "default",
     "include_fields": ["name","email","message"]
   },

--- a/templates/email/default.html.php
+++ b/templates/email/default.html.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+defined('ABSPATH') || exit;
+?>
+<p>
+Form: <?= htmlspecialchars($meta['form_id'] ?? '', ENT_QUOTES) ?><br>
+Instance: <?= htmlspecialchars($meta['instance_id'] ?? '', ENT_QUOTES) ?><br>
+Submitted: <?= htmlspecialchars($meta['submitted_at'] ?? '', ENT_QUOTES) ?>
+</p>
+<table>
+<?php foreach ($include_fields as $key):
+    if (isset($canonical['_uploads'][$key])) {
+        $names = array_column($canonical['_uploads'][$key], 'original_name_safe');
+        $val = implode(', ', $names);
+    } else {
+        $val = $canonical[$key] ?? ($meta[$key] ?? '');
+    }
+?>
+<tr><th><?= htmlspecialchars($key, ENT_QUOTES) ?></th><td><?= nl2br(htmlspecialchars((string)$val, ENT_QUOTES)) ?></td></tr>
+<?php endforeach; ?>
+</table>

--- a/templates/email/default.txt.php
+++ b/templates/email/default.txt.php
@@ -6,6 +6,11 @@ echo 'Form: ' . ($meta['form_id'] ?? '') . "\n";
 echo 'Instance: ' . ($meta['instance_id'] ?? '') . "\n";
 echo 'Submitted: ' . ($meta['submitted_at'] ?? '') . "\n\n";
 foreach ($include_fields as $key) {
-    $val = $canonical[$key] ?? ($meta[$key] ?? '');
+    if (isset($canonical['_uploads'][$key])) {
+        $names = array_column($canonical['_uploads'][$key], 'original_name_safe');
+        $val = implode(', ', $names);
+    } else {
+        $val = $canonical[$key] ?? ($meta[$key] ?? '');
+    }
     echo $key . ': ' . $val . "\n";
 }

--- a/templates/upload_test.json
+++ b/templates/upload_test.json
@@ -11,7 +11,7 @@
   },
   "fields": [
     {"key":"name","type":"name","label":"Name"},
-    {"key":"file1","type":"file","label":"File","accept":["pdf"]}
+    {"key":"file1","type":"file","label":"File","accept":["pdf"],"email_attach":true}
   ],
   "submit_button_text": "Send"
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -110,7 +110,7 @@ function wp_upload_dir() {
 }
 function wp_http_validate_url($url) { return filter_var((string)$url, FILTER_VALIDATE_URL) ? $url : false; }
 function wp_generate_uuid4() { return bin2hex(random_bytes(16)); }
-function wp_mail($to, $subject, $message, $headers = []) {
+function wp_mail($to, $subject, $message, $headers = [], $attachments = []) {
     global $TEST_ARTIFACTS;
     $list = json_decode((string)file_get_contents($TEST_ARTIFACTS['mail_file']), true) ?: [];
     $list[] = [
@@ -118,6 +118,7 @@ function wp_mail($to, $subject, $message, $headers = []) {
         'subject' => $subject,
         'message' => $message,
         'headers' => $headers,
+        'attachments' => $attachments,
     ];
     file_put_contents($TEST_ARTIFACTS['mail_file'], json_encode($list));
     // Allow forcing failure via env variable

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -155,11 +155,17 @@ record_result "success inline: shows message" $ok
 run_test test_minimal_email
 ok=0
 assert_grep tmp/mail.json 'office@flooringartists.com' || ok=1
-assert_grep tmp/mail.json 'Contact Form' || ok=1
+assert_grep tmp/mail.json 'Contact Form - Zed' || ok=1
 assert_grep tmp/mail.json 'name: Zed' || ok=1
 assert_grep tmp/mail.json 'email: zed@example.com' || ok=1
 assert_grep tmp/mail.json 'message: Ping' || ok=1
 record_result "minimal email: to/subject/body" $ok
+
+# 7b) Email attachments
+run_test test_email_attachment
+ok=0
+assert_grep tmp/mail.json 'doc.pdf' || ok=1
+record_result "email attachments: file included" $ok
 
 # 8) Logging minimal: SMTP failure
 run_test test_logging

--- a/tests/test_email_attachment.php
+++ b/tests/test_email_attachment.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_COOKIE['eforms_t_upload_test'] = 'tokEA1';
+$tmp = __DIR__ . '/tmp/upload.pdf';
+file_put_contents($tmp, "%PDF-1.4\n");
+$_FILES = [
+    'file1' => [
+        'name' => 'doc.pdf',
+        'type' => 'application/pdf',
+        'tmp_name' => $tmp,
+        'error' => UPLOAD_ERR_OK,
+        'size' => filesize($tmp),
+    ],
+];
+$_POST = [
+    'form_id' => 'upload_test',
+    'instance_id' => 'instEA1',
+    'timestamp' => time(),
+    'eforms_hp' => '',
+    'name' => 'Zed',
+];
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();


### PR DESCRIPTION
## Summary
- support HTML email templates and token expansion
- attach uploaded files and include sanitized meta
- validate `email_attach` field option and update tests

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bf37c5aa80832da11af433b831a383