### PR TITLE
Align security and uploads behavior with spec

### DIFF
--- a/src/Logging.php
+++ b/src/Logging.php
@@ -134,7 +134,7 @@ class Logging
 
     private static function emitFail2ban(string $code, array $ctx): void
     {
-        $ip = $ctx['ip'] ?? ($_SERVER['REMOTE_ADDR'] ?? '');
+        $ip = $ctx['ip'] ?? Helpers::client_ip();
         $form = $ctx['form_id'] ?? '';
         $line = sprintf(
             'eforms-fail2ban ts=%d code=%s ip=%s form=%s',

--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -197,7 +197,7 @@ class TemplateValidator
                 }
                 $global = Config::get('uploads.allowed_tokens', ['image','pdf']);
                 $intersection = array_intersect($accept, $global);
-                if ($accept && empty($intersection)) {
+                if (empty($accept) || empty($intersection)) {
                     $errors[] = ['code'=>self::EFORMS_ERR_ACCEPT_EMPTY,'path'=>$path.'accept'];
                 }
                 if (isset($f['email_attach']) && !is_bool($f['email_attach'])) {

--- a/src/Uploads.php
+++ b/src/Uploads.php
@@ -215,6 +215,9 @@ class Uploads
                 if ($mime === $m && in_array($ext, $exts, true)) {
                     return true;
                 }
+                if ($mime === 'application/octet-stream' && in_array($ext, $exts, true)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/tests/ChallengeInitTest.php
+++ b/tests/ChallengeInitTest.php
@@ -1,0 +1,54 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use EForms\Config;
+use EForms\FormManager;
+
+final class ChallengeInitTest extends TestCase
+{
+    private array $origConfig;
+
+    protected function setUp(): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $prop = $ref->getProperty('data');
+        $prop->setAccessible(true);
+        $this->origConfig = $prop->getValue();
+    }
+
+    protected function tearDown(): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $prop = $ref->getProperty('data');
+        $prop->setAccessible(true);
+        $prop->setValue(null, $this->origConfig);
+        $GLOBALS['wp_enqueued_scripts'] = [];
+    }
+
+    private function setConfig(string $path, $value): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $prop = $ref->getProperty('data');
+        $prop->setAccessible(true);
+        $data = $prop->getValue();
+        $segments = explode('.', $path);
+        $cursor =& $data;
+        $last = array_pop($segments);
+        foreach ($segments as $seg) {
+            if (!isset($cursor[$seg]) || !is_array($cursor[$seg])) {
+                $cursor[$seg] = [];
+            }
+            $cursor =& $cursor[$seg];
+        }
+        $cursor[$last] = $value;
+        $prop->setValue(null, $data);
+    }
+
+    public function testCookiePolicyChallengeEnqueuesScript(): void
+    {
+        $this->setConfig('security.cookie_missing_policy', 'challenge');
+        $fm = new FormManager();
+        $GLOBALS['wp_enqueued_scripts'] = [];
+        $fm->render('contact_us');
+        $this->assertContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+    }
+}

--- a/tests/ClientIpHeaderTest.php
+++ b/tests/ClientIpHeaderTest.php
@@ -1,0 +1,65 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use EForms\Config;
+use EForms\Helpers;
+
+final class ClientIpHeaderTest extends TestCase
+{
+    private array $origConfig;
+
+    protected function setUp(): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $prop = $ref->getProperty('data');
+        $prop->setAccessible(true);
+        $this->origConfig = $prop->getValue();
+    }
+
+    protected function tearDown(): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $prop = $ref->getProperty('data');
+        $prop->setAccessible(true);
+        $prop->setValue(null, $this->origConfig);
+        unset($_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_X_FORWARDED_FOR']);
+    }
+
+    private function setConfig(string $path, $value): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $prop = $ref->getProperty('data');
+        $prop->setAccessible(true);
+        $data = $prop->getValue();
+        $segments = explode('.', $path);
+        $cursor =& $data;
+        $last = array_pop($segments);
+        foreach ($segments as $seg) {
+            if (!isset($cursor[$seg]) || !is_array($cursor[$seg])) {
+                $cursor[$seg] = [];
+            }
+            $cursor =& $cursor[$seg];
+        }
+        $cursor[$last] = $value;
+        $prop->setValue(null, $data);
+    }
+
+    public function testHeaderUsedWhenTrustedProxy(): void
+    {
+        $this->setConfig('privacy.client_ip_header', 'X-Forwarded-For');
+        $this->setConfig('privacy.trusted_proxies', ['10.0.0.1']);
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.5, 70.1.1.1';
+        $ip = Helpers::client_ip();
+        $this->assertSame('203.0.113.5', $ip);
+    }
+
+    public function testHeaderIgnoredWhenUntrusted(): void
+    {
+        $this->setConfig('privacy.client_ip_header', 'X-Forwarded-For');
+        $this->setConfig('privacy.trusted_proxies', ['10.0.0.1']);
+        $_SERVER['REMOTE_ADDR'] = '198.51.100.9';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.5';
+        $ip = Helpers::client_ip();
+        $this->assertSame('198.51.100.9', $ip);
+    }
+}

