### PR TITLE
Implement email policy parsing and staging send controls

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -242,6 +242,16 @@ add_filter('eforms_config', function (array $defaults) {
     if (getenv('EFORMS_THROTTLE_HARD_MULTIPLIER')) {
         $defaults['throttle']['per_ip']['hard_multiplier'] = (float) getenv('EFORMS_THROTTLE_HARD_MULTIPLIER');
     }
+    if (getenv('EFORMS_EMAIL_POLICY')) {
+        $defaults['email']['policy'] = getenv('EFORMS_EMAIL_POLICY');
+    }
+    if (getenv('EFORMS_EMAIL_DISABLE_SEND')) {
+        $defaults['email']['disable_send'] = (getenv('EFORMS_EMAIL_DISABLE_SEND') === '1');
+    }
+    if (getenv('EFORMS_EMAIL_STAGING_REDIRECT_TO')) {
+        $val = getenv('EFORMS_EMAIL_STAGING_REDIRECT_TO');
+        $defaults['email']['staging_redirect_to'] = str_contains($val, ',') ? array_map('trim', explode(',', $val)) : $val;
+    }
     return $defaults;
 });
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -245,6 +245,27 @@ ok=0
 assert_grep tmp/mail.json 'doc.pdf' || ok=1
 record_result "email attachments: file included" $ok
 
+# 7c) Email policy autocorrect
+EFORMS_EMAIL_POLICY=autocorrect run_test test_email_policy_autocorrect
+ok=0
+assert_grep tmp/mail.json 'a@example.com' || ok=1
+record_result "email policy autocorrect" $ok
+
+# 7d) Email disable send
+EFORMS_EMAIL_DISABLE_SEND=1 run_test test_email_disable_send
+ok=0
+assert_equal_file tmp/mail.json '[]' || ok=1
+record_result "email disable send" $ok
+
+# 7e) Email staging redirect
+EFORMS_EMAIL_STAGING_REDIRECT_TO=stage@example.com run_test test_email_staging_redirect
+ok=0
+assert_grep tmp/mail.json 'stage@example.com' || ok=1
+assert_grep tmp/mail.json '\[STAGING\]' || ok=1
+assert_grep tmp/mail.json 'X-EForms-Env: staging' || ok=1
+assert_grep tmp/mail.json 'X-EForms-Original-To: a@example.com' || ok=1
+record_result "email staging redirect" $ok
+
 # 8) Logging minimal: SMTP failure
 run_test test_logging
 ok=0

--- a/tests/test_email_disable_send.php
+++ b/tests/test_email_disable_send.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+$tpl = [
+    'email' => [
+        'to' => 'a@example.com',
+        'subject' => 'Hi',
+        'email_template' => 'default',
+        'include_fields' => [],
+    ],
+    'fields' => [],
+];
+\EForms\Emailer::send($tpl, [], []);

--- a/tests/test_email_policy_autocorrect.php
+++ b/tests/test_email_policy_autocorrect.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+$tpl = [
+    'email' => [
+        'to' => 'a@Example.c0m ',
+        'subject' => 'Hi',
+        'email_template' => 'default',
+        'include_fields' => [],
+    ],
+    'fields' => [],
+];
+\EForms\Emailer::send($tpl, [], []);

--- a/tests/test_email_staging_redirect.php
+++ b/tests/test_email_staging_redirect.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+$tpl = [
+    'email' => [
+        'to' => 'a@example.com',
+        'subject' => 'Hi',
+        'email_template' => 'default',
+        'include_fields' => [],
+    ],
+    'fields' => [],
+];
+\EForms\Emailer::send($tpl, [], []);


### PR DESCRIPTION
## Summary
- Parse recipient and reply-to emails based on configurable `email.policy` and autocorrect common domain typos
- Respect `email.disable_send` and `email.staging_redirect_to`, prefixing subjects and tagging headers for staging
- Add tests for email policy autocorrect, disable-send, and staging redirect with bootstrap env overrides

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c09e2a61c0832d9c7423b09e8af7b3