### PR TITLE
Use template file mtime when version missing

### DIFF
--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -38,9 +38,10 @@ class TemplateValidator
      * Perform structural validation and return context.
      *
      * @param array $tpl
+     * @param string|null $srcPath
      * @return array{ok:bool,errors:array<int,array{code:string,path:string}>,context?:array}
      */
-    public static function preflight(array $tpl): array
+    public static function preflight(array $tpl, ?string $srcPath = null): array
     {
         $errors = [];
 
@@ -350,10 +351,14 @@ class TemplateValidator
             }
         }
 
+        $version = $tpl['version'] ?? '';
+        if ($version === '' && $srcPath && is_file($srcPath)) {
+            $version = (string) (@filemtime($srcPath) ?: '');
+        }
         $ctx = [
             'has_uploads' => $hasUploads,
             'descriptors' => self::buildDescriptors($normFields),
-            'version' => $tpl['version'] ?? '',
+            'version' => $version,
             'id' => $tpl['id'] ?? '',
             'title' => $tpl['title'] ?? '',
             'email' => $email,

--- a/tests/TemplateValidatorTest.php
+++ b/tests/TemplateValidatorTest.php
@@ -255,4 +255,16 @@ class TemplateValidatorTest extends TestCase
         $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_TYPE, $codes);
         $this->assertContains('email.include_fields', $paths);
     }
+
+    public function testEmptyVersionReplacedWithMtime(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['version'] = '';
+        $tmp = tempnam(sys_get_temp_dir(), 'tpl');
+        touch($tmp, 123);
+        $res = TemplateValidator::preflight($tpl, $tmp);
+        $this->assertTrue($res['ok']);
+        $this->assertSame('123', $res['context']['version']);
+        unlink($tmp);
+    }
 }


### PR DESCRIPTION
## Summary
- use template file modification time when version is empty
- pass template path from FormManager to validator
- cover version fallback with a unit test

## Testing
- `phpunit -c phpunit.xml.dist` *(fails: Access level to RulesTest::run() must be public)*

------
https://chatgpt.com/codex/tasks/task_e_68c0965e4048832da4ef86172df052ac