### PR TITLE
Enforce multipart boundaries

### DIFF
--- a/eforms.php
+++ b/eforms.php
@@ -134,10 +134,24 @@ namespace {
                 exit;
             }
             $ct = $_SERVER['CONTENT_TYPE'] ?? '';
-            if ($ct && !preg_match('~^(application/x-www-form-urlencoded|multipart/form-data)(;|$)~i', $ct)) {
-                status_header(415);
-                echo 'Unsupported Media Type';
-                exit;
+            if ($ct) {
+                if (stripos($ct, 'multipart/form-data') === 0) {
+                    if (!preg_match('~boundary=(?:"([^"]+)"|([^;]+))~i', $ct, $m)) {
+                        status_header(415);
+                        echo 'Unsupported Media Type';
+                        exit;
+                    }
+                    $boundary = $m[1] !== '' ? $m[1] : ($m[2] ?? '');
+                    if ($boundary === '') {
+                        status_header(415);
+                        echo 'Unsupported Media Type';
+                        exit;
+                    }
+                } elseif (!preg_match('~^application/x-www-form-urlencoded($|;)~i', $ct)) {
+                    status_header(415);
+                    echo 'Unsupported Media Type';
+                    exit;
+                }
             }
             // Delegate to FormManager for full submit pipeline.
             $fm = new FormManager();

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -84,6 +84,26 @@ assert_equal_file tmp/status_code.txt "415" || ok=1
 assert_grep tmp/stdout.txt "Unsupported Media Type" || ok=1
 record_result "submit 415 on bad content-type" $ok
 
+# 1b) Submit route: multipart boundary valid
+run_test test_submit_boundary_valid
+ok=0
+assert_equal_file tmp/status_code.txt "" || ok=1
+record_result "submit multipart valid boundary" $ok
+
+# 1c) Submit route: multipart boundary missing
+run_test test_submit_boundary_missing
+ok=0
+assert_equal_file tmp/status_code.txt "415" || ok=1
+assert_grep tmp/stdout.txt "Unsupported Media Type" || ok=1
+record_result "submit multipart missing boundary" $ok
+
+# 1d) Submit route: multipart boundary empty
+run_test test_submit_boundary_empty
+ok=0
+assert_equal_file tmp/status_code.txt "415" || ok=1
+assert_grep tmp/stdout.txt "Unsupported Media Type" || ok=1
+record_result "submit multipart empty boundary" $ok
+
 # 2) Origin soft default: allow cross origin
 run_test test_origin_soft
 ok=0

--- a/tests/test_submit_boundary_empty.php
+++ b/tests/test_submit_boundary_empty.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+global $TEST_QUERY_VARS;
+$TEST_QUERY_VARS['eforms_submit'] = 1;
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['CONTENT_TYPE'] = 'multipart/form-data; boundary=';
+
+ob_start();
+do_action('template_redirect');
+$out = ob_get_clean();
+file_put_contents(__DIR__ . '/tmp/out_boundary_empty.txt', $out);

--- a/tests/test_submit_boundary_missing.php
+++ b/tests/test_submit_boundary_missing.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+global $TEST_QUERY_VARS;
+$TEST_QUERY_VARS['eforms_submit'] = 1;
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['CONTENT_TYPE'] = 'multipart/form-data';
+
+ob_start();
+do_action('template_redirect');
+$out = ob_get_clean();
+file_put_contents(__DIR__ . '/tmp/out_boundary_missing.txt', $out);

--- a/tests/test_submit_boundary_valid.php
+++ b/tests/test_submit_boundary_valid.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+global $TEST_QUERY_VARS;
+$TEST_QUERY_VARS['eforms_submit'] = 1;
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['CONTENT_TYPE'] = 'multipart/form-data; boundary=foo';
+
+ob_start();
+do_action('template_redirect');
+$out = ob_get_clean();
+file_put_contents(__DIR__ . '/tmp/out_boundary_valid.txt', $out);


### PR DESCRIPTION
## Summary
- require multipart/form-data requests to include a non-empty boundary parameter
- add regression tests for valid, missing, and empty boundaries

## Testing
- `tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0387acbd0832db30f5619b11ecbdd