### PR TITLE
Enforce upload dimension caps and failed-send cleanup

### DIFF
--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -351,6 +351,9 @@ class FormManager
             Uploads::deleteStored($canonical['_uploads']);
         }
         if (!$email['ok']) {
+            if (!empty($canonical['_uploads']) && (int) Config::get('uploads.retention_seconds', 86400) === 0) {
+                Uploads::deleteStored($canonical['_uploads']);
+            }
             $ctx = [
                 'form_id' => $formId,
                 'instance_id' => $metaInfo['instance_id'],

--- a/src/Uploads.php
+++ b/src/Uploads.php
@@ -54,6 +54,7 @@ class Uploads
         $allowedGlobal = Config::get('uploads.allowed_tokens', ['image','pdf']);
         $allowedMime = array_map('strtolower', (array) Config::get('uploads.allowed_mime', []));
         $allowedExt = array_map('strtolower', (array) Config::get('uploads.allowed_ext', []));
+        $maxImagePx = (int) Config::get('uploads.max_image_px', 50000000);
 
         foreach ($tpl['fields'] as $f) {
             $type = $f['type'] ?? '';
@@ -101,8 +102,13 @@ class Uploads
                     continue;
                 }
                 if (str_starts_with($mime, 'image/')) {
-                    if (!@getimagesize($it['tmp_name'])) {
+                    $dim = @getimagesize($it['tmp_name']);
+                    if (!$dim) {
                         $errors[$k][] = 'File upload failed. Please try again.';
+                        continue;
+                    }
+                    if ((int) $dim[0] * (int) $dim[1] > $maxImagePx) {
+                        $errors[$k][] = 'Image dimensions too large.';
                         continue;
                     }
                 }

--- a/tests/UploadFailCleanupTest.php
+++ b/tests/UploadFailCleanupTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class UploadFailCleanupTest extends TestCase
+{
+    public function testFilesRemovedWhenEmailFailsAndNoRetention(): void
+    {
+        $php = escapeshellcmd(PHP_BINARY);
+        $script = escapeshellarg(__DIR__ . '/upload_fail_cleanup_runner.php');
+        @unlink(__DIR__ . '/tmp/upload_fail_cleanup.txt');
+        foreach (glob(__DIR__ . '/tmp/uploads/eforms-private/*/*') ?: [] as $f) {
+            if (!str_contains($f, '/ledger/') && !str_contains($f, '/throttle/')) {
+                @unlink($f);
+            }
+        }
+        $ledgerDir = __DIR__ . '/tmp/uploads/eforms-private/ledger';
+        if (is_dir($ledgerDir)) {
+            foreach (glob($ledgerDir . '/*') ?: [] as $f) {
+                if (is_file($f)) @unlink($f); else @array_map('unlink', glob($f . '/*') ?: []);
+                if (is_dir($f)) @rmdir($f);
+            }
+        }
+        shell_exec("$php $script");
+        $out = trim((string) @file_get_contents(__DIR__ . '/tmp/upload_fail_cleanup.txt'));
+        $this->assertSame('', $out);
+    }
+}

--- a/tests/UploadsMaxImagePxTest.php
+++ b/tests/UploadsMaxImagePxTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Uploads;
+use EForms\Config;
+
+final class UploadsMaxImagePxTest extends TestCase
+{
+    private array $origConfig;
+
+    protected function setUp(): void
+    {
+        Config::bootstrap();
+        $ref = new \ReflectionClass(Config::class);
+        $prop = $ref->getProperty('data');
+        $prop->setAccessible(true);
+        $this->origConfig = $prop->getValue();
+        $data = $this->origConfig;
+        $data['uploads']['max_image_px'] = 100;
+        $prop->setValue(null, $data);
+    }
+
+    protected function tearDown(): void
+    {
+        $ref = new \ReflectionClass(Config::class);
+        $prop = $ref->getProperty('data');
+        $prop->setAccessible(true);
+        $prop->setValue(null, $this->origConfig);
+    }
+
+    public function testRejectsOversizedImages(): void
+    {
+        $tpl = [
+            'fields' => [
+                ['type' => 'file', 'key' => 'pic', 'accept' => ['image']],
+            ],
+        ];
+        $tmp = tempnam(sys_get_temp_dir(), 'img');
+        $png = base64_decode('iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAEklEQVQ4jWNgGAWjYBSMgqELAATEAAEeAgbGAAAAAElFTkSuQmCC');
+        file_put_contents($tmp, $png);
+        $files = [
+            'pic' => [
+                'name' => 'test.png',
+                'type' => 'image/png',
+                'tmp_name' => $tmp,
+                'error' => UPLOAD_ERR_OK,
+                'size' => filesize($tmp),
+            ],
+        ];
+        $res = Uploads::normalizeAndValidate($tpl, $files);
+        $this->assertArrayHasKey('pic', $res['errors']);
+        @unlink($tmp);
+    }
+}

--- a/tests/upload_fail_cleanup_runner.php
+++ b/tests/upload_fail_cleanup_runner.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_FORCE_MAIL_FAIL=1');
+require __DIR__ . '/bootstrap.php';
+\EForms\Config::bootstrap();
+$ref = new \ReflectionClass(\EForms\Config::class);
+$prop = $ref->getProperty('data');
+$prop->setAccessible(true);
+$data = $prop->getValue();
+$data['uploads']['retention_seconds'] = 0;
+$prop->setValue(null, $data);
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_COOKIE['eforms_t_upload_test'] = '00000000-0000-4000-8000-000000000008';
+
+$tmp = __DIR__ . '/tmp/fail_upload.pdf';
+file_put_contents($tmp, "%PDF-1.4\n");
+
+$_FILES = [
+    'upload_test' => [
+        'name' => ['file1' => 'doc.pdf'],
+        'type' => ['file1' => 'application/pdf'],
+        'tmp_name' => ['file1' => $tmp],
+        'error' => ['file1' => UPLOAD_ERR_OK],
+        'size' => ['file1' => filesize($tmp)],
+    ],
+];
+
+$_POST = [
+    'form_id' => 'upload_test',
+    'instance_id' => 'instU2',
+    'timestamp' => time(),
+    'eforms_hp' => '',
+    'upload_test' => ['name' => 'Zed'],
+    'js_ok' => '1',
+];
+
+register_shutdown_function(function () use ($tmp): void {
+    $files = array_filter(glob(__DIR__ . '/tmp/uploads/eforms-private/*/*') ?: [], function ($f) {
+        return !str_contains($f, '/ledger/') && !str_contains($f, '/throttle/');
+    });
+    file_put_contents(__DIR__ . '/tmp/upload_fail_cleanup.txt', $files ? implode("\n", $files) : '');
+    @unlink($tmp);
+});
+
+$fm = new \EForms\FormManager();
+$fm->handleSubmit();


### PR DESCRIPTION
## Summary
- enforce configurable pixel count limit for image uploads
- clean up stored uploads when email delivery fails and no retention is configured
- add regression tests for image pixel guard and failed-email cleanup

## Testing
- `phpunit tests/UploadsMaxImagePxTest.php`
- `phpunit tests/UploadFailCleanupTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1d1350984832d93640de136d6dfb4