### PR TITLE
Support per-field upload limits and step attribute

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -87,7 +87,7 @@ electronic_forms - Spec
 5. TEMPLATE MODEL
 	1. Field Generation and Namespacing
 		- Template field keys may include:
-			- key (slug), type, label?, placeholder?, required (bool), size (1-100; text-like only), autocomplete?, options (for radios/checkboxes/select), class?, max_length?, before_html?, after_html?
+                        - key (slug), type, label?, placeholder?, required (bool), size (1-100; text-like only), autocomplete?, options (for radios/checkboxes/select), class?, max_length?, min?, max?, step?, pattern?, before_html?, after_html?
 		- key (slug): required; must match ^[a-z0-9_:-]{1,64}$ (lowercase); [] prohibited to prevent PHP array collisions; reserved keys remain disallowed.
 		- autocomplete: exactly one token is allowed. The literal "on"/"off" are accepted as-is. All other values must match the WHATWG tokens (e.g., name, given-name, family-name, email, tel, postal-code, street-address, address-line1, address-line2, organization, …). Invalid tokens are dropped.
 		- size: 1-100; ignored for non-text types.
@@ -103,7 +103,7 @@ electronic_forms - Spec
 			- Attributes: class for all listed elements; for <a> allow href and class only.
 			- Allowed URL schemes for <a href> are restricted to http, https, and mailto (pass ['http','https','mailto'] as the third wp_kses() arg).
 			- No inline styles. May not cross row_group boundaries.
-		- For type=file/files fields, optional properties are supported: accept[], max_file_bytes, max_files (files only), and email_attach (bool).
+                - For type=file/files fields, optional properties are supported: accept[], max_file_bytes, max_files (files only), and email_attach (bool). max_file_bytes and max_files override the global upload limits for that field.
 		- Attribute emission list (summary): maxlength, min, max, step, minlength, pattern, inputmode, multiple, and accept are emitted when applicable from the template/registry traits.
 		- Client-side attribute mirroring (UX hints only): the Renderer mirrors server limits as HTML attributes - max_length -> maxlength, min/max/step for numeric/date types, and min_length -> minlength (when present in a future template). These attributes never relax server rules; server validation remains authoritative.
 		- Typing/editing aids: the Renderer emits inputmode, pattern (hints only), and editing helpers per field type (see 11).

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -249,6 +249,7 @@ class Renderer
                     if ($f['max'] !== null) $html .= ' max="' . \esc_attr((string)$f['max']) . '"';
                     if (!empty($f['pattern'])) $html .= ' pattern="' . \esc_attr($f['pattern']) . '"';
                     if (!empty($f['size'])) $html .= ' size="' . (int)$f['size'] . '"';
+                    if ($f['step'] !== null) $html .= ' step="' . \esc_attr((string)$f['step']) . '"';
                     $html .= $extra . $errAttr . $extraHint . '>';
                     break;
             }

--- a/src/Uploads.php
+++ b/src/Uploads.php
@@ -65,6 +65,10 @@ class Uploads
                 $accept = [];
             }
             $accept = array_intersect($accept, $allowedGlobal);
+            $fieldMaxFile = isset($f['max_file_bytes']) && is_int($f['max_file_bytes']) ? $f['max_file_bytes'] : $maxFile;
+            $fieldMaxFiles = $type === 'files'
+                ? (isset($f['max_files']) && is_int($f['max_files']) ? $f['max_files'] : $maxFiles)
+                : 1;
             $fieldBytes = 0;
             $fieldCount = 0;
             foreach ($items as $it) {
@@ -74,7 +78,7 @@ class Uploads
                 if ($err !== UPLOAD_ERR_OK || $size <= 0 || $name === '') {
                     continue;
                 }
-                if ($size > $maxFile) {
+                if ($size > $fieldMaxFile) {
                     $errors[$k][] = 'File too large.';
                     continue;
                 }
@@ -106,7 +110,7 @@ class Uploads
             if ($fieldBytes > $maxFieldBytes) {
                 $errors[$k][] = 'Total upload size exceeded.';
             }
-            if ($fieldCount > $maxFiles || ($type === 'file' && $fieldCount > 1)) {
+            if ($fieldCount > $fieldMaxFiles) {
                 $errors[$k][] = 'Too many files.';
             }
         }

--- a/tests/RendererStepTest.php
+++ b/tests/RendererStepTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Config;
+use EForms\Renderer;
+
+final class RendererStepTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $boot = $ref->getProperty('bootstrapped');
+        $boot->setAccessible(true);
+        $boot->setValue(false);
+        $data = $ref->getProperty('data');
+        $data->setAccessible(true);
+        $data->setValue([]);
+        Config::bootstrap();
+    }
+
+    public function testStepAttributeMirrored(): void
+    {
+        $tpl = [
+            'id' => 't1',
+            'version' => '1',
+            'title' => 't',
+            'success' => ['mode' => 'inline'],
+            'email' => ['to' => 'a@example.com', 'subject' => 's', 'email_template' => 'default', 'include_fields' => []],
+            'fields' => [
+                ['type' => 'name', 'key' => 'age', 'label' => 'Age', 'step' => 5],
+            ],
+            'submit_button_text' => 'Send',
+            'rules' => [],
+        ];
+        $meta = [
+            'form_id' => 'f1',
+            'instance_id' => 'i1',
+            'timestamp' => time(),
+            'cacheable' => true,
+            'client_validation' => false,
+            'action' => '#',
+            'hidden_token' => null,
+            'enctype' => 'application/x-www-form-urlencoded',
+        ];
+        $html = Renderer::form($tpl, $meta, [], []);
+        $this->assertStringContainsString('step="5"', $html);
+    }
+}

