### PR TITLE
Align plugin with template spec and schema

### DIFF
--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -123,7 +123,7 @@ class FormManager
             $_COOKIE[$cookieName] = $newToken;
         }
         if ($tokenInfo['hard_fail']) {
-            $this->renderErrorAndExit($tpl, $formId, 'Security token error.');
+            $this->renderErrorAndExit($tpl, $formId, 'This form was already submitted or has expired – please reload the page.');
         }
         $softFailCount += $tokenInfo['soft_signal'];
         $ua = Helpers::sanitize_user_agent($_SERVER['HTTP_USER_AGENT'] ?? '');

--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -49,7 +49,7 @@ class TemplateValidator
         self::checkUnknown($tpl, $rootAllowed, '', $errors);
 
         // Required + type
-        $reqRoot = ['id'=>'string','version'=>null,'success'=>'array','email'=>'array','fields'=>'array','submit_button_text'=>'string'];
+        $reqRoot = ['id'=>'string','version'=>null,'title'=>'string','success'=>'array','email'=>'array','fields'=>'array','submit_button_text'=>'string'];
         foreach ($reqRoot as $k => $type) {
             if (!array_key_exists($k, $tpl)) {
                 $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$k];
@@ -102,6 +102,7 @@ class TemplateValidator
         $rowStack = 0;
         $hasUploads = false;
         $normFields = [];
+        $realFieldCount = 0;
         $reserved = ['form_id','instance_id','eforms_token','eforms_hp','timestamp','js_ok','ip','submitted_at'];
         $allowedTypes = ['name','email','textarea','textarea_html','tel_us','zip_us','select','radio','checkbox','file','files','row_group'];
         foreach ($fields as $idx => $f) {
@@ -305,6 +306,7 @@ class TemplateValidator
                 'max_files' => isset($f['max_files']) && is_int($f['max_files']) ? $f['max_files'] : null,
                 'step' => (is_numeric($stepVal) && $stepVal > 0) ? $stepVal + 0 : null,
             ];
+            $realFieldCount++;
         }
         if ($rowStack !== 0) {
             $errors[] = ['code'=>self::EFORMS_ERR_ROW_GROUP_UNBALANCED,'path'=>'fields'];
@@ -329,11 +331,12 @@ class TemplateValidator
             'descriptors' => self::buildDescriptors($normFields),
             'version' => $tpl['version'] ?? '',
             'id' => $tpl['id'] ?? '',
+            'title' => $tpl['title'] ?? '',
             'email' => $email,
             'success' => $success,
             'rules' => $rules,
             'fields' => $normFields,
-            'max_input_vars_estimate' => count($normFields) * 3,
+            'max_input_vars_estimate' => $realFieldCount * 3,
         ];
 
         return ['ok'=>empty($errors), 'errors'=>$errors, 'context'=>$ctx];

--- a/src/Uploads.php
+++ b/src/Uploads.php
@@ -249,6 +249,10 @@ class Uploads
         if ($base === '') {
             $base = 'file';
         }
+        $reserved = ['con','prn','aux','nul','com1','com2','com3','com4','com5','com6','com7','com8','com9','lpt1','lpt2','lpt3','lpt4','lpt5','lpt6','lpt7','lpt8','lpt9'];
+        if (in_array($base, $reserved, true)) {
+            $base .= '_';
+        }
         $extSafe = strtolower($ext);
         $originalSafe = $base . ($extSafe !== '' ? '.' . $extSafe : '');
         return [$base, $extSafe, $originalSafe];

