### PR TITLE
Refactor Spec registry into handler-aware descriptors

### DIFF
--- a/src/Spec.php
+++ b/src/Spec.php
@@ -8,143 +8,266 @@ namespace EForms;
  */
 class Spec
 {
-    private const REGISTRY = [
-        'name' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'input','type'=>'text','autocomplete'=>'name'],
-            'validate' => [],
-        ],
-        'first_name' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'input','type'=>'text','autocomplete'=>'given-name'],
-            'validate' => [],
-        ],
-        'last_name' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'input','type'=>'text','autocomplete'=>'family-name'],
-            'validate' => [],
-        ],
-        'text' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'input','type'=>'text','attrs_mirror'=>['maxlength'=>null,'minlength'=>null]],
-            'validate' => [],
-        ],
-        'email' => [
-            'is_multivalue' => false,
-            'html' => [
-                'tag'=>'input',
-                'type'=>'email',
-                'inputmode'=>'email',
-                'spellcheck'=>'false',
-                'autocapitalize'=>'off',
-                'autocomplete'=>'email',
-                'attrs_mirror'=>[],
-            ],
-            'validate' => [],
-        ],
-        'url' => [
-            'is_multivalue' => false,
-            'html' => [
-                'tag'=>'input',
-                'type'=>'url',
-                'spellcheck'=>'false',
-                'autocapitalize'=>'off',
-                'attrs_mirror'=>['maxlength'=>null,'minlength'=>null],
-            ],
-            'validate' => [],
-        ],
-        'tel' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'input','type'=>'tel','inputmode'=>'tel','autocomplete'=>'tel','attrs_mirror'=>['maxlength'=>null]],
-            'validate' => [],
-        ],
-        'tel_us' => [
-            'is_multivalue' => false,
-            'html' => [
-                'tag'=>'input',
-                'type'=>'tel',
-                'inputmode'=>'tel',
-                'pattern'=>'\d{3}-?\d{3}-?\d{4}',
-                'autocomplete'=>'tel',
-                'attrs_mirror'=>['maxlength'=>null],
-            ],
-            'validate' => [],
-        ],
-        'number' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'input','type'=>'number','inputmode'=>'decimal','attrs_mirror'=>['min'=>null,'max'=>null,'step'=>null]],
-            'validate' => [],
-        ],
-        'range' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'input','type'=>'range','inputmode'=>'decimal','attrs_mirror'=>['min'=>null,'max'=>null,'step'=>null]],
-            'validate' => [],
-        ],
-        'date' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'input','type'=>'date','attrs_mirror'=>['min'=>null,'max'=>null,'step'=>null]],
-            'validate' => [],
-        ],
-        'textarea' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'textarea','attrs_mirror'=>['maxlength'=>null,'minlength'=>null]],
-            'validate' => [],
-        ],
-        'textarea_html' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'textarea','attrs_mirror'=>['maxlength'=>null,'minlength'=>null]],
-            'validate' => [],
-        ],
-        'zip' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'input','type'=>'text','attrs_mirror'=>['maxlength'=>null,'minlength'=>null]],
-            'validate' => [],
-        ],
-        'zip_us' => [
-            'is_multivalue' => false,
-            'html' => [
-                'tag'=>'input',
-                'type'=>'text',
-                'inputmode'=>'numeric',
-                'pattern'=>'\d{5}',
-                'autocomplete'=>'postal-code',
-                'attrs_mirror'=>['maxlength'=>5],
-            ],
-            'validate' => ['pattern'=>'/^\d{5}$/'],
-        ],
-        'select' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'select'],
-            'validate' => [],
-        ],
-        'radio' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'fieldset'],
-            'validate' => [],
-        ],
-        'checkbox' => [
-            'is_multivalue' => true,
-            'html' => ['tag'=>'fieldset'],
-            'validate' => [],
-        ],
-        'file' => [
-            'is_multivalue' => false,
-            'html' => ['tag'=>'input','type'=>'file'],
-            'validate' => [],
-        ],
-        'files' => [
-            'is_multivalue' => true,
-            'html' => ['tag'=>'input','type'=>'file','multiple'=>true],
-            'validate' => [],
-        ],
+    private const HANDLERS_DEFAULT = [
+        'validator_id' => '',
+        'normalizer_id' => '',
+        'renderer_id' => '',
     ];
