### PR TITLE
Add tests for challenge verification soft-fail handling

### DIFF
--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -108,6 +108,11 @@ class FormManager
             if ($ver['ok'] ?? false) {
                 $softFailCount = 0;
             } elseif (!($ver['unconfigured'] ?? false)) {
+                $softFailCount++;
+                Logging::write('warn', 'EFORMS_ERR_CHALLENGE_FAILED', [
+                    'form_id' => $formId,
+                    'instance_id' => $_POST['instance_id'] ?? '',
+                ]);
                 $this->renderErrorAndExit($tpl, $formId, 'Security challenge failed.');
             }
         }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -104,6 +104,21 @@ ok=0
 assert_grep tmp/mail.json 'zed@example.com' || ok=1
 record_result "cookie policy challenge: allow when unconfigured" $ok
 
+# 2c) Challenge verification
+run_test test_challenge_success
+ok=0
+assert_grep tmp/redirect.txt '"status":303' || ok=1
+assert_grep tmp/mail.json 'zed@example.com' || ok=1
+assert_equal_file tmp/uploads/eforms-private/eforms.log '' || ok=1
+record_result "challenge success clears soft signal" $ok
+
+run_test test_challenge_fail
+ok=0
+assert_grep tmp/stdout.txt 'Security challenge failed\.' || ok=1
+assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_CHALLENGE_FAILED' || ok=1
+! assert_grep tmp/mail.json 'zed@example.com' || ok=1
+record_result "challenge failure logged" $ok
+
 # 3) Honeypot stealth success
 run_test test_honeypot
 ok=0

--- a/tests/test_challenge_fail.php
+++ b/tests/test_challenge_fail.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_COOKIE_MISSING_POLICY=challenge');
+putenv('EFORMS_CHALLENGE_MODE=auto');
+putenv('EFORMS_CHALLENGE_PROVIDER=turnstile');
+putenv('EFORMS_TURNSTILE_SITE_KEY=site');
+putenv('EFORMS_TURNSTILE_SECRET_KEY=secret');
+putenv('EFORMS_LOG_LEVEL=1');
+require __DIR__ . '/bootstrap.php';
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instCHFAIL',
+    'timestamp' => time() - 5,
+    'eforms_hp' => '',
+    'js_ok' => '1',
+    'name' => 'Zed',
+    'email' => 'zed@example.com',
+    'message' => 'Ping',
+    'cf-turnstile-response' => 'fail',
+];
+$fm = new \EForms\FormManager();
+$fm->handleSubmit();

--- a/tests/test_challenge_success.php
+++ b/tests/test_challenge_success.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_COOKIE_MISSING_POLICY=challenge');
+putenv('EFORMS_CHALLENGE_MODE=auto');
+putenv('EFORMS_CHALLENGE_PROVIDER=turnstile');
+putenv('EFORMS_TURNSTILE_SITE_KEY=site');
+putenv('EFORMS_TURNSTILE_SECRET_KEY=secret');
+putenv('EFORMS_LOG_LEVEL=1');
+require __DIR__ . '/bootstrap.php';
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instCHPASS',
+    'timestamp' => time() - 5,
+    'eforms_hp' => '',
+    'js_ok' => '1',
+    'name' => 'Zed',
+    'email' => 'zed@example.com',
+    'message' => 'Ping',
+    'cf-turnstile-response' => 'pass',
+];
+$fm = new \EForms\FormManager();
+$fm->handleSubmit();


### PR DESCRIPTION
## Summary
- log challenge failures and increment soft-fail count
- test challenge success clears soft signals
- test challenge failures are logged and block submission

## Testing
- `./tests/run.sh`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5b384118832db10c130acc4c5e06