### PR TITLE
Improve logging, email handling, and template hardening

### DIFF
--- a/templates/.htaccess
+++ b/templates/.htaccess
@@ -1,7 +1,3 @@
-# Deny direct access to JSON form templates
-<IfModule mod_authz_core.c>
-  Require all denied
-</IfModule>
-<IfModule !mod_authz_core.c>
-  Deny from all
-</IfModule>
+<FilesMatch "\.(json|php)$">
+    Require all denied
+</FilesMatch>

--- a/templates/default.json
+++ b/templates/default.json
@@ -1,0 +1,18 @@
+{
+  "id": "default",
+  "version": "1",
+  "title": "Sample Form",
+  "success": { "mode": "inline", "message": "Thanks for your submission." },
+  "email": {
+    "to": "admin@example.com",
+    "subject": "New submission from {{field.name}}",
+    "email_template": "default",
+    "include_fields": ["name","email","message"]
+  },
+  "fields": [
+    {"key":"name","type":"text","label":"Your Name","required":true},
+    {"key":"email","type":"email","label":"Email","autocomplete":"email","required":true},
+    {"key":"message","type":"textarea","label":"Message","required":true}
+  ],
+  "submit_button_text": "Send"
+}

--- a/tests/UploadsLimitTest.php
+++ b/tests/UploadsLimitTest.php
@@ -26,7 +26,7 @@ final class UploadsLimitTest extends TestCase
         ];
         $res = Uploads::normalizeAndValidate($tpl, $files);
         $this->assertArrayHasKey('up', $res['errors']);
-        $this->assertSame('File too large.', $res['errors']['up'][0]);
+        $this->assertSame('This file exceeds the size limit.', $res['errors']['up'][0]);
         @unlink($tmp);
     }
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -290,7 +290,7 @@ record_result "upload: valid file handled" $ok
 # 9b) Upload too large
 EFORMS_UPLOAD_MAX_FILE_BYTES=100 run_test test_upload_reject
 ok=0
-assert_grep tmp/stdout.txt 'File too large\.' || ok=1
+assert_grep tmp/stdout.txt 'This file exceeds the size limit\.' || ok=1
 ! assert_grep tmp/uploaded.txt 'eforms-private' || ok=1
 record_result "upload: file too large rejected" $ok
 


### PR DESCRIPTION
## Summary
- enrich logging with timestamps, request URIs, spam summaries, and optional canonical data
- capture wp_mail failures and SMTP debug output; extend email autocorrect
- align upload error messages, log SHA-256 digests, and add default form template with .htaccess hardening

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c0abebe778832d920b55cb504355b4