### PR TITLE
Cache resolved descriptors

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -217,8 +217,7 @@ class Renderer
             $before = isset($f['before_html']) ? self::sanitizeFragment($f['before_html']) : '';
             $after = isset($f['after_html']) ? self::sanitizeFragment($f['after_html']) : '';
             $html .= $before;
-            $rendererId = $desc['handlers']['renderer_id'] ?? '';
-            $handler = self::resolve($rendererId);
+            $handler = $desc['handlers']['renderer'] ?? self::resolve($desc['handlers']['renderer_id'] ?? '');
             $ctx = [
                 'desc' => $desc,
                 'f' => $f,

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -101,6 +101,9 @@ class Validator
     }
     public static function descriptors(array $tpl): array
     {
+        if (isset($tpl['descriptors']) && is_array($tpl['descriptors'])) {
+            return $tpl['descriptors'];
+        }
         $desc = [];
         foreach ($tpl['fields'] as $f) {
             if (($f['type'] ?? '') === 'row_group') {


### PR DESCRIPTION
## Summary
- merge template field attributes into base Spec descriptors
- resolve validator, normalizer, and renderer handlers up front
- reuse cached descriptors via Validator::descriptors

## Testing
- `php -l src/TemplateValidator.php`
- `php -l src/Renderer.php`
- `php -l src/Validator.php`
- `phpunit --testdox tests` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ff9db26c832da9fbd275b1250814