### PR TITLE
Add tests for token modes and honeypot

### DIFF
--- a/tests/HoneypotBehaviorTest.php
+++ b/tests/HoneypotBehaviorTest.php
@@ -1,0 +1,35 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class HoneypotBehaviorTest extends TestCase
+{
+    public function testStealthHeaderAndTokenBurn(): void
+    {
+        $tmpDir = __DIR__ . '/tmp';
+        if (is_dir($tmpDir)) {
+            exec('rm -rf ' . escapeshellarg($tmpDir));
+        }
+        mkdir($tmpDir, 0777, true);
+        $script = __DIR__ . '/test_honeypot_capture.php';
+        $cmd = 'php-cgi ' . escapeshellarg($script);
+        $out = [];
+        exec($cmd, $out, $code);
+        $this->assertSame(0, $code);
+
+        $headers = [];
+        foreach ($out as $line) {
+            $line = rtrim($line, "\r\n");
+            if ($line === '') break;
+            $headers[] = $line;
+        }
+        $this->assertContains('X-EForms-Stealth: 1', $headers);
+
+        $log = (string)file_get_contents($tmpDir . '/uploads/eforms-private/eforms.log');
+        $this->assertStringContainsString('EFORMS_ERR_HONEYPOT', $log);
+        $this->assertStringContainsString('"stealth":true', $log);
+
+        $hash = sha1('contact_us:tokHP');
+        $ledgerFile = $tmpDir . '/uploads/eforms-private/ledger/' . substr($hash,0,2) . '/' . $hash . '.used';
+        $this->assertFileExists($ledgerFile);
+    }
+}

--- a/tests/SecurityTokenModesTest.php
+++ b/tests/SecurityTokenModesTest.php
@@ -1,0 +1,112 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use EForms\Security;
+use EForms\Config;
+
+class SecurityTokenModesTest extends TestCase
+{
+    private array $origConfig;
+
+    protected function setUp(): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $prop = $ref->getProperty('data');
+        $prop->setAccessible(true);
+        $this->origConfig = $prop->getValue();
+    }
+
+    protected function tearDown(): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $prop = $ref->getProperty('data');
+        $prop->setAccessible(true);
+        $prop->setValue(null, $this->origConfig);
+    }
+
+    private function setConfig(string $path, $value): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $prop = $ref->getProperty('data');
+        $prop->setAccessible(true);
+        $data = $prop->getValue();
+        $segments = explode('.', $path);
+        $cursor =& $data;
+        $last = array_pop($segments);
+        foreach ($segments as $seg) {
+            if (!isset($cursor[$seg]) || !is_array($cursor[$seg])) {
+                $cursor[$seg] = [];
+            }
+            $cursor =& $cursor[$seg];
+        }
+        $cursor[$last] = $value;
+        $prop->setValue(null, $data);
+    }
+
+    public function testHiddenTokenMode(): void
+    {
+        $res = Security::token_validate('contact_us', true, 'tokHidden');
+        $this->assertSame('hidden', $res['mode']);
+        $this->assertTrue($res['token_ok']);
+        $this->assertFalse($res['hard_fail']);
+    }
+
+    public function testCookieModeSoftMissing(): void
+    {
+        $this->setConfig('security.cookie_missing_policy', 'soft');
+        unset($_COOKIE['eforms_t_contact_us']);
+        $res = Security::token_validate('contact_us', false, null);
+        $this->assertSame('cookie', $res['mode']);
+        $this->assertFalse($res['token_ok']);
+        $this->assertFalse($res['hard_fail']);
+        $this->assertSame(1, $res['soft_signal']);
+        $this->assertFalse($res['require_challenge']);
+    }
+
+    public function testCookieModeHardMissing(): void
+    {
+        $this->setConfig('security.cookie_missing_policy', 'hard');
+        unset($_COOKIE['eforms_t_contact_us']);
+        $res = Security::token_validate('contact_us', false, null);
+        $this->assertSame('cookie', $res['mode']);
+        $this->assertTrue($res['hard_fail']);
+        $this->assertFalse($res['require_challenge']);
+    }
+
+    public function testCookieModeChallenge(): void
+    {
+        $this->setConfig('security.cookie_missing_policy', 'challenge');
+        unset($_COOKIE['eforms_t_contact_us']);
+        $res = Security::token_validate('contact_us', false, null);
+        $this->assertSame('cookie', $res['mode']);
+        $this->assertFalse($res['hard_fail']);
+        $this->assertSame(1, $res['soft_signal']);
+        $this->assertTrue($res['require_challenge']);
+    }
+
+    public function testCookieModeOffPolicy(): void
+    {
+        $this->setConfig('security.cookie_missing_policy', 'off');
+        unset($_COOKIE['eforms_t_contact_us']);
+        $res = Security::token_validate('contact_us', false, null);
+        $this->assertSame('cookie', $res['mode']);
+        $this->assertFalse($res['hard_fail']);
+        $this->assertSame(0, $res['soft_signal']);
+        $this->assertFalse($res['require_challenge']);
+    }
+
+    public function testCookieRotation(): void
+    {
+        $tmpDir = __DIR__ . '/tmp';
+        if (is_dir($tmpDir)) {
+            exec('rm -rf ' . escapeshellarg($tmpDir));
+        }
+        mkdir($tmpDir, 0777, true);
+        $script = __DIR__ . '/test_cookie_rotation.php';
+        $cmd = 'php ' . escapeshellarg($script);
+        exec($cmd, $out, $code);
+        $this->assertSame(0, $code);
+        $cookie = trim((string)file_get_contents($tmpDir . '/cookie.txt'));
+        $this->assertNotSame('oldCookie', $cookie);
+        $this->assertNotSame('', $cookie);
+    }
+}

--- a/tests/test_cookie_rotation.php
+++ b/tests/test_cookie_rotation.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_COOKIE['eforms_t_contact_us'] = 'oldCookie';
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instROT',
+    'timestamp' => time(),
+    'eforms_hp' => '',
+    'name' => 'Zed',
+    'email' => 'zed@example.com',
+    'message' => 'Ping',
+];
+
+register_shutdown_function(function () {
+    file_put_contents(__DIR__ . '/tmp/cookie.txt', $_COOKIE['eforms_t_contact_us'] ?? '');
+});
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();

--- a/tests/test_honeypot_capture.php
+++ b/tests/test_honeypot_capture.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_LOG_LEVEL=1');
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_COOKIE['eforms_t_contact_us'] = 'tokHP';
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instHP',
+    'timestamp' => time(),
+    'eforms_hp' => 'bot',
+    'name' => '',
+    'email' => '',
+    'message' => '',
+];
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();


### PR DESCRIPTION
## Summary
- exercise hidden-token vs. cookie submission modes, including cookie_missing_policy permutations and cookie rotation
- verify honeypot stealth logging, header emission, and token burn

## Testing
- `phpunit tests/SecurityTokenModesTest.php`
- `phpunit tests/HoneypotBehaviorTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf471641a4832d97d7e4771fe3083a