--- a/tests/TemplateValidatorTest.php
+++ b/tests/TemplateValidatorTest.php
@@ -192,4 +192,16 @@ class TemplateValidatorTest extends TestCase
         $this->assertContains('fields[0].size', $paths);
         $this->assertNull($res['context']['fields'][0]['size']);
     }
+
+    public function testFileLimitsAndStepAllowed(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['step'] = 5;
+        $tpl['fields'][] = ['type' => 'file', 'key' => 'up1', 'max_file_bytes' => 100];
+        $tpl['fields'][] = ['type' => 'files', 'key' => 'up2', 'max_files' => 2];
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertNotContains(TemplateValidator::EFORMS_ERR_SCHEMA_UNKNOWN_KEY, $codes);
+        $this->assertTrue($res['ok']);
+    }
 }

--- a/tests/UploadsLimitTest.php
+++ b/tests/UploadsLimitTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Uploads;
+
+final class UploadsLimitTest extends TestCase
+{
+    public function testMaxFileBytesPerField(): void
+    {
+        $tpl = [
+            'fields' => [
+                ['type' => 'file', 'key' => 'up', 'max_file_bytes' => 50, 'accept' => ['pdf']],
+            ],
+        ];
+        $tmp = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp, "%PDF-1.4\n%\xE2\xE3\xCF\xD3\n" . str_repeat('A', 100)); // >50 bytes
+        $files = [
+            'up' => [
+                'name' => 'a.pdf',
+                'type' => 'application/pdf',
+                'tmp_name' => $tmp,
+                'error' => UPLOAD_ERR_OK,
+                'size' => filesize($tmp),
+            ],
+        ];
+        $res = Uploads::normalizeAndValidate($tpl, $files);
+        $this->assertArrayHasKey('up', $res['errors']);
+        $this->assertSame('File too large.', $res['errors']['up'][0]);
+        @unlink($tmp);
+    }
+
+    public function testMaxFilesPerField(): void
+    {
+        $tpl = [
+            'fields' => [
+                ['type' => 'files', 'key' => 'docs', 'max_files' => 1, 'accept' => ['pdf']],
+            ],
+        ];
+        $tmp1 = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp1, "%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+        $tmp2 = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp2, "%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+        $files = [
+            'docs' => [
+                'name' => ['a.pdf', 'b.pdf'],
+                'type' => ['application/pdf', 'application/pdf'],
+                'tmp_name' => [$tmp1, $tmp2],
+                'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_OK],
+                'size' => [filesize($tmp1), filesize($tmp2)],
+            ],
+        ];
+        $res = Uploads::normalizeAndValidate($tpl, $files);
+        $this->assertArrayHasKey('docs', $res['errors']);
+        $this->assertSame('Too many files.', $res['errors']['docs'][0]);
+        @unlink($tmp1);
+        @unlink($tmp2);
+    }
+}


### PR DESCRIPTION
## Summary
- allow `max_file_bytes`, `max_files`, and `step` in template validation
- enforce per-field file limits and mirror `step` in rendering
- document new options and add test coverage

## Testing
- `phpunit tests/TemplateValidatorTest.php tests/RendererFragmentTest.php tests/RendererRowGroupTest.php tests/UploadsLimitTest.php tests/RendererStepTest.php`
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c048ead3e4832d97005ebab38117b8