### PR TITLE
Add explicit JS hard-mode toggle for soft JS test

### DIFF
--- a/tests/test_js_soft.php
+++ b/tests/test_js_soft.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 putenv('EFORMS_LOG_LEVEL=1');
+putenv('EFORMS_JS_HARD_MODE=0');
 require __DIR__ . '/bootstrap.php';
 
 $_SERVER['REQUEST_METHOD'] = 'POST';


### PR DESCRIPTION
## Summary
- Ensure soft JS-disabled scenario explicitly disables hard mode

## Testing
- `bash tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bf6bc95a04832db9315f80868fc757