+    private const HANDLERS_TEXT = [
+        'validator_id' => 'text',
+        'normalizer_id' => 'text',
+        'renderer_id' => 'text',
+    ];
+    private const HANDLERS_EMAIL = [
+        'validator_id' => 'email',
+        'normalizer_id' => 'email',
+        'renderer_id' => 'email',
+    ];
+    private const HANDLERS_URL = [
+        'validator_id' => 'url',
+        'normalizer_id' => 'url',
+        'renderer_id' => 'url',
+    ];
+    private const HANDLERS_TEL = [
+        'validator_id' => 'tel',
+        'normalizer_id' => 'tel',
+        'renderer_id' => 'tel',
+    ];
+    private const HANDLERS_TEL_US = [
+        'validator_id' => 'tel_us',
+        'normalizer_id' => 'tel_us',
+        'renderer_id' => 'tel_us',
+    ];
+    private const HANDLERS_NUMBER = [
+        'validator_id' => 'number',
+        'normalizer_id' => 'number',
+        'renderer_id' => 'number',
+    ];
+    private const HANDLERS_RANGE = [
+        'validator_id' => 'range',
+        'normalizer_id' => 'range',
+        'renderer_id' => 'range',
+    ];
+    private const HANDLERS_DATE = [
+        'validator_id' => 'date',
+        'normalizer_id' => 'date',
+        'renderer_id' => 'date',
+    ];
+    private const HANDLERS_TEXTAREA = [
+        'validator_id' => 'textarea',
+        'normalizer_id' => 'textarea',
+        'renderer_id' => 'textarea',
+    ];
+    private const HANDLERS_TEXTAREA_HTML = [
+        'validator_id' => 'textarea_html',
+        'normalizer_id' => 'textarea_html',
+        'renderer_id' => 'textarea_html',
+    ];
+    private const HANDLERS_ZIP = [
+        'validator_id' => 'zip',
+        'normalizer_id' => 'zip',
+        'renderer_id' => 'zip',
+    ];
+    private const HANDLERS_ZIP_US = [
+        'validator_id' => 'zip_us',
+        'normalizer_id' => 'zip_us',
+        'renderer_id' => 'zip_us',
+    ];
+    private const HANDLERS_SELECT = [
+        'validator_id' => 'select',
+        'normalizer_id' => 'select',
+        'renderer_id' => 'select',
+    ];
+    private const HANDLERS_RADIO = [
+        'validator_id' => 'radio',
+        'normalizer_id' => 'radio',
+        'renderer_id' => 'radio',
+    ];
+    private const HANDLERS_CHECKBOX = [
+        'validator_id' => 'checkbox',
+        'normalizer_id' => 'checkbox',
+        'renderer_id' => 'checkbox',
+    ];
+    private const HANDLERS_FILE = [
+        'validator_id' => 'file',
+        'normalizer_id' => 'file',
+        'renderer_id' => 'file',
+    ];
+    private const HANDLERS_FILES = [
+        'validator_id' => 'files',
+        'normalizer_id' => 'files',
+        'renderer_id' => 'files',
+    ];
+
+    /**
+     * Return descriptors for all built-in field types.
+     */
+    public static function typeDescriptors(): array
+    {
+        return [
+            'name' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'input','type'=>'text','autocomplete'=>'name'],
+                'validate' => [],
+                'handlers' => self::HANDLERS_TEXT,
+            ],
+            'first_name' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'input','type'=>'text','autocomplete'=>'given-name'],
+                'validate' => [],
+                'handlers' => self::HANDLERS_TEXT,
+            ],
+            'last_name' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'input','type'=>'text','autocomplete'=>'family-name'],
+                'validate' => [],
+                'handlers' => self::HANDLERS_TEXT,
+            ],
+            'text' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'input','type'=>'text','attrs_mirror'=>['maxlength'=>null,'minlength'=>null]],
+                'validate' => [],
+                'handlers' => self::HANDLERS_TEXT,
+            ],
+            'email' => [
+                'is_multivalue' => false,
+                'html' => [
+                    'tag'=>'input',
+                    'type'=>'email',
+                    'inputmode'=>'email',
+                    'spellcheck'=>'false',
+                    'autocapitalize'=>'off',
+                    'autocomplete'=>'email',
+                    'attrs_mirror'=>[],
+                ],
+                'validate' => [],
+                'handlers' => self::HANDLERS_EMAIL,
+            ],
+            'url' => [
+                'is_multivalue' => false,
+                'html' => [
+                    'tag'=>'input',
+                    'type'=>'url',
+                    'spellcheck'=>'false',
+                    'autocapitalize'=>'off',
+                    'attrs_mirror'=>['maxlength'=>null,'minlength'=>null],
+                ],
+                'validate' => [],
+                'handlers' => self::HANDLERS_URL,
+            ],
+            'tel' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'input','type'=>'tel','inputmode'=>'tel','autocomplete'=>'tel','attrs_mirror'=>['maxlength'=>null]],
+                'validate' => [],
+                'handlers' => self::HANDLERS_TEL,
+            ],
+            'tel_us' => [
+                'is_multivalue' => false,
+                'html' => [
+                    'tag'=>'input',
+                    'type'=>'tel',
+                    'inputmode'=>'tel',
+                    'pattern'=>'\\d{3}-?\\d{3}-?\\d{4}',
+                    'autocomplete'=>'tel',
+                    'attrs_mirror'=>['maxlength'=>null],
+                ],
+                'validate' => [],
+                'handlers' => self::HANDLERS_TEL_US,
+            ],
+            'number' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'input','type'=>'number','inputmode'=>'decimal','attrs_mirror'=>['min'=>null,'max'=>null,'step'=>null]],
+                'validate' => [],
+                'handlers' => self::HANDLERS_NUMBER,
+            ],
+            'range' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'input','type'=>'range','inputmode'=>'decimal','attrs_mirror'=>['min'=>null,'max'=>null,'step'=>null]],
+                'validate' => [],
+                'handlers' => self::HANDLERS_RANGE,
+            ],
+            'date' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'input','type'=>'date','attrs_mirror'=>['min'=>null,'max'=>null,'step'=>null]],
+                'validate' => [],
+                'handlers' => self::HANDLERS_DATE,
+            ],
+            'textarea' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'textarea','attrs_mirror'=>['maxlength'=>null,'minlength'=>null]],
+                'validate' => [],
+                'handlers' => self::HANDLERS_TEXTAREA,
+            ],
+            'textarea_html' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'textarea','attrs_mirror'=>['maxlength'=>null,'minlength'=>null]],
+                'validate' => [],
+                'handlers' => self::HANDLERS_TEXTAREA_HTML,
+            ],
+            'zip' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'input','type'=>'text','attrs_mirror'=>['maxlength'=>null,'minlength'=>null]],
+                'validate' => [],
+                'handlers' => self::HANDLERS_ZIP,
+            ],
+            'zip_us' => [
+                'is_multivalue' => false,
+                'html' => [
+                    'tag'=>'input',
+                    'type'=>'text',
+                    'inputmode'=>'numeric',
+                    'pattern'=>'\\d{5}',
+                    'autocomplete'=>'postal-code',
+                    'attrs_mirror'=>['maxlength'=>5],
+                ],
+                'validate' => ['pattern'=>'/^\\d{5}$/'],
+                'handlers' => self::HANDLERS_ZIP_US,
+            ],
+            'select' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'select'],
+                'validate' => [],
+                'handlers' => self::HANDLERS_SELECT,
+            ],
+            'radio' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'fieldset'],
+                'validate' => [],
+                'handlers' => self::HANDLERS_RADIO,
+            ],
+            'checkbox' => [
+                'is_multivalue' => true,
+                'html' => ['tag'=>'fieldset'],
+                'validate' => [],
+                'handlers' => self::HANDLERS_CHECKBOX,
+            ],
+            'file' => [
+                'is_multivalue' => false,
+                'html' => ['tag'=>'input','type'=>'file'],
+                'validate' => [],
+                'handlers' => self::HANDLERS_FILE,
+            ],
+            'files' => [
+                'is_multivalue' => true,
+                'html' => ['tag'=>'input','type'=>'file','multiple'=>true],
+                'validate' => [],
+                'handlers' => self::HANDLERS_FILES,
+            ],
+        ];
+    }
 
     /**
      * Returns descriptor for field type.
      */
     public static function descriptorFor(string $type): array
     {
-        return self::REGISTRY[$type] ?? ['is_multivalue'=>false,'html'=>['tag'=>'input'],'validate'=>[]];
+        $all = self::typeDescriptors();
+        return $all[$type] ?? [
+            'is_multivalue' => false,
+            'html' => ['tag'=>'input'],
+            'validate' => [],
+            'handlers' => self::HANDLERS_DEFAULT,
+        ];
     }
 
     /**
@@ -166,3 +289,4 @@ class Spec
         ];
     }
 }
+


### PR DESCRIPTION
## Summary
- replace Spec's static REGISTRY with a `typeDescriptors()` method that returns descriptors enriched with validator, normalizer, and renderer handler IDs
- expose handler constants and update `descriptorFor()` to use the new descriptors and default handler mapping

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f24fafd8832dae01c933389e7e73