### PR TITLE
Sanitize logged user agent and add tests

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -59,4 +59,14 @@ class Helpers
         $data[8] = chr(ord($data[8]) & 0x3f | 0x80);
         return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
     }
+
+    public static function sanitize_user_agent(string $ua): string
+    {
+        $ua = preg_replace('/[^\x20-\x7E]/', '', $ua) ?? '';
+        $max = (int) Config::get('security.ua_maxlen', 256);
+        if ($max > 0 && strlen($ua) > $max) {
+            $ua = substr($ua, 0, $max);
+        }
+        return $ua;
+    }
 }

--- a/src/Logging.php
+++ b/src/Logging.php
@@ -90,7 +90,10 @@ class Logging
         if (Config::get('logging.headers', false)) {
             $headers = [];
             if (!empty($_SERVER['HTTP_USER_AGENT'])) {
-                $headers['user_agent'] = $_SERVER['HTTP_USER_AGENT'];
+                $ua = Helpers::sanitize_user_agent((string) $_SERVER['HTTP_USER_AGENT']);
+                if ($ua !== '') {
+                    $headers['user_agent'] = $ua;
+                }
             }
             $origin = $_SERVER['HTTP_ORIGIN'] ?? ($_SERVER['HTTP_REFERER'] ?? '');
             if ($origin !== '') {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -182,6 +182,9 @@ add_filter('eforms_config', function (array $defaults) {
     if (getenv('EFORMS_LOG_LEVEL')) {
         $defaults['logging']['level'] = (int) getenv('EFORMS_LOG_LEVEL');
     }
+    if (getenv('EFORMS_LOG_HEADERS')) {
+        $defaults['logging']['headers'] = (getenv('EFORMS_LOG_HEADERS') === '1');
+    }
     if (getenv('EFORMS_UPLOAD_MAX_FILE_BYTES')) {
         $defaults['uploads']['max_file_bytes'] = (int) getenv('EFORMS_UPLOAD_MAX_FILE_BYTES');
     }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -225,6 +225,12 @@ assert_grep tmp/uploads/eforms-private/eforms.log '"severity":"error"' || ok=1
 assert_grep tmp/uploads/eforms-private/eforms.log '"code":"EFORMS_EMAIL_FAIL"' || ok=1
 record_result "logging: SMTP failure" $ok
 
+# 8b) Logging User-Agent sanitization
+EFORMS_LOG_HEADERS=1 run_test test_logging_user_agent
+ok=0
+assert_grep tmp/ua.txt '^A{256}$' || ok=1
+record_result "logging: user-agent sanitized" $ok
+
 # 9) Upload valid
 run_test test_upload_valid
 ok=0

--- a/tests/test_logging_user_agent.php
+++ b/tests/test_logging_user_agent.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['HTTP_USER_AGENT'] = str_repeat('A', 300) . "\x01\x02B";
+\EForms\Logging::write('error', 'EFORMS_TEST', []);
+
+$logfile = __DIR__ . '/tmp/uploads/eforms-private/eforms.log';
+$line = trim((string) file_get_contents($logfile));
+$data = json_decode($line, true);
+$ua = $data['headers']['user_agent'] ?? '';
+file_put_contents(__DIR__ . '/tmp/ua.txt', $ua);


### PR DESCRIPTION
## Summary
- Strip non-printable characters from the User-Agent and truncate to the configured length before logging
- Add helper for User-Agent normalization and unit test covering long/non-printable inputs

## Testing
- `./tests/run.sh`
- `phpunit -c phpunit.xml.dist` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa7af5938832d8850b4222386b017