### PR TITLE
Only enqueue challenge script when rendering challenge

### DIFF
--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -45,13 +45,10 @@ class FormManager
             'enctype' => $hasUploads ? 'multipart/form-data' : 'application/x-www-form-urlencoded',
         ];
         $challengeMode = Config::get('challenge.mode', 'off');
-        $cookiePolicy = Config::get('security.cookie_missing_policy', 'soft');
-        if ($challengeMode !== 'off' || $cookiePolicy === 'challenge') {
+        if ($challengeMode === 'always') {
             $prov = Config::get('challenge.provider', 'turnstile');
-            if ($challengeMode === 'always') {
-                $site = Config::get('challenge.' . $prov . '.site_key', '');
-                $meta['challenge'] = ['provider' => $prov, 'site_key' => $site];
-            }
+            $site = Config::get('challenge.' . $prov . '.site_key', '');
+            $meta['challenge'] = ['provider' => $prov, 'site_key' => $site];
             Challenge::enqueueScript($prov);
         }
         $this->enqueueAssetsIfNeeded();

--- a/tests/ChallengeInitTest.php
+++ b/tests/ChallengeInitTest.php
@@ -43,9 +43,18 @@ final class ChallengeInitTest extends TestCase
         $prop->setValue(null, $data);
     }
 
-    public function testCookiePolicyChallengeEnqueuesScript(): void
+    public function testInitialGetDoesNotEnqueueScript(): void
     {
         $this->setConfig('security.cookie_missing_policy', 'challenge');
+        $fm = new FormManager();
+        $GLOBALS['wp_enqueued_scripts'] = [];
+        $fm->render('contact_us');
+        $this->assertNotContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+    }
+
+    public function testChallengeModeAlwaysEnqueuesScript(): void
+    {
+        $this->setConfig('challenge.mode', 'always');
         $fm = new FormManager();
         $GLOBALS['wp_enqueued_scripts'] = [];
         $fm->render('contact_us');


### PR DESCRIPTION
## Summary
- Avoid loading challenge script on initial GET when auto mode doesn't require it
- Add test coverage for challenge script enqueue logic

## Testing
- `phpunit tests/ChallengeInitTest.php`
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c1b39b4558832da160c9db2fc3a1ff