### PR TITLE
Add required markers to labels and auto-hide generated labels

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -131,7 +131,22 @@ class Renderer
             }
             $key = $f['key'];
             $id = self::makeId($formId, $key, $instanceId);
-            $label = $f['label'] ?? ucwords(str_replace(['_','-'], ' ', $key));
+            $labelHidden = false;
+            if (array_key_exists('label', $f)) {
+                if ($f['label'] === null) {
+                    $labelHidden = true;
+                    $label = ucwords(str_replace(['_','-'], ' ', $key));
+                } else {
+                    $label = $f['label'];
+                }
+            } else {
+                $label = ucwords(str_replace(['_','-'], ' ', $key));
+            }
+            $labelAttr = $labelHidden ? ' class="visually-hidden"' : '';
+            $labelHtml = \esc_html($label);
+            if (!empty($f['required'])) {
+                $labelHtml .= '<span class="required">*</span>';
+            }
             $value = $values[$key] ?? '';
             $fieldErrors = $errors[$key] ?? [];
             $errId = 'error-' . $id;
@@ -144,7 +159,7 @@ class Renderer
             $html .= $before;
             switch ($type) {
                 case 'textarea':
-                    $html .= '<label for="' . \esc_attr($id) . '">' . \esc_html($label) . '</label>';
+                    $html .= '<label for="' . \esc_attr($id) . '"' . $labelAttr . '>' . $labelHtml . '</label>';
                     $extraHint = ($key === $lastText) ? ' enterkeyhint="send"' : '';
                     $html .= '<textarea id="' . \esc_attr($id) . '" name="' . \esc_attr($formId . '[' . $key . ']') . '"';
                     if (!empty($f['required'])) $html .= ' required';
@@ -154,7 +169,7 @@ class Renderer
                     $html .= $errAttr . $extraHint . '>' . \esc_textarea((string)$value) . '</textarea>';
                     break;
                 case 'textarea_html':
-                    $html .= '<label for="' . \esc_attr($id) . '">' . \esc_html($label) . '</label>';
+                    $html .= '<label for="' . \esc_attr($id) . '"' . $labelAttr . '>' . $labelHtml . '</label>';
                     $extraHint = ($key === $lastText) ? ' enterkeyhint="send"' : '';
                     $html .= '<textarea id="' . \esc_attr($id) . '" name="' . \esc_attr($formId . '[' . $key . ']') . '"';
                     if (!empty($f['required'])) $html .= ' required';
@@ -164,7 +179,7 @@ class Renderer
                     $html .= $errAttr . $extraHint . '>' . \esc_textarea((string)$value) . '</textarea>';
                     break;
                 case 'select':
-                    $html .= '<label for="' . \esc_attr($id) . '">' . \esc_html($label) . '</label>';
+                    $html .= '<label for="' . \esc_attr($id) . '"' . $labelAttr . '>' . $labelHtml . '</label>';
                     $multiple = !empty($f['multiple']);
                     $nameAttr = $formId . '[' . $key . ']' . ($multiple ? '[]' : '');
                     $vals = $multiple && is_array($value) ? $value : (string)$value;
@@ -191,7 +206,7 @@ class Renderer
                     $html .= '<fieldset id="' . \esc_attr($id) . '"';
                     if (!empty($f['required'])) $html .= ' required';
                     if ($fieldErrors) $html .= ' aria-describedby="' . \esc_attr($errId) . '" aria-invalid="true"';
-                    $html .= '><legend>' . \esc_html($label) . '</legend>';
+                    $html .= '><legend' . $labelAttr . '>' . $labelHtml . '</legend>';
                     $vals = $type === 'checkbox' ? (array)$value : $value;
                     foreach ($f['options'] ?? [] as $opt) {
                         $idOpt = self::makeId($formId, $key . '-' . $opt['key'], $instanceId);
@@ -211,7 +226,7 @@ class Renderer
                 case 'file':
                 case 'files':
                     $nameAttr = $formId . '[' . $key . ']' . ($type === 'files' ? '[]' : '');
-                    $html .= '<label for="' . \esc_attr($id) . '">' . \esc_html($label) . '</label>';
+                    $html .= '<label for="' . \esc_attr($id) . '"' . $labelAttr . '>' . $labelHtml . '</label>';
                     $html .= '<input type="file" id="' . \esc_attr($id) . '" name="' . \esc_attr($nameAttr) . '"';
                     if ($type === 'files') $html .= ' multiple';
                     if (!empty($f['required'])) $html .= ' required';
@@ -238,7 +253,7 @@ class Renderer
                         $inputType = 'text';
                         $extra .= ' inputmode="numeric" pattern="\d{5}" maxlength="5"';
                     }
-                    $html .= '<label for="' . \esc_attr($id) . '">' . \esc_html($label) . '</label>';
+                    $html .= '<label for="' . \esc_attr($id) . '"' . $labelAttr . '>' . $labelHtml . '</label>';
                     $extraHint = ($key === $lastText) ? ' enterkeyhint="send"' : '';
                     $html .= '<input type="' . \esc_attr($inputType) . '" id="' . \esc_attr($id) . '" name="' . \esc_attr($formId . '[' . $key . ']') . '" value="' . \esc_attr((string)$value) . '"';
                     if (!empty($f['required'])) $html .= ' required';

--- a/tests/RendererLabelTest.php
+++ b/tests/RendererLabelTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Config;
+use EForms\Renderer;
+use EForms\TemplateValidator;
+
+final class RendererLabelTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $boot = $ref->getProperty('bootstrapped');
+        $boot->setAccessible(true);
+        $boot->setValue(false);
+        $data = $ref->getProperty('data');
+        $data->setAccessible(true);
+        $data->setValue([]);
+        Config::bootstrap();
+    }
+
+    public function testRequiredAndHiddenLabels(): void
+    {
+        $tpl = [
+            'id' => 't1',
+            'version' => '1',
+            'title' => 't',
+            'success' => ['mode' => 'inline'],
+            'email' => ['to' => 'a@example.com', 'subject' => 's', 'email_template' => 'default', 'include_fields' => []],
+            'fields' => [
+                ['type' => 'name', 'key' => 'name', 'label' => 'Your Name', 'required' => true],
+                ['type' => 'email', 'key' => 'email', 'label' => null, 'required' => true],
+                ['type' => 'radio', 'key' => 'color', 'label' => 'Color', 'required' => true, 'options' => [
+                    ['key' => 'r', 'label' => 'Red'],
+                ]],
+            ],
+            'submit_button_text' => 'Send',
+            'rules' => [],
+        ];
+        $meta = [
+            'form_id' => 'f1',
+            'instance_id' => 'i1',
+            'timestamp' => time(),
+            'cacheable' => true,
+            'client_validation' => false,
+            'action' => '#',
+            'hidden_token' => null,
+            'enctype' => 'application/x-www-form-urlencoded',
+        ];
+        $tpl = TemplateValidator::preflight($tpl)['context'];
+        $html = Renderer::form($tpl, $meta, [], []);
+        $this->assertStringContainsString('<label for="f1-name-i1">Your Name<span class="required">*</span></label>', $html);
+        $this->assertStringContainsString('<label for="f1-email-i1" class="visually-hidden">Email<span class="required">*</span></label>', $html);
+        $this->assertStringContainsString('<legend>Color<span class="required">*</span></legend>', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- Display a `*` marker on field labels and legends when marked required
- Generate default label text and hide it visually when the template label is null
- Test rendering of required markers and hidden labels

## Testing
- `phpunit -c phpunit.xml.dist` *(fails: SecurityOriginTest::testMissingHard, SecurityTokenModesTest::testCookieRotation, TokenLoggingTest::testTokenHardFailureLogged)*
- `phpunit -c phpunit.xml.dist tests/RendererLabelTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c09b5aa0e0832db815c5a13a25c46f