### PR TITLE
Add template schema pointers and HTML fragment checks

### DIFF
--- a/src/schema/template.schema.json
+++ b/src/schema/template.schema.json
@@ -4,6 +4,7 @@
   "required": ["id","version","title","success","email","fields","submit_button_text"],
   "additionalProperties": false,
   "properties": {
+    "$schema": {"type": "string"},
     "id": {"type": "string"},
     "version": {"type": ["string","number"]},
     "title": {"type": "string"},

--- a/templates/contact.json
+++ b/templates/contact.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../src/schema/template.schema.json",
   "id": "contact_us",
   "version": "1",
   "title": "Contact Us",

--- a/templates/quote_request.json
+++ b/templates/quote_request.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../src/schema/template.schema.json",
   "id": "quote_request",
   "version": "1",
   "title": "Quote Request",

--- a/templates/upload_test.json
+++ b/templates/upload_test.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../src/schema/template.schema.json",
   "id": "upload_test",
   "version": "1",
   "title": "Upload Test",

--- a/tests/TemplateValidatorTest.php
+++ b/tests/TemplateValidatorTest.php
@@ -134,6 +134,25 @@ class TemplateValidatorTest extends TestCase
         $this->assertCount(4, $res['context']['fields']);
     }
 
+    public function testFragmentsMustBeBalanced(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['before_html'] = '<div>';
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $paths = array_column($res['errors'], 'path');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_FRAGMENT_UNBALANCED, $codes);
+        $this->assertContains('fields[0].before_html', $paths);
+
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['after_html'] = '</div>';
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $paths = array_column($res['errors'], 'path');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_FRAGMENT_UNBALANCED, $codes);
+        $this->assertContains('fields[0].after_html', $paths);
+    }
+
     public function testUnknownValidationRule(): void
     {
         $tpl = $this->baseTpl();


### PR DESCRIPTION
## Summary
- add `$schema` references to bundled templates for design-time linting
- validate that `before_html` and `after_html` fragments are balanced to avoid row-group boundary issues
- allow `$schema` in template schema and cover with tests

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c0b29c6220832d8da4f16645b41e0f