### PR TITLE
Enforce field and option count limits from Config

### DIFF
--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -45,6 +45,9 @@ class TemplateValidator
     {
         $errors = [];
 
+        $maxFields = Config::get('validation.max_fields_per_form', 150);
+        $maxOptions = Config::get('validation.max_options_per_group', 100);
+
         // Root unknown keys
         $rootAllowed = ['id','version','title','success','email','fields','submit_button_text','rules'];
         self::checkUnknown($tpl, $rootAllowed, '', $errors);
@@ -172,6 +175,9 @@ class TemplateValidator
                 if (!is_array($f['options'])) {
                     $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$path.'options'];
                 } else {
+                    if (count($f['options']) > $maxOptions) {
+                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>$path.'options'];
+                    }
                     $optSeen = [];
                     foreach ($f['options'] as $oIdx => $opt) {
                         $opath = $path.'options['.$oIdx.'].';
@@ -311,6 +317,10 @@ class TemplateValidator
         }
         if ($rowStack !== 0) {
             $errors[] = ['code'=>self::EFORMS_ERR_ROW_GROUP_UNBALANCED,'path'=>'fields'];
+        }
+
+        if ($realFieldCount > $maxFields) {
+            $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>'fields'];
         }
 
         $allowedMeta = ['ip','submitted_at','form_id','instance_id'];

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -4,7 +4,7 @@ use EForms\Validator;
 
 class RulesTest extends TestCase
 {
-    private function run(array $tpl, array $post): array
+    private function runRules(array $tpl, array $post): array
     {
         $desc = Validator::descriptors($tpl);
         $values = Validator::normalize($tpl, $post);
@@ -23,7 +23,7 @@ class RulesTest extends TestCase
                 ['rule'=>'required_if','field'=>'a','other'=>'b','equals'=>'x']
             ],
         ];
-        $errors = $this->run($tpl, ['b'=>'x']);
+        $errors = $this->runRules($tpl, ['b'=>'x']);
         $this->assertArrayHasKey('a', $errors);
     }
 
@@ -39,7 +39,7 @@ class RulesTest extends TestCase
                 ['rule'=>'required_if_any','field'=>'a','fields'=>['b','c'],'equals_any'=>['yes','y']]
             ],
         ];
-        $errors = $this->run($tpl, ['b'=>'y']);
+        $errors = $this->runRules($tpl, ['b'=>'y']);
         $this->assertArrayHasKey('a', $errors);
     }
 
@@ -54,7 +54,7 @@ class RulesTest extends TestCase
                 ['rule'=>'required_unless','field'=>'a','other'=>'b','equals'=>'skip']
             ],
         ];
-        $errors = $this->run($tpl, ['b'=>'no']);
+        $errors = $this->runRules($tpl, ['b'=>'no']);
         $this->assertArrayHasKey('a', $errors);
     }
 
@@ -69,7 +69,7 @@ class RulesTest extends TestCase
                 ['rule'=>'matches','field'=>'a','other'=>'b']
             ],
         ];
-        $errors = $this->run($tpl, ['a'=>'one','b'=>'two']);
+        $errors = $this->runRules($tpl, ['a'=>'one','b'=>'two']);
         $this->assertArrayHasKey('a', $errors);
     }
 
@@ -85,7 +85,7 @@ class RulesTest extends TestCase
                 ['rule'=>'one_of','fields'=>['a','b','c']]
             ],
         ];
-        $errors = $this->run($tpl, []);
+        $errors = $this->runRules($tpl, []);
         $this->assertArrayHasKey('a', $errors);
         $this->assertArrayHasKey('b', $errors);
         $this->assertArrayHasKey('c', $errors);
@@ -102,7 +102,7 @@ class RulesTest extends TestCase
                 ['rule'=>'mutually_exclusive','fields'=>['a','b']]
             ],
         ];
-        $errors = $this->run($tpl, ['a'=>'one','b'=>'two']);
+        $errors = $this->runRules($tpl, ['a'=>'one','b'=>'two']);
         $this->assertArrayHasKey('a', $errors);
         $this->assertArrayHasKey('b', $errors);
     }

--- a/tests/TemplateValidatorTest.php
+++ b/tests/TemplateValidatorTest.php
@@ -256,6 +256,34 @@ class TemplateValidatorTest extends TestCase
         $this->assertContains('email.include_fields', $paths);
     }
 
+    public function testMaxFieldsPerForm(): void
+    {
+        $tpl = $this->baseTpl();
+        for ($i = 0; $i < 149; $i++) {
+            $tpl['fields'][] = ['type' => 'text', 'key' => 'f'.$i];
+        }
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $paths = array_column($res['errors'], 'path');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_ENUM, $codes);
+        $this->assertContains('fields', $paths);
+    }
+
+    public function testMaxOptionsPerGroup(): void
+    {
+        $tpl = $this->baseTpl();
+        $opts = [];
+        for ($i = 0; $i < 101; $i++) {
+            $opts[] = ['key' => 'o'.$i, 'label' => 'L'.$i];
+        }
+        $tpl['fields'][] = ['type' => 'select', 'key' => 'sel', 'options' => $opts];
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $paths = array_column($res['errors'], 'path');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_ENUM, $codes);
+        $this->assertContains('fields[2].options', $paths);
+    }
+
     public function testEmptyVersionReplacedWithMtime(): void
     {
         $tpl = $this->baseTpl();


### PR DESCRIPTION
## Summary
- honor `validation.max_fields_per_form` and `validation.max_options_per_group` in `TemplateValidator::preflight`
- cover the new limits with TemplateValidator tests
- rename test helper to avoid PHPUnit method conflict

## Testing
- `phpunit` *(fails: RendererRowGroupTest, ValidatorRulesTest, SecurityOriginTest, SecurityTokenModesTest, TokenLoggingTest)*
- `tests/run.sh` *(fails: throttle: hard over-limit)*

------
https://chatgpt.com/codex/tasks/task_e_68c099489578832d9d1e1c7f710c8c64