### PR TITLE
Add timestamp timing checks for submissions

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -124,6 +124,19 @@ assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_HONEYPOT' || ok=1
 assert_grep tmp/uploads/eforms-private/eforms.log '"stealth":false' || ok=1
 record_result "honeypot: hard fail" $ok
 
+# 3c) Timing checks
+run_test test_timing_min_fill
+ok=0
+assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_MIN_FILL' || ok=1
+assert_grep tmp/mail.json 'alice@example.com' || ok=1
+record_result "timing: early submission soft fail" $ok
+
+run_test test_timing_expired
+ok=0
+assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_FORM_AGE' || ok=1
+assert_grep tmp/mail.json 'zed@example.com' || ok=1
+record_result "timing: expired form soft fail" $ok
+
 # 4) Validation missing required
 run_test test_validation_required
 ok=0

--- a/tests/test_timing_expired.php
+++ b/tests/test_timing_expired.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_LOG_LEVEL=1');
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instOld',
+    'timestamp' => time() - 1000,
+    'eforms_token' => 'tokOld',
+    'name' => 'Zed',
+    'email' => 'zed@example.com',
+    'message' => 'Hi',
+];
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();

--- a/tests/test_timing_min_fill.php
+++ b/tests/test_timing_min_fill.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_LOG_LEVEL=1');
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_COOKIE['eforms_t_contact_us'] = 'tokTS';
+
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instTS',
+    'timestamp' => time(),
+    'name' => 'Alice',
+    'email' => 'alice@example.com',
+    'message' => 'Hi',
+];
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();


### PR DESCRIPTION
## Summary
- enforce configurable min fill and max age using submitted timestamp
- log EFORMS_ERR_MIN_FILL and EFORMS_ERR_FORM_AGE and track soft-fail signals
- test early submission and expired form handling

## Testing
- `./tests/run.sh`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4e3fc83c832da55b4cf2bd34e80e