### PR TITLE
Add configurable fail2ban logging targets with rotation

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -63,6 +63,20 @@ class Config
         $cfg['logging']['on_failure_canonical'] = (bool)$cfg['logging']['on_failure_canonical'];
         $cfg['logging']['file_max_size'] = self::clampInt($cfg['logging']['file_max_size'], 0, PHP_INT_MAX);
         $cfg['logging']['retention_days'] = self::clampInt($cfg['logging']['retention_days'], 1, 365);
+        $f2b =& $cfg['logging']['fail2ban'];
+        $f2b['enable'] = (bool)($f2b['enable'] ?? false);
+        $f2b['target'] = in_array($f2b['target'], ['error_log','syslog','file'], true) ? $f2b['target'] : 'error_log';
+        $f2b['file'] = is_string($f2b['file']) ? $f2b['file'] : null;
+        $f2b['file_max_size'] = self::clampInt(
+            $f2b['file_max_size'] ?? $cfg['logging']['file_max_size'],
+            0,
+            PHP_INT_MAX
+        );
+        $f2b['retention_days'] = self::clampInt(
+            $f2b['retention_days'] ?? $cfg['logging']['retention_days'],
+            1,
+            365
+        );
 
         // throttle
         $cfg['throttle']['enable'] = (bool)($cfg['throttle']['enable'] ?? false);

--- a/tests/Fail2banLoggingTest.php
+++ b/tests/Fail2banLoggingTest.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms {
+    function syslog($level, $message) {
+        global $TEST_F2B_SYSLOG;
+        $TEST_F2B_SYSLOG[] = [$level, $message];
+    }
+}
+
+namespace {
+// bootstrap handled by phpunit.xml
+
+use PHPUnit\Framework\TestCase;
+use EForms\Config;
+use EForms\Logging;
+
+final class Fail2banLoggingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $TEST_FILTERS, $TEST_F2B_SYSLOG, $TEST_ARTIFACTS;
+        $TEST_F2B_SYSLOG = [];
+        $TEST_FILTERS = [];
+        file_put_contents($TEST_ARTIFACTS['log_file'], '');
+    }
+
+    private function boot(array $opts): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $boot = $ref->getProperty('bootstrapped');
+        $boot->setAccessible(true);
+        $boot->setValue(false);
+        $data = $ref->getProperty('data');
+        $data->setAccessible(true);
+        $data->setValue([]);
+        add_filter('eforms_config', function ($defaults) use ($opts) {
+            $defaults['logging']['mode'] = 'off';
+            $defaults['logging']['fail2ban'] = array_replace($defaults['logging']['fail2ban'], $opts);
+            return $defaults;
+        });
+        Config::bootstrap();
+    }
+
+    public function testErrorLogTarget(): void
+    {
+        global $TEST_ARTIFACTS;
+        $this->boot(['enable' => true, 'target' => 'error_log']);
+        Logging::write('warn', 'EFORMS_F2B_ERR', ['ip' => '1.2.3.4']);
+        $log = file_get_contents($TEST_ARTIFACTS['log_file']);
+        $this->assertStringContainsString('code=EFORMS_F2B_ERR', (string) $log);
+    }
+
+    public function testSyslogTarget(): void
+    {
+        global $TEST_F2B_SYSLOG;
+        $this->boot(['enable' => true, 'target' => 'syslog']);
+        Logging::write('warn', 'EFORMS_F2B_SYS', ['ip' => '5.6.7.8']);
+        $this->assertNotEmpty($TEST_F2B_SYSLOG);
+        $this->assertStringContainsString('code=EFORMS_F2B_SYS', $TEST_F2B_SYSLOG[0][1]);
+    }
+
+    public function testFileRotationAndRetention(): void
+    {
+        $this->boot([
+            'enable' => true,
+            'target' => 'file',
+            'file' => 'f2b/eforms-f2b.log',
+            'file_max_size' => 40,
+            'retention_days' => 1,
+        ]);
+        $base = rtrim(Config::get('uploads.dir'), '/') . '/f2b';
+        $file = $base . '/eforms-f2b.log';
+        @unlink($file);
+        foreach (glob($base . '/eforms-f2b-*.log') ?: [] as $f) {
+            @unlink($f);
+        }
+        @mkdir($base, 0700, true);
+        $old = $base . '/eforms-f2b-20000101-000000.log';
+        file_put_contents($old, 'old');
+        touch($old, time() - 86400 * 2);
+        Logging::write('warn', 'CODE1', ['ip' => '1.1.1.1']);
+        Logging::write('warn', 'CODE2', ['ip' => '1.1.1.1']);
+        $rotated = glob($base . '/eforms-f2b-*.log');
+        $this->assertNotEmpty($rotated);
+        $this->assertStringContainsString('CODE1', file_get_contents($rotated[0]));
+        $this->assertStringContainsString('CODE2', (string) file_get_contents($file));
+        $this->assertFalse(file_exists($old));
+    }
+}
+}


### PR DESCRIPTION
## Summary
- Support fail2ban logging to `error_log`, `syslog`, or file with rotation and retention
- Clamp and validate new `logging.fail2ban.*` config options
- Test fail2ban output for each target and rotation/retention

## Testing
- `phpunit tests/Fail2banLoggingTest.php`
- `php -d display_errors=1 /usr/bin/phpunit` *(fails: Access level to RulesTest::run() must be public)*
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c05ca9f5b8832d8204655822265a8d