### PR TITLE
Implement IP-based throttling with tests

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -64,6 +64,15 @@ class Config
         $cfg['logging']['file_max_size'] = self::clampInt($cfg['logging']['file_max_size'], 0, PHP_INT_MAX);
         $cfg['logging']['retention_days'] = self::clampInt($cfg['logging']['retention_days'], 1, 365);
 
+        // throttle
+        $cfg['throttle']['enable'] = (bool)($cfg['throttle']['enable'] ?? false);
+        $thr =& $cfg['throttle']['per_ip'];
+        $thr['max_per_minute'] = self::clampInt($thr['max_per_minute'] ?? 5, 1, 120);
+        $thr['cooldown_seconds'] = self::clampInt($thr['cooldown_seconds'] ?? 60, 10, 600);
+        $thr['hard_multiplier'] = (float)($thr['hard_multiplier'] ?? 3.0);
+        if ($thr['hard_multiplier'] < 1.5) $thr['hard_multiplier'] = 1.5;
+        if ($thr['hard_multiplier'] > 10.0) $thr['hard_multiplier'] = 10.0;
+
         // validation
         $cfg['validation']['max_fields_per_form'] = self::clampInt($cfg['validation']['max_fields_per_form'], 1, 1000);
         $cfg['validation']['max_options_per_group'] = self::clampInt($cfg['validation']['max_options_per_group'], 1, 1000);

