### PR TITLE
Log throttle state on honeypot submissions

### DIFF
--- a/src/FormManager.php
+++ b/src/FormManager.php
@@ -167,6 +167,10 @@ class FormManager
         // Honeypot
         $token = $hasHidden ? (string)$postedToken : $cookieToken;
         if (!empty($_POST['eforms_hp'])) {
+            $thr = ['state' => 'ok'];
+            if (Config::get('throttle.enable', false)) {
+                $thr = Throttle::check(Helpers::client_ip());
+            }
             $res = Security::ledger_reserve($formId, $token);
             if (!$res['ok'] && !empty($res['io'])) {
                 Logging::write('error', 'EFORMS_LEDGER_IO', [
@@ -181,6 +185,7 @@ class FormManager
                 'form_id' => $formId,
                 'instance_id' => $_POST['instance_id'] ?? '',
                 'stealth' => $stealth,
+                'throttle_state' => $thr['state'] ?? 'ok',
             ]);
             \header('X-EForms-Stealth: 1');
             Uploads::unlinkTemps($_FILES);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -183,7 +183,16 @@ assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_HONEYPOT' || ok=1
 assert_grep tmp/uploads/eforms-private/eforms.log '"stealth":false' || ok=1
 record_result "honeypot: hard fail" $ok
 
-# 3c) Timing checks
+# 3c) Honeypot throttle increments
+EFORMS_THROTTLE_ENABLE=1 EFORMS_THROTTLE_MAX_PER_MINUTE=1 run_test test_honeypot_throttle_first
+EFORMS_THROTTLE_ENABLE=1 EFORMS_THROTTLE_MAX_PER_MINUTE=1 run_test_keep test_honeypot_throttle_second
+ok=0
+assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_HONEYPOT' || ok=1
+assert_grep tmp/uploads/eforms-private/eforms.log '"throttle_state":"ok"' || ok=1
+assert_grep tmp/uploads/eforms-private/eforms.log '"throttle_state":"over"' || ok=1
+record_result "honeypot: throttle increments logged" $ok
+
+# 3d) Timing checks
 run_test test_timing_min_fill
 ok=0
 assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_MIN_FILL' || ok=1
@@ -196,7 +205,7 @@ assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_FORM_AGE' || ok=1
 assert_grep tmp/mail.json 'zed@example.com' || ok=1
 record_result "timing: expired form soft fail" $ok
 
-# 3d) JS disabled checks
+# 3e) JS disabled checks
 run_test test_js_soft
 ok=0
 assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_JS_DISABLED' || ok=1

--- a/tests/test_honeypot_throttle_first.php
+++ b/tests/test_honeypot_throttle_first.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_LOG_LEVEL=1');
+putenv('EFORMS_THROTTLE_ENABLE=1');
+putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000014';
+
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instHT1',
+    'timestamp' => time(),
+    'eforms_hp' => 'bot',
+    'contact_us' => [
+        'name' => '',
+        'email' => '',
+        'message' => '',
+    ],
+];
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();

--- a/tests/test_honeypot_throttle_second.php
+++ b/tests/test_honeypot_throttle_second.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+putenv('EFORMS_LOG_LEVEL=1');
+putenv('EFORMS_THROTTLE_ENABLE=1');
+putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
+require __DIR__ . '/bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000015';
+
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instHT2',
+    'timestamp' => time(),
+    'eforms_hp' => 'bot',
+    'contact_us' => [
+        'name' => '',
+        'email' => '',
+        'message' => '',
+    ],
+];
+
+$fm = new \EForms\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();


### PR DESCRIPTION
## Summary
- ensure honeypot hits increment throttle counters and record resulting state
- log throttle state in `EFORMS_ERR_HONEYPOT`
- add tests covering honeypot-triggered throttling and logging

## Testing
- `./tests/run.sh` *(fails: template schema parity)*

------
https://chatgpt.com/codex/tasks/task_e_68c21342e064832dbc577f692b19a3f3