### PR TITLE
Add tests for HTML fragments, row groups, and validation rules

### DIFF
--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -214,6 +214,20 @@ class TemplateValidator
             $errors[] = ['code'=>self::EFORMS_ERR_ROW_GROUP_UNBALANCED,'path'=>'fields'];
         }
 
+        $rules = is_array($tpl['rules'] ?? null) ? $tpl['rules'] : [];
+        $allowedRules = ['required_if','required_if_any','required_unless','matches','one_of','mutually_exclusive'];
+        foreach ($rules as $rIdx => $rule) {
+            $rpath = 'rules['.$rIdx.'].';
+            if (!is_array($rule)) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_OBJECT,'path'=>rtrim($rpath,'.')];
+                continue;
+            }
+            $type = $rule['rule'] ?? '';
+            if (!in_array($type, $allowedRules, true)) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>$rpath.'rule'];
+            }
+        }
+
         $ctx = [
             'has_uploads' => $hasUploads,
             'descriptors' => self::buildDescriptors($normFields),
@@ -221,7 +235,7 @@ class TemplateValidator
             'id' => $tpl['id'] ?? '',
             'email' => $email,
             'success' => $success,
-            'rules' => $tpl['rules'] ?? [],
+            'rules' => $rules,
             'fields' => $normFields,
             'max_input_vars_estimate' => count($normFields) * 3,
         ];

--- a/tests/RendererFragmentTest.php
+++ b/tests/RendererFragmentTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Renderer;
+
+final class RendererFragmentTest extends TestCase
+{
+    public function testAllowedAndDisallowedTags(): void
+    {
+        $ref = new \ReflectionClass(Renderer::class);
+        $m = $ref->getMethod('sanitizeFragment');
+        $m->setAccessible(true);
+        $input = '<p><strong>ok</strong><script>alert(1)</script><em>hi</em></p>';
+        $output = $m->invoke(null, $input);
+        $this->assertStringContainsString('<strong>ok</strong>', $output);
+        $this->assertStringContainsString('<em>hi</em>', $output);
+        $this->assertStringNotContainsString('<script>', $output);
+    }
+}

--- a/tests/RendererRowGroupTest.php
+++ b/tests/RendererRowGroupTest.php
@@ -54,4 +54,38 @@ final class RendererRowGroupTest extends TestCase
         $log = file_get_contents($logFile);
         $this->assertStringContainsString(TemplateValidator::EFORMS_ERR_ROW_GROUP_UNBALANCED, (string)$log);
     }
+
+    public function testRowGroupStrayEndLogged(): void
+    {
+        $tpl = [
+            'id' => 't1',
+            'version' => '1',
+            'title' => 't',
+            'success' => ['mode' => 'inline'],
+            'email' => ['to' => 'a@example.com', 'subject' => 's', 'email_template' => '', 'include_fields' => []],
+            'fields' => [
+                ['type' => 'row_group', 'mode' => 'end', 'tag' => 'section'],
+                ['type' => 'name', 'key' => 'name', 'label' => 'Name'],
+            ],
+            'submit_button_text' => 'Send',
+            'rules' => [],
+        ];
+        $meta = [
+            'form_id' => 'f1',
+            'instance_id' => 'i1',
+            'timestamp' => time(),
+            'cacheable' => true,
+            'client_validation' => false,
+            'action' => '#',
+            'hidden_token' => null,
+            'enctype' => 'application/x-www-form-urlencoded',
+        ];
+        $logFile = Config::get('uploads.dir', sys_get_temp_dir()) . '/eforms.log';
+        @unlink($logFile);
+        $html = Renderer::form($tpl, $meta, [], []);
+        $this->assertStringContainsString('<form', $html);
+        $this->assertStringContainsString('<button', $html);
+        $log = file_get_contents($logFile);
+        $this->assertStringContainsString(TemplateValidator::EFORMS_ERR_ROW_GROUP_UNBALANCED, (string)$log);
+    }
 }

--- a/tests/TemplateValidatorTest.php
+++ b/tests/TemplateValidatorTest.php
@@ -72,6 +72,19 @@ class TemplateValidatorTest extends TestCase
         $this->assertContains(TemplateValidator::EFORMS_ERR_ROW_GROUP_UNBALANCED, $codes);
     }
 
+    public function testUnknownValidationRule(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['rules'] = [
+            ['rule' => 'bogus_rule', 'field' => 'name'],
+        ];
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $paths = array_column($res['errors'], 'path');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_ENUM, $codes);
+        $this->assertContains('rules[0].rule', $paths);
+    }
+
     public function testMaxLengthValidation(): void
     {
         $tpl = $this->baseTpl();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -73,8 +73,13 @@ function esc_html($s) { return (string)$s; }
 function esc_attr($s) { return (string)$s; }
 function esc_url($s) { return (string)$s; }
 function esc_textarea($s) { return (string)$s; }
-function wp_kses($html, $allowed, $allowed_protocols = []) { return $html; }
-function wp_kses_post($html) { return $html; }
+function wp_kses($html, $allowed, $allowed_protocols = []) {
+    $tags = '<' . implode('><', array_keys($allowed)) . '>';
+    return strip_tags((string)$html, $tags);
+}
+function wp_kses_post($html) {
+    return strip_tags((string)$html);
+}
 function sanitize_key($key) { return preg_replace('/[^a-z0-9_\-]/', '', strtolower((string)$key)); }
 function shortcode_atts($pairs, $atts, $shortcode = '') {
     $atts = (array)$atts;


### PR DESCRIPTION
## Summary
- ensure HTML fragments keep allowed tags and strip disallowed ones
- check row groups auto-close or log when unbalanced
- flag unknown validation rules during template preflight

## Testing
- `phpunit tests/TemplateValidatorTest.php`
- `phpunit tests/RendererFragmentTest.php`
- `phpunit tests/RendererRowGroupTest.php`
- `phpunit tests/ValidatorRulesTest.php`
- `tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bf4a4ffa54832d872de5cd97fe1da5