### PR TITLE
Ensure unique upload filenames per email

### DIFF
--- a/src/Uploads.php
+++ b/src/Uploads.php
@@ -127,8 +127,10 @@ class Uploads
         if ($base === '') {
             return $out;
         }
+        $names = [];
         foreach ($files as $k => $list) {
             foreach ($list as $item) {
+                $safeName = self::uniqueName($item['original_name_safe'], $names);
                 $rel = self::buildPath($base, $item['tmp_name'], $item['slug'], $item['ext']);
                 $dest = $base . '/' . $rel;
                 $dir = dirname($dest);
@@ -144,7 +146,7 @@ class Uploads
                     'size' => $item['size'],
                     'mime' => $item['mime'],
                     'original_name' => $item['original_name'],
-                    'original_name_safe' => $item['original_name_safe'],
+                    'original_name_safe' => $safeName,
                 ];
             }
         }
@@ -234,6 +236,20 @@ class Uploads
         $extSafe = strtolower($ext);
         $originalSafe = $base . ($extSafe !== '' ? '.' . $extSafe : '');
         return [$base, $extSafe, $originalSafe];
+    }
+
+    private static function uniqueName(string $name, array &$used): string
+    {
+        $candidate = $name;
+        $i = 1;
+        while (isset($used[$candidate])) {
+            $i++;
+            $base = pathinfo($name, PATHINFO_FILENAME);
+            $ext = pathinfo($name, PATHINFO_EXTENSION);
+            $candidate = $base . ' (' . $i . ')' . ($ext !== '' ? '.' . $ext : '');
+        }
+        $used[$candidate] = true;
+        return $candidate;
     }
 
     private static function buildPath(string $baseDir, string $tmp, string $slug, string $ext): string

--- a/tests/UploadsNameDedupTest.php
+++ b/tests/UploadsNameDedupTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Uploads;
+use EForms\Config;
+
+final class UploadsNameDedupTest extends TestCase
+{
+    public function testDuplicateNamesAreUniquified(): void
+    {
+        Config::bootstrap();
+        $tpl = [
+            'fields' => [
+                ['type' => 'files', 'key' => 'docs', 'accept' => ['pdf']],
+            ],
+        ];
+        $tmp1 = tempnam(sys_get_temp_dir(), 'up');
+        $tmp2 = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp1, "%PDF-1.4\n");
+        file_put_contents($tmp2, "%PDF-1.4\n");
+        $files = [
+            'docs' => [
+                'name' => ['report.pdf', 'report.pdf'],
+                'type' => ['application/pdf', 'application/pdf'],
+                'tmp_name' => [$tmp1, $tmp2],
+                'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_OK],
+                'size' => [filesize($tmp1), filesize($tmp2)],
+            ],
+        ];
+        $res = Uploads::normalizeAndValidate($tpl, $files);
+        $stored = Uploads::store($res['files']);
+        $names = array_column($stored['docs'], 'original_name_safe');
+        $this->assertSame(['report.pdf', 'report (2).pdf'], $names);
+        Uploads::deleteStored($stored);
+        @unlink($tmp1);
+        @unlink($tmp2);
+    }
+}


### PR DESCRIPTION
## Summary
- Deduplicate uploaded filenames per email, appending " (n)" before the extension when conflicts occur
- Add regression test to verify unique sanitized filenames

## Testing
- `phpunit tests/UploadsNameDedupTest.php`
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c0526d5258832d9f3baac8c0aaabdf