### PR TITLE
Align logging output with JSONL spec

### DIFF
--- a/tests/test_logging_user_agent.php
+++ b/tests/test_logging_user_agent.php
@@ -8,5 +8,5 @@ $_SERVER['HTTP_USER_AGENT'] = str_repeat('A', 300) . "\x01\x02B";
 $logfile = __DIR__ . '/tmp/uploads/eforms-private/eforms.log';
 $line = trim((string) file_get_contents($logfile));
 $data = json_decode($line, true);
-$ua = $data['headers']['user_agent'] ?? '';
+$ua = $data['meta']['headers']['user_agent'] ?? '';
 file_put_contents(__DIR__ . '/tmp/ua.txt', $ua);


### PR DESCRIPTION
## Summary
- emit JSONL fields using spec names (`ts`, `uri`, `ip`) and support `spam`, `email`, and `meta` groups
- adjust minimal logging format to match spec field names and group outputs
- update user agent test for new meta header location

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c1b8508d84832daa0673d62a025e36