--- a/tests/TemplateValidatorTest.php
+++ b/tests/TemplateValidatorTest.php
@@ -105,6 +105,15 @@ class TemplateValidatorTest extends TestCase
         $this->assertContains(TemplateValidator::EFORMS_ERR_ACCEPT_EMPTY, $codes);
     }
 
+    public function testAcceptRequiredForUploads(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][] = ['type' => 'file', 'key' => 'up'];
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_ACCEPT_EMPTY, $codes);
+    }
+
     public function testUnbalancedRowGroups(): void
     {
         $tpl = $this->baseTpl();
@@ -217,8 +226,8 @@ class TemplateValidatorTest extends TestCase
     {
         $tpl = $this->baseTpl();
         $tpl['fields'][0]['step'] = 5;
-        $tpl['fields'][] = ['type' => 'file', 'key' => 'up1', 'max_file_bytes' => 100];
-        $tpl['fields'][] = ['type' => 'files', 'key' => 'up2', 'max_files' => 2];
+        $tpl['fields'][] = ['type' => 'file', 'key' => 'up1', 'max_file_bytes' => 100, 'accept' => ['pdf']];
+        $tpl['fields'][] = ['type' => 'files', 'key' => 'up2', 'max_files' => 2, 'accept' => ['pdf']];
         $res = TemplateValidator::preflight($tpl);
         $codes = array_column($res['errors'], 'code');
         $this->assertNotContains(TemplateValidator::EFORMS_ERR_SCHEMA_UNKNOWN_KEY, $codes);

--- a/tests/TokenLoggingTest.php
+++ b/tests/TokenLoggingTest.php
@@ -1,0 +1,26 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class TokenLoggingTest extends TestCase
+{
+    private function runScript(string $script): array
+    {
+        $tmpDir = __DIR__ . '/tmp';
+        if (is_dir($tmpDir)) {
+            exec('rm -rf ' . escapeshellarg($tmpDir));
+        }
+        mkdir($tmpDir, 0777, true);
+        $cmd = 'php-cgi ' . escapeshellarg(__DIR__ . '/' . $script);
+        $out = [];
+        exec($cmd, $out, $code);
+        return [$code, $out, $tmpDir];
+    }
+
+    public function testTokenHardFailureLogged(): void
+    {
+        [$code, $out, $dir] = $this->runScript('token_hard_fail.php');
+        $this->assertSame(0, $code);
+        $log = @file_get_contents($dir . '/uploads/eforms-private/eforms.log');
+        $this->assertStringContainsString('EFORMS_ERR_TOKEN', (string)$log);
+    }
+}

--- a/tests/UploadsOctetStreamTest.php
+++ b/tests/UploadsOctetStreamTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Uploads;
+
+final class UploadsOctetStreamTest extends TestCase
+{
+    public function testOctetStreamAllowedWhenExtensionMatches(): void
+    {
+        $tpl = [
+            'fields' => [
+                ['type' => 'file', 'key' => 'up', 'accept' => ['pdf']],
+            ],
+        ];
+        $tmp = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp, random_bytes(100));
+        $files = [
+            'up' => [
+                'name' => 'a.pdf',
+                'type' => 'application/octet-stream',
+                'tmp_name' => $tmp,
+                'error' => UPLOAD_ERR_OK,
+                'size' => filesize($tmp),
+            ],
+        ];
+        $res = Uploads::normalizeAndValidate($tpl, $files);
+        $this->assertArrayNotHasKey('up', $res['errors']);
+        @unlink($tmp);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -164,8 +164,9 @@ function is_wp_error($v) { return false; }
 
 function wp_register_style($handle, $src, $deps = [], $ver = false, $args = []) {}
 function wp_register_script($handle, $src, $deps = [], $ver = false, $in_footer = []) {}
+$GLOBALS['wp_enqueued_scripts'] = [];
 function wp_enqueue_style($handle) {}
-function wp_enqueue_script($handle) {}
+function wp_enqueue_script($handle) { $GLOBALS['wp_enqueued_scripts'][] = $handle; }
 
 // Ensure uploads subdirs exist
 @mkdir(__DIR__ . '/tmp/uploads/eforms-private', 0777, true);

--- a/tests/challenge_cookie_policy.php
+++ b/tests/challenge_cookie_policy.php
@@ -15,6 +15,7 @@ $_POST = [
         'email' => 'zed@example.com',
         'message' => 'Ping',
     ],
+    'js_ok' => '1',
 ];
 $fm = new \EForms\FormManager();
 $fm->handleSubmit();

--- a/tests/challenge_success.php
+++ b/tests/challenge_success.php
@@ -19,6 +19,7 @@ $_POST = [
         'message' => 'Ping',
     ],
     'cf-turnstile-response' => 'pass',
+    'js_ok' => '1',
 ];
 $fm = new \EForms\FormManager();
 $fm->handleSubmit();

--- a/tests/token_hard_fail.php
+++ b/tests/token_hard_fail.php
@@ -1,16 +1,13 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_COOKIE_MISSING_POLICY=challenge');
-putenv('EFORMS_CHALLENGE_MODE=auto');
-putenv('EFORMS_CHALLENGE_PROVIDER=turnstile');
-putenv('EFORMS_TURNSTILE_SITE_KEY=site');
-putenv('EFORMS_TURNSTILE_SECRET_KEY=secret');
+putenv('EFORMS_COOKIE_MISSING_POLICY=hard');
+putenv('EFORMS_LOG_LEVEL=1');
 require __DIR__ . '/bootstrap.php';
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_POST = [
     'form_id' => 'contact_us',
-    'instance_id' => 'instCHFAIL',
+    'instance_id' => 'instTOKH1',
     'timestamp' => time(),
     'eforms_hp' => '',
     'contact_us' => [
@@ -18,7 +15,6 @@ $_POST = [
         'email' => 'zed@example.com',
         'message' => 'Ping',
     ],
-    'cf-turnstile-response' => 'fail',
     'js_ok' => '1',
 ];
 $fm = new \EForms\FormManager();


### PR DESCRIPTION
## Summary
- enforce non-empty upload accept tokens during template validation
- enqueue challenge assets when cookie policy requires challenge
- respect client IP headers and log token failures

## Testing
- `phpunit tests/TemplateValidatorTest.php`
- `phpunit tests/ChallengeVerifierTest.php`
- `phpunit tests/ClientIpHeaderTest.php`
- `phpunit tests/UploadsOctetStreamTest.php`
- `phpunit tests/TokenLoggingTest.php`
- `phpunit tests/ChallengeInitTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c08b496ea0832db15ef2c4600c299e