### PR TITLE
Support configurable email templates

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -124,7 +124,7 @@ electronic_forms - Spec
 		- Minimal shape:
 			- id (slug), version (string), title (string)
 			- success { mode:"inline"|"redirect", redirect_url?, message? }
-			- email { to, subject, email_template, include_fields[], display_format_tel? }
+                    - email { to, subject, email_template ("foo" -> templates/email/foo.*), include_fields[], display_format_tel? }
 				- display_format_tel enum: "xxx-xxx-xxxx" (default), "(xxx) xxx-xxxx", "xxx.xxx.xxxx" (any other value falls back to default at runtime)
 			- fields[] of field objects (see 5.1)
 			- submit_button_text (string)
@@ -838,10 +838,8 @@ uploads.*
 	- Cookie mode does not require JS
 	
 24. EMAIL TEMPLATES (REGISTRY)
-	- Files:
-		- /templates/email/default.txt.php
-		- /templates/email/default.html.php (used only when email.html=true)
-	- JSON "email_template": "default" maps to those files
+        - Files live in /templates/email/{name}.txt.php and {name}.html.php
+        - JSON "email_template": "foo" selects those files ("foo.html.php" when email.html=true); missing or unknown names raise an error
 	- Template inputs:
 		- form_id, instance_id, submitted_at (UTC ISO-8601)
 		- fields (canonical values only, keyed by field key)

--- a/src/Emailer.php
+++ b/src/Emailer.php
@@ -48,7 +48,14 @@ class Emailer
 
     private static function renderBody(array $tpl, array $canonical, array $meta, bool $html): string
     {
-        $file = __DIR__ . '/../templates/email/' . ($html ? 'default.html.php' : 'default.txt.php');
+        $template = $tpl['email']['email_template'] ?? 'default';
+        if (!is_string($template) || !preg_match('/^[a-z0-9_-]+$/', $template)) {
+            throw new \RuntimeException('Invalid email template');
+        }
+        $file = __DIR__ . '/../templates/email/' . $template . ($html ? '.html.php' : '.txt.php');
+        if (!is_file($file)) {
+            throw new \RuntimeException('Email template not found');
+        }
         $allowedMeta = ['submitted_at','ip','form_id','instance_id'];
         $include_fields = $tpl['email']['include_fields'] ?? [];
         $include_fields = array_values(array_filter($include_fields, function ($k) use ($canonical, $meta, $allowedMeta) {

--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -69,6 +69,17 @@ class TemplateValidator
             }
         }
 
+        $tmpl = $email['email_template'] ?? 'default';
+        if (!is_string($tmpl) || !preg_match('/^[a-z0-9_-]+$/', $tmpl)) {
+            $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>'email.email_template'];
+        } else {
+            $base = __DIR__ . '/../templates/email/' . $tmpl;
+            if (!is_file($base . '.txt.php') && !is_file($base . '.html.php')) {
+                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>'email.email_template'];
+            }
+        }
+        $email['email_template'] = $tmpl;
+
         // fields
         $fields = is_array($tpl['fields'] ?? null) ? $tpl['fields'] : [];
         $seenKeys = [];

--- a/templates/email/default.html.php
+++ b/templates/email/default.html.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 defined('ABSPATH') || exit;
+// Rendered when email.email_template="default".
 ?>
 <p>
 Form: <?= htmlspecialchars($meta['form_id'] ?? '', ENT_QUOTES) ?><br>

--- a/templates/email/default.txt.php
+++ b/templates/email/default.txt.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 defined('ABSPATH') || exit;
 
+// Rendered when email.email_template="default".
 echo 'Form: ' . ($meta['form_id'] ?? '') . "\n";
 echo 'Instance: ' . ($meta['instance_id'] ?? '') . "\n";
 echo 'Submitted: ' . ($meta['submitted_at'] ?? '') . "\n\n";

--- a/tests/RendererRowGroupTest.php
+++ b/tests/RendererRowGroupTest.php
@@ -28,7 +28,7 @@ final class RendererRowGroupTest extends TestCase
             'version' => '1',
             'title' => 't',
             'success' => ['mode' => 'inline'],
-            'email' => ['to' => 'a@example.com', 'subject' => 's', 'email_template' => '', 'include_fields' => []],
+            'email' => ['to' => 'a@example.com', 'subject' => 's', 'email_template' => 'default', 'include_fields' => []],
             'fields' => [
                 ['type' => 'row_group', 'mode' => 'start', 'tag' => 'section', 'class' => 'custom'],
                 ['type' => 'name', 'key' => 'name', 'label' => 'Name'],
@@ -62,7 +62,7 @@ final class RendererRowGroupTest extends TestCase
             'version' => '1',
             'title' => 't',
             'success' => ['mode' => 'inline'],
-            'email' => ['to' => 'a@example.com', 'subject' => 's', 'email_template' => '', 'include_fields' => []],
+            'email' => ['to' => 'a@example.com', 'subject' => 's', 'email_template' => 'default', 'include_fields' => []],
             'fields' => [
                 ['type' => 'row_group', 'mode' => 'end', 'tag' => 'section'],
                 ['type' => 'name', 'key' => 'name', 'label' => 'Name'],

--- a/tests/TemplateValidatorTest.php
+++ b/tests/TemplateValidatorTest.php
@@ -76,6 +76,17 @@ class TemplateValidatorTest extends TestCase
         }
     }
 
+    public function testUnknownEmailTemplate(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['email']['email_template'] = 'bogus';
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $paths = array_column($res['errors'], 'path');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_ENUM, $codes);
+        $this->assertContains('email.email_template', $paths);
+    }
+
     public function testEmptyAcceptIntersection(): void
     {
         $tpl = $this->baseTpl();


### PR DESCRIPTION
## Summary
- Allow selecting email templates via `email.email_template` and validate against available files
- Document and comment default templates to show selection by slug
- Check template slug existence during structural validation and adjust tests

## Testing
- `phpunit tests/TemplateValidatorTest.php`
- `tests/run.sh` *(fails: timing: expired form soft fail)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa21ce328832dbd72379280bd3aba