### PR TITLE
Respect privacy.ip_mode in IP handling

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -326,10 +326,11 @@ electronic_forms - Spec
 		- add headers: X-EForms-Soft-Fails, X-EForms-Suspect; subject tag (configurable)
 	9. Throttling (optional; file-based)
 		- Purpose: dampen spikes from the same IP without DBs or queues.
-		- Keying: compute a throttle key from the resolved client IP per §16, then apply privacy settings:
-			- privacy.ip_mode=hash → sha256(ip + privacy.ip_salt).
-			- privacy.ip_mode=masked|full → hash the masked/full IP the same way.
-			- privacy.ip_mode=none → throttling disabled (no key available)
+                - Keying: compute a throttle key from the resolved client IP per §16, then apply privacy settings:
+                        - privacy.ip_mode=hash → sha256(ip + privacy.ip_salt).
+                        - privacy.ip_mode=masked → sha256(masked_ip + privacy.ip_salt).
+                        - privacy.ip_mode=full → plain IP (no hashing).
+                        - privacy.ip_mode=none → throttling disabled (no key available)
 		- Algorithm (fixed 60s window, tiny file):
 			- File shape: {"window_start": <unix>, "count": <int>, "cooldown_until": <unix|0>}.
 			- On POST: lock file with flock, roll window if now - window_start >= 60, then count++.
@@ -577,9 +578,11 @@ electronic_forms - Spec
 	
 16. PRIVACY AND IP HANDLING
 	- privacy.ip_mode = none | masked | hash | full (default masked)
-	- masked: IPv4 last octet(s) redacted; IPv6 last 80 bits zeroed (compressed)
-	- hash: sha256(ip + optional salt); store hash only
-	- include ip in email.include_fields only when mode != none
+        - masked: IPv4 last octet(s) redacted; IPv6 last 80 bits zeroed (compressed)
+        - hash: sha256(ip + optional salt); store hash only
+        - full: store/display IP as-is
+        - logs and emails honor this setting for IP presentation
+        - include ip in email.include_fields only when mode != none
 	- UA and Origin never included in emails; logging only
 	- submitted_at set server-side (UTC ISO-8601) for logs/emails
 	- By default, use REMOTE_ADDR. When behind trusted proxies, set:

--- a/src/Emailer.php
+++ b/src/Emailer.php
@@ -13,6 +13,14 @@ class Emailer
             return ['ok' => false, 'msg' => 'invalid_to'];
         }
         $meta = self::sanitizeMeta($meta);
+        if (isset($meta['ip'])) {
+            $ipDisp = Helpers::ip_display((string) $meta['ip']);
+            if ($ipDisp === '') {
+                unset($meta['ip']);
+            } else {
+                $meta['ip'] = $ipDisp;
+            }
+        }
         $subjectRaw = $tpl['email']['subject'] ?? 'Form Submission';
         $subjectRaw = self::expandTokens($subjectRaw, $canonical, $meta);
         $subject = self::sanitizeHeader($subjectRaw);

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -97,4 +97,32 @@ class Helpers
         }
         return $remote;
     }
+
+    public static function mask_ip(string $ip): string
+    {
+        if (str_contains($ip, ':')) {
+            $parts = explode(':', $ip);
+            $parts[count($parts) - 1] = '0';
+            return implode(':', $parts);
+        }
+        $parts = explode('.', $ip);
+        $parts[3] = '0';
+        return implode('.', $parts);
+    }
+
+    public static function ip_display(string $ip): string
+    {
+        $mode = Config::get('privacy.ip_mode', 'masked');
+        if ($mode === 'none' || $ip === '') {
+            return '';
+        }
+        if ($mode === 'masked') {
+            return self::mask_ip($ip);
+        }
+        if ($mode === 'hash') {
+            $salt = (string) Config::get('privacy.ip_salt', '');
+            return hash('sha256', $ip . $salt);
+        }
+        return $ip;
+    }
 }

--- a/src/Logging.php
+++ b/src/Logging.php
@@ -96,16 +96,23 @@ class Logging
         $meta = $ctx;
         unset($meta['form_id'], $meta['instance_id'], $meta['msg']);
         if (!empty($meta)) {
-            if (!Config::get('logging.pii', false)) {
-                if (isset($meta['ip'])) {
-                    $meta['ip'] = preg_replace('/\d+\.\d+\.\d+\.\d+/', 'x.x.x.x', (string) $meta['ip']);
+            if (isset($meta['ip'])) {
+                $ipDisp = Helpers::ip_display((string) $meta['ip']);
+                if ($ipDisp === '') {
+                    unset($meta['ip']);
+                } else {
+                    $meta['ip'] = $ipDisp;
                 }
+            }
+            if (!Config::get('logging.pii', false)) {
                 if (isset($meta['email'])) {
                     $parts = explode('@', (string) $meta['email']);
                     $meta['email'] = ($parts[0] ?? '') !== '' ? substr($parts[0],0,1) . '***@' . ($parts[1] ?? '') : '';
                 }
             }
-            $data['meta'] = $meta;
+            if (!empty($meta)) {
+                $data['meta'] = $meta;
+            }
         }
         if (Config::get('logging.headers', false)) {
             $headers = [];

--- a/src/Throttle.php
+++ b/src/Throttle.php
@@ -94,23 +94,13 @@ class Throttle
         if ($mode === 'none' || $ip === '') {
             return null;
         }
-        $salt = (string) Config::get('privacy.ip_salt', '');
+        if ($mode === 'full') {
+            return $ip;
+        }
         if ($mode === 'masked') {
-            $ip = self::maskIp($ip);
+            $ip = Helpers::mask_ip($ip);
         }
-        // 'hash' and 'full' use raw IP
+        $salt = (string) Config::get('privacy.ip_salt', '');
         return hash('sha256', $ip . $salt);
-    }
-
-    private static function maskIp(string $ip): string
-    {
-        if (str_contains($ip, ':')) {
-            $parts = explode(':', $ip);
-            $parts[count($parts) - 1] = '0';
-            return implode(':', $parts);
-        }
-        $parts = explode('.', $ip);
-        $parts[3] = '0';
-        return implode('.', $parts);
     }
 }


### PR DESCRIPTION
## Summary
- derive IP display for logs and emails from `privacy.ip_mode`
- throttle stores raw IP when `privacy.ip_mode=full`
- document new IP handling behavior

## Testing
- `./tests/run.sh`
- `phpunit tests/ChallengeInitTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0a3e10a7c832d97af06a65569f854