### PR TITLE
Refine challenge script loading and honeypot messaging

### DIFF
--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -45,14 +45,10 @@ class FormManager
             'enctype' => $hasUploads ? 'multipart/form-data' : 'application/x-www-form-urlencoded',
         ];
         $challengeMode = Config::get('challenge.mode', 'off');
-        $cookiePolicy = Config::get('security.cookie_missing_policy', 'soft');
         if ($challengeMode === 'always') {
             $prov = Config::get('challenge.provider', 'turnstile');
             $site = Config::get('challenge.' . $prov . '.site_key', '');
             $meta['challenge'] = ['provider' => $prov, 'site_key' => $site];
-            Challenge::enqueueScript($prov);
-        } elseif ($challengeMode !== 'off' || $cookiePolicy === 'challenge') {
-            $prov = Config::get('challenge.provider', 'turnstile');
             Challenge::enqueueScript($prov);
         }
         $this->enqueueAssetsIfNeeded();
@@ -189,7 +185,7 @@ class FormManager
             \header('X-EForms-Stealth: 1');
             Uploads::unlinkTemps($_FILES);
             if ($mode === 'hard_fail') {
-                $this->renderErrorAndExit($tpl, $formId, 'Security check failed.');
+                $this->renderErrorAndExit($tpl, $formId, 'Form submission failed.');
             }
             $this->successAndRedirect($tpl, $formId, $_POST['instance_id'] ?? '');
             return;

--- a/templates/email/.htaccess
+++ b/templates/email/.htaccess
@@ -1,0 +1,6 @@
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>

--- a/templates/email/web.config
+++ b/templates/email/web.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <security>
+      <requestFiltering>
+        <hiddenSegments>
+          <add segment="." />
+        </hiddenSegments>
+      </requestFiltering>
+    </security>
+  </system.webServer>
+</configuration>

--- a/tests/ChallengeInitTest.php
+++ b/tests/ChallengeInitTest.php
@@ -43,22 +43,22 @@ final class ChallengeInitTest extends TestCase
         $prop->setValue(null, $data);
     }
 
-    public function testChallengeModeAutoEnqueuesScript(): void
+    public function testChallengeModeAutoDoesNotEnqueueScript(): void
     {
         $this->setConfig('challenge.mode', 'auto');
         $fm = new FormManager();
         $GLOBALS['wp_enqueued_scripts'] = [];
         $fm->render('contact_us');
-        $this->assertContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $this->assertNotContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
     }
 
-    public function testPolicyChallengeEnqueuesScript(): void
+    public function testPolicyChallengeDoesNotEnqueueScript(): void
     {
         $this->setConfig('security.cookie_missing_policy', 'challenge');
         $fm = new FormManager();
         $GLOBALS['wp_enqueued_scripts'] = [];
         $fm->render('contact_us');
-        $this->assertContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $this->assertNotContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
     }
 
     public function testChallengeModeAlwaysEnqueuesScript(): void

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -176,7 +176,7 @@ record_result "honeypot: stealth success, no email" $ok
 # 3b) Honeypot hard fail
 run_test test_honeypot_hard
 ok=0
-assert_grep tmp/stdout.txt 'Security check failed\.' || ok=1
+assert_grep tmp/stdout.txt 'Form submission failed\.' || ok=1
 ! assert_grep tmp/redirect.txt '"status":303' || ok=1
 ! assert_grep tmp/mail.json 'bot-foo|alice@example.com|zed@example.com' || ok=1
 assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_HONEYPOT' || ok=1


### PR DESCRIPTION
## Summary
- Load challenge provider scripts only when a challenge widget is actually rendered
- Show spec-compliant "Form submission failed." on honeypot hard-fails
- Harden email template directory with deny rules

## Testing
- `phpunit -c phpunit.xml.dist $(find tests -maxdepth 1 -name '*Test.php')`
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c1fe19a298832d98673019a2e78137