--- a/src/schema/template.schema.json
+++ b/src/schema/template.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["id","version","success","email","fields","submit_button_text"],
+  "required": ["id","version","title","success","email","fields","submit_button_text"],
   "additionalProperties": false,
   "properties": {
     "id": {"type": "string"},
@@ -21,7 +21,11 @@
     "email": {
       "type": "object",
       "properties": {
-        "display_format_tel": {"enum": ["xxx-xxx-xxxx","(xxx) xxx-xxxx","xxx.xxx.xxxx"]}
+        "display_format_tel": {"enum": ["xxx-xxx-xxxx","(xxx) xxx-xxxx","xxx.xxx.xxxx"]},
+        "to": {"type": "string"},
+        "subject": {"type": "string"},
+        "email_template": {"type": "string"},
+        "include_fields": {"type": "array", "items": {"type": "string"}}
       },
       "additionalProperties": false
     },
@@ -40,7 +44,7 @@
       "required": ["type"],
       "additionalProperties": false,
       "properties": {
-        "type": {"enum": ["name","email","textarea","tel_us","zip_us","select","radio","checkbox","file","files","row_group"]},
+        "type": {"enum": ["name","email","textarea","textarea_html","tel_us","zip_us","select","radio","checkbox","file","files","row_group"]},
         "key": {"type": "string"},
         "label": {"type": "string"},
         "required": {"type": "boolean"},
@@ -52,7 +56,20 @@
         "accept": {"type": "array", "items": {"type": "string"}},
         "mode": {"enum": ["start","end"]},
         "tag": {"enum": ["div","section"]},
-        "class": {"type": "string"}
+        "class": {"type": "string"},
+        "before_html": {"type": "string"},
+        "after_html": {"type": "string"},
+        "placeholder": {"type": "string"},
+        "autocomplete": {"type": "string"},
+        "size": {"type": "integer"},
+        "max_length": {"type": "integer"},
+        "min": {"type": ["number","string"]},
+        "max": {"type": ["number","string"]},
+        "pattern": {"type": "string"},
+        "email_attach": {"type": "boolean"},
+        "max_file_bytes": {"type": "integer"},
+        "max_files": {"type": "integer"},
+        "step": {"type": ["number","string"]}
       }
     },
     "option": {

--- a/tests/RendererRowGroupTest.php
+++ b/tests/RendererRowGroupTest.php
@@ -48,7 +48,7 @@ final class RendererRowGroupTest extends TestCase
         ];
         $logFile = Config::get('uploads.dir', sys_get_temp_dir()) . '/eforms.log';
         @unlink($logFile);
-        $html = Renderer::form($tpl, $meta, [], []);
+        $html = Renderer::form(TemplateValidator::preflight($tpl)['context'], $meta, [], []);
         $this->assertStringContainsString('<section class="eforms-row custom">', $html);
         $this->assertStringContainsString('</section><button', $html);
         $log = file_get_contents($logFile);
@@ -82,7 +82,7 @@ final class RendererRowGroupTest extends TestCase
         ];
         $logFile = Config::get('uploads.dir', sys_get_temp_dir()) . '/eforms.log';
         @unlink($logFile);
-        $html = Renderer::form($tpl, $meta, [], []);
+        $html = Renderer::form(TemplateValidator::preflight($tpl)['context'], $meta, [], []);
         $this->assertStringContainsString('<form', $html);
         $this->assertStringContainsString('<button', $html);
         $log = file_get_contents($logFile);

--- a/tests/RendererStepTest.php
+++ b/tests/RendererStepTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use EForms\Config;
 use EForms\Renderer;
+use EForms\TemplateValidator;
 
 final class RendererStepTest extends TestCase
 {
@@ -43,6 +44,7 @@ final class RendererStepTest extends TestCase
             'hidden_token' => null,
             'enctype' => 'application/x-www-form-urlencoded',
         ];
+        $tpl = TemplateValidator::preflight($tpl)['context'];
         $html = Renderer::form($tpl, $meta, [], []);
         $this->assertStringContainsString('step="5"', $html);
     }

--- a/tests/TemplateValidatorTest.php
+++ b/tests/TemplateValidatorTest.php
@@ -27,6 +27,15 @@ class TemplateValidatorTest extends TestCase
         $this->assertTrue($res['ok']);
     }
 
