### PR TITLE
Validate autocomplete tokens and enforce size range

### DIFF
--- a/tests/TemplateValidatorTest.php
+++ b/tests/TemplateValidatorTest.php
@@ -160,4 +160,36 @@ class TemplateValidatorTest extends TestCase
         $codes = array_column($res['errors'], 'code');
         $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_ENUM, $codes);
     }
+
+    public function testAutocompleteInvalid(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['autocomplete'] = 'not-a-token';
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $paths = array_column($res['errors'], 'path');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_ENUM, $codes);
+        $this->assertContains('fields[0].autocomplete', $paths);
+        $this->assertNull($res['context']['fields'][0]['autocomplete']);
+    }
+
+    public function testSizeValidation(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['size'] = 'big';
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $paths = array_column($res['errors'], 'path');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_TYPE, $codes);
+        $this->assertContains('fields[0].size', $paths);
+
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['size'] = 0;
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $paths = array_column($res['errors'], 'path');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_ENUM, $codes);
+        $this->assertContains('fields[0].size', $paths);
+        $this->assertNull($res['context']['fields'][0]['size']);
+    }
 }


### PR DESCRIPTION
## Summary
- validate `autocomplete` against WHATWG token list plus on/off
- enforce `size` within 1–100 and flag out-of-range values
- add unit tests for invalid `autocomplete` and `size`

## Testing
- `phpunit tests/TemplateValidatorTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0445f20e8832da176d4c349da68f4