### PR TITLE
Enforce js_ok validation with optional hard failure

### DIFF
--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -142,6 +142,20 @@ class FormManager
                 ]);
             }
         }
+        $jsOk = $_POST['js_ok'] ?? '';
+        if ($jsOk !== '1') {
+            $meta = [
+                'form_id' => $formId,
+                'instance_id' => $_POST['instance_id'] ?? '',
+            ];
+            if (Config::get('security.js_hard_mode', false)) {
+                Logging::write('warn', 'EFORMS_ERR_JS_DISABLED', $meta);
+                $this->renderErrorAndExit($tpl, $formId, 'Security check failed.');
+            } else {
+                $softFails++;
+                Logging::write('warn', 'EFORMS_ERR_JS_DISABLED', $meta);
+            }
+        }
         $values = Validator::normalize($tpl, $_POST);
         $desc = Validator::descriptors($tpl);
         $val = Validator::validate($tpl, $desc, $values);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -161,6 +161,9 @@ add_filter('eforms_config', function (array $defaults) {
     if (getenv('EFORMS_HONEYPOT_RESPONSE')) {
         $defaults['security']['honeypot_response'] = getenv('EFORMS_HONEYPOT_RESPONSE');
     }
+    if (getenv('EFORMS_JS_HARD_MODE')) {
+        $defaults['security']['js_hard_mode'] = (getenv('EFORMS_JS_HARD_MODE') === '1');
+    }
     if (getenv('EFORMS_LOG_LEVEL')) {
         $defaults['logging']['level'] = (int) getenv('EFORMS_LOG_LEVEL');
     }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -137,6 +137,20 @@ assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_FORM_AGE' || ok=1
 assert_grep tmp/mail.json 'zed@example.com' || ok=1
 record_result "timing: expired form soft fail" $ok
 
+# 3d) JS disabled checks
+run_test test_js_soft
+ok=0
+assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_JS_DISABLED' || ok=1
+assert_grep tmp/mail.json 'alice@example.com' || ok=1
+record_result "js disabled: soft signal" $ok
+
+run_test test_js_hard
+ok=0
+assert_grep tmp/stdout.txt 'Security check failed\.' || ok=1
+! assert_grep tmp/mail.json 'alice@example.com' || ok=1
+assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_JS_DISABLED' || ok=1
+record_result "js disabled: hard fail" $ok
+
 # 4) Validation missing required
 run_test test_validation_required
 ok=0

--- a/tests/test_js_hard.php
+++ b/tests/test_js_hard.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_LOG_LEVEL=1');
+putenv('EFORMS_JS_HARD_MODE=1');
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_COOKIE['eforms_t_contact_us'] = 'tokJH1';
+
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instJH1',
+    'timestamp' => time() - 10,
+    'eforms_hp' => '',
+    'name' => 'Alice',
+    'email' => 'alice@example.com',
+    'message' => 'Hi',
+    'js_ok' => '0',
+];
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();
+

--- a/tests/test_js_soft.php
+++ b/tests/test_js_soft.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_LOG_LEVEL=1');
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_COOKIE['eforms_t_contact_us'] = 'tokJS1';
+
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instJS1',
+    'timestamp' => time() - 10,
+    'eforms_hp' => '',
+    'name' => 'Alice',
+    'email' => 'alice@example.com',
+    'message' => 'Hi',
+    'js_ok' => '0',
+];
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();
+


### PR DESCRIPTION
## Summary
- log and optionally hard fail when `js_ok` is not `1`
- allow tests to toggle `security.js_hard_mode` via env var
- cover soft vs hard JS-disabled cases in test suite

## Testing
- `./tests/run.sh`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4fe1c980832d92d0aa51c12636fa