+    public function testTitleIsRequired(): void
+    {
+        $tpl = $this->baseTpl();
+        unset($tpl['title']);
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_REQUIRED, $codes);
+    }
+
     public function testUnknownRootKey(): void
     {
         $tpl = $this->baseTpl();
@@ -103,6 +112,17 @@ class TemplateValidatorTest extends TestCase
         $res = TemplateValidator::preflight($tpl);
         $codes = array_column($res['errors'], 'code');
         $this->assertContains(TemplateValidator::EFORMS_ERR_ROW_GROUP_UNBALANCED, $codes);
+    }
+
+    public function testRowGroupNotCountedForInputEstimate(): void
+    {
+        $tpl = $this->baseTpl();
+        array_unshift($tpl['fields'], ['type' => 'row_group', 'mode' => 'start', 'tag' => 'div']);
+        $tpl['fields'][] = ['type' => 'row_group', 'mode' => 'end', 'tag' => 'div'];
+        $res = TemplateValidator::preflight($tpl);
+        $this->assertTrue($res['ok']);
+        $this->assertSame(6, $res['context']['max_input_vars_estimate']);
+        $this->assertCount(4, $res['context']['fields']);
     }
 
     public function testUnknownValidationRule(): void

--- a/tests/UploadsReservedNameTest.php
+++ b/tests/UploadsReservedNameTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Uploads;
+use EForms\Config;
+
+final class UploadsReservedNameTest extends TestCase
+{
+    public function testReservedWindowsNamesAreModified(): void
+    {
+        Config::bootstrap();
+        $tpl = [
+            'fields' => [
+                ['type' => 'file', 'key' => 'doc', 'accept' => ['pdf']],
+            ],
+        ];
+        $tmp = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp, "%PDF-1.4\n");
+        $files = [
+            'doc' => [
+                'name' => 'CON.pdf',
+                'type' => 'application/pdf',
+                'tmp_name' => $tmp,
+                'error' => UPLOAD_ERR_OK,
+                'size' => filesize($tmp),
+            ],
+        ];
+        $res = Uploads::normalizeAndValidate($tpl, $files);
+        $stored = Uploads::store($res['files']);
+        $names = array_column($stored['doc'], 'original_name_safe');
+        $this->assertSame(['con_.pdf'], $names);
+        Uploads::deleteStored($stored);
+        @unlink($tmp);
+    }
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -71,6 +71,12 @@ function record_result() {
   fi
 }
 
+# Schema validation for templates
+run_test template_schema_check
+ok=0
+assert_grep tmp/stdout.txt '^OK$' || ok=1
+record_result "template schema parity" $ok
+
 # 1) Submit route: 405
 run_test test_submit_405
 ok=0
@@ -123,7 +129,7 @@ record_result "origin policy hard: blocked" $ok
 # 2b) Cookie missing policies
 run_test test_cookie_policy_hard
 ok=0
-assert_grep tmp/stdout.txt 'Security token error\.' || ok=1
+assert_grep tmp/stdout.txt 'This form was already submitted or has expired – please reload the page\.' || ok=1
 ! assert_grep tmp/mail.json 'zed@example.com' || ok=1
 record_result "cookie policy hard: missing cookie hard fail" $ok
 

--- a/tests/template_schema_check.php
+++ b/tests/template_schema_check.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+use EForms\TemplateValidator;
+
+$schema = realpath(__DIR__ . '/../src/schema/template.schema.json');
+$templates = glob(__DIR__ . '/../templates/*.json') ?: [];
+foreach ($templates as $tplFile) {
+    $cmd = 'python3 -m jsonschema ' . escapeshellarg($schema) . ' -i ' . escapeshellarg($tplFile);
+    exec($cmd, $out, $code);
+    if ($code !== 0) {
+        fwrite(STDERR, "schema fail: $tplFile\n");
+        exit(1);
+    }
+    $tpl = json_decode(file_get_contents($tplFile), true);
+    $res = TemplateValidator::preflight($tpl);
+    if (!$res['ok']) {
+        fwrite(STDERR, "preflight fail: $tplFile\n");
+        exit(1);
+    }
+}
+echo "OK";


### PR DESCRIPTION
## Summary
- enforce `title` as required in templates and exclude row groups from input variable limits
- improve token failure messaging and block Windows reserved filenames
- add JSON schema parity checks and tests for reserved upload names

## Testing
- `phpunit tests/ChallengeVerifierTest.php` *(fails: Failed asserting that null is identical to 303)*
- `phpunit tests/SecurityOriginTest.php` *(fails: Expected 'unknown' got 'cross')*
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c075fcf5c8832dab2c386775fdc1ed