--- a/src/Throttle.php
+++ b/src/Throttle.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class Throttle
+{
+    public static function check(string $ip): array
+    {
+        if (!Config::get('throttle.enable', false)) {
+            return ['state' => 'ok'];
+        }
+        $key = self::keyFromIp($ip);
+        if ($key === null) {
+            return ['state' => 'ok'];
+        }
+        $base = rtrim((string) Config::get('uploads.dir', ''), '/');
+        if ($base === '') {
+            return ['state' => 'ok'];
+        }
+        $dir = $base . '/throttle';
+        $h2 = substr($key, 0, 2);
+        $pathDir = $dir . '/' . $h2;
+        if (!is_dir($pathDir)) {
+            @mkdir($pathDir, 0700, true);
+        }
+        $file = $pathDir . '/' . $key . '.json';
+        $now = time();
+        $data = ['window_start' => $now, 'count' => 0, 'cooldown_until' => 0];
+        $fh = @fopen($file, 'c+');
+        if ($fh) {
+            flock($fh, LOCK_EX);
+            $raw = stream_get_contents($fh);
+            if ($raw !== false && $raw !== '') {
+                $json = json_decode($raw, true);
+                if (is_array($json)) {
+                    $data = array_merge($data, $json);
+                }
+            }
+            if (($now - (int) $data['window_start']) >= 60) {
+                $data['window_start'] = $now;
+                $data['count'] = 0;
+            }
+            $data['count']++;
+            $max = (int) Config::get('throttle.per_ip.max_per_minute', 5);
+            $cool = (int) Config::get('throttle.per_ip.cooldown_seconds', 60);
+            $mult = (float) Config::get('throttle.per_ip.hard_multiplier', 3.0);
+            $state = 'ok';
+            if ($now < (int) $data['cooldown_until']) {
+                $state = 'over';
+            }
+            if ($data['count'] > $max * $mult) {
+                $state = 'hard';
+            } elseif ($data['count'] > $max || $state === 'over') {
+                $state = 'over';
+                if ($now >= (int) $data['cooldown_until']) {
+                    $data['cooldown_until'] = $now + $cool;
+                }
+            }
+            ftruncate($fh, 0);
+            rewind($fh);
+            fwrite($fh, json_encode($data));
+            fflush($fh);
+            flock($fh, LOCK_UN);
+            fclose($fh);
+            @chmod($file, 0600);
+            return ['state' => $state, 'count' => $data['count']];
+        }
+        return ['state' => 'ok'];
+    }
+
+    public static function gc(): void
+    {
+        $base = rtrim((string) Config::get('uploads.dir', ''), '/');
+        if ($base === '') return;
+        $dir = $base . '/throttle';
+        if (!is_dir($dir)) return;
+        $cutoff = time() - 172800; // 2 days
+        foreach (glob($dir . '/*/*') ?: [] as $f) {
+            if (@filemtime($f) !== false && filemtime($f) < $cutoff) {
+                @unlink($f);
+            }
+        }
+        foreach (glob($dir . '/*', GLOB_ONLYDIR) ?: [] as $sub) {
+            if (count(glob($sub . '/*') ?: []) === 0) {
+                @rmdir($sub);
+            }
+        }
+    }
+
+    private static function keyFromIp(string $ip): ?string
+    {
+        $mode = Config::get('privacy.ip_mode', 'masked');
+        if ($mode === 'none' || $ip === '') {
+            return null;
+        }
+        $salt = (string) Config::get('privacy.ip_salt', '');
+        if ($mode === 'masked') {
+            $ip = self::maskIp($ip);
+        }
+        // 'hash' and 'full' use raw IP
+        return hash('sha256', $ip . $salt);
+    }
+
+    private static function maskIp(string $ip): string
+    {
+        if (str_contains($ip, ':')) {
+            $parts = explode(':', $ip);
+            $parts[count($parts) - 1] = '0';
+            return implode(':', $parts);
+        }
+        $parts = explode('.', $ip);
+        $parts[3] = '0';
+        return implode('.', $parts);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -197,6 +197,18 @@ add_filter('eforms_config', function (array $defaults) {
     if (getenv('EFORMS_RECAPTCHA_SECRET_KEY')) {
         $defaults['challenge']['recaptcha']['secret_key'] = getenv('EFORMS_RECAPTCHA_SECRET_KEY');
     }
+    if (getenv('EFORMS_THROTTLE_ENABLE')) {
+        $defaults['throttle']['enable'] = (getenv('EFORMS_THROTTLE_ENABLE') === '1');
+    }
+    if (getenv('EFORMS_THROTTLE_MAX_PER_MINUTE')) {
+        $defaults['throttle']['per_ip']['max_per_minute'] = (int) getenv('EFORMS_THROTTLE_MAX_PER_MINUTE');
+    }
+    if (getenv('EFORMS_THROTTLE_COOLDOWN_SECONDS')) {
+        $defaults['throttle']['per_ip']['cooldown_seconds'] = (int) getenv('EFORMS_THROTTLE_COOLDOWN_SECONDS');
+    }
+    if (getenv('EFORMS_THROTTLE_HARD_MULTIPLIER')) {
+        $defaults['throttle']['per_ip']['hard_multiplier'] = (float) getenv('EFORMS_THROTTLE_HARD_MULTIPLIER');
+    }
     return $defaults;
 });
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -220,6 +220,22 @@ ok=0
 assert_equal_file tmp/gc.txt 'empty' || ok=1
 record_result "upload: retention GC" $ok
 
+# 10) Throttle soft and hard
+EFORMS_THROTTLE_ENABLE=1 EFORMS_THROTTLE_MAX_PER_MINUTE=1 run_test test_throttle_soft_first
+EFORMS_THROTTLE_ENABLE=1 EFORMS_THROTTLE_MAX_PER_MINUTE=1 run_test_keep test_throttle_soft_second
+ok=0
+assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_THROTTLE' || ok=1
+assert_grep tmp/uploads/eforms-private/eforms.log '"state":"over"' || ok=1
+record_result "throttle: soft over-limit" $ok
+
+EFORMS_THROTTLE_ENABLE=1 EFORMS_THROTTLE_MAX_PER_MINUTE=1 EFORMS_THROTTLE_HARD_MULTIPLIER=1.5 run_test test_throttle_hard_first
+EFORMS_THROTTLE_ENABLE=1 EFORMS_THROTTLE_MAX_PER_MINUTE=1 EFORMS_THROTTLE_HARD_MULTIPLIER=1.5 run_test_keep test_throttle_hard_second
+ok=0
+assert_grep tmp/stdout.txt 'Security check failed\.' || ok=1
+! assert_grep tmp/mail.json 'alice@example.com.*alice@example.com' || ok=1
+assert_grep tmp/uploads/eforms-private/eforms.log '"state":"hard"' || ok=1
+record_result "throttle: hard over-limit" $ok
+
 echo
 echo "Summary: $pass passed, $fail failed"
 exit $(( fail > 0 ))

--- a/tests/test_throttle_hard_first.php
+++ b/tests/test_throttle_hard_first.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_LOG_LEVEL=1');
+putenv('EFORMS_THROTTLE_ENABLE=1');
+putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
+putenv('EFORMS_THROTTLE_HARD_MULTIPLIER=1.5');
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+$_COOKIE['eforms_t_contact_us'] = 'tokH1';
+
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instH1',
+    'timestamp' => time() - 10,
+    'name' => 'Alice',
+    'email' => 'alice@example.com',
+    'message' => 'Hello',
+    'js_ok' => '1',
+];
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();

--- a/tests/test_throttle_hard_second.php
+++ b/tests/test_throttle_hard_second.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_LOG_LEVEL=1');
+putenv('EFORMS_THROTTLE_ENABLE=1');
+putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
+putenv('EFORMS_THROTTLE_HARD_MULTIPLIER=1.5');
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+$_COOKIE['eforms_t_contact_us'] = 'tokH2';
+
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instH2',
+    'timestamp' => time() - 10,
+    'name' => 'Alice',
+    'email' => 'alice@example.com',
+    'message' => 'Hello again',
+    'js_ok' => '1',
+];
+
+$fm = new \EForms\FormManager();
+$fm->handleSubmit();

--- a/tests/test_throttle_soft_first.php
+++ b/tests/test_throttle_soft_first.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_LOG_LEVEL=1');
+putenv('EFORMS_THROTTLE_ENABLE=1');
+putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+$_COOKIE['eforms_t_contact_us'] = 'tokS1';
+
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instS1',
+    'timestamp' => time() - 10,
+    'name' => 'Alice',
+    'email' => 'alice@example.com',
+    'message' => 'Hello',
+    'js_ok' => '1',
+];
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();

--- a/tests/test_throttle_soft_second.php
+++ b/tests/test_throttle_soft_second.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_LOG_LEVEL=1');
+putenv('EFORMS_THROTTLE_ENABLE=1');
+putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+$_COOKIE['eforms_t_contact_us'] = 'tokS2';
+
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instS2',
+    'timestamp' => time() - 10,
+    'name' => 'Alice',
+    'email' => 'alice@example.com',
+    'message' => 'Hello again',
+    'js_ok' => '1',
+];
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();


### PR DESCRIPTION
## Summary
- add file-based throttle service storing per-IP counters under uploads
- invoke throttle in FormManager before validation and collect garbage
- exercise soft and hard throttling paths in integration tests

## Testing
- `./tests/run.sh`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5476ca5c832d9f8d261ec8cb9830