### PR TITLE
Refactor validator handlers

### DIFF
--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -586,10 +586,11 @@ class TemplateValidator
 
             $handlers = $d['handlers'] ?? [];
             $d['handlers'] = [
-                'validator'  => Validator::resolve($handlers['validator_id'] ?? ''),
-                'normalizer' => Validator::resolve($handlers['normalizer_id'] ?? ''),
+                'validator'  => Validator::resolve($handlers['validator_id'] ?? '', 'validator'),
+                'normalizer' => Validator::resolve($handlers['normalizer_id'] ?? '', 'normalizer'),
                 'renderer'   => Renderer::resolve($handlers['renderer_id'] ?? ''),
             ];
+            $d['form_id'] = $tpl['id'] ?? '';
 
             $desc[$f['key']] = $d;
         }

--- a/tests/AliasTypesParityTest.php
+++ b/tests/AliasTypesParityTest.php
@@ -17,8 +17,8 @@ final class AliasTypesParityTest extends TestCase
             $desc = Spec::descriptorFor($t);
             $handlers = $desc['handlers'];
             $callables[] = [
-                'validator' => Validator::resolve($handlers['validator_id']),
-                'normalizer' => Validator::resolve($handlers['normalizer_id']),
+                'validator' => Validator::resolve($handlers['validator_id'], 'validator'),
+                'normalizer' => Validator::resolve($handlers['normalizer_id'], 'normalizer'),
                 'renderer' => Renderer::resolve($handlers['renderer_id']),
             ];
             $autocomplete[$t] = $desc['html']['autocomplete'] ?? '';

--- a/tests/DescriptorsResolutionTest.php
+++ b/tests/DescriptorsResolutionTest.php
@@ -13,8 +13,8 @@ final class DescriptorsResolutionTest extends TestCase
         $all = Spec::typeDescriptors();
         foreach ($all as $type => $desc) {
             $handlers = $desc['handlers'];
-            $v = Validator::resolve($handlers['validator_id'] ?? '');
-            $n = Validator::resolve($handlers['normalizer_id'] ?? '');
+            $v = Validator::resolve($handlers['validator_id'] ?? '', 'validator');
+            $n = Validator::resolve($handlers['normalizer_id'] ?? '', 'normalizer');
             $r = Renderer::resolve($handlers['renderer_id'] ?? '');
             $this->assertTrue(is_callable($v), "$type validator");
             $this->assertTrue(is_callable($n), "$type normalizer");
@@ -25,6 +25,6 @@ final class DescriptorsResolutionTest extends TestCase
     public function testUnknownHandlerIdFails(): void
     {
         $this->expectException(\RuntimeException::class);
-        Validator::resolve('unknown');
+        Validator::resolve('unknown', 'validator');
     }
 }

--- a/tests/ValidatorFieldValidationTest.php
+++ b/tests/ValidatorFieldValidationTest.php
@@ -30,4 +30,24 @@ final class ValidatorFieldValidationTest extends TestCase
         $errors = $this->validate(['type' => 'text', 'key' => 't', 'pattern' => '[A-Z]+'], 'abc');
         $this->assertArrayHasKey('t', $errors);
     }
+
+    public function testValidatorCallableExecutes(): void
+    {
+        $called = false;
+        $field = [
+            'type' => 'text',
+            'key' => 't',
+            'handlers' => [
+                'validator' => function ($v, $f, &$errors) use (&$called) {
+                    $called = true;
+                    return $v;
+                },
+                'normalizer' => [Validator::class, 'identity'],
+            ],
+        ];
+        $tpl = ['fields' => [$field]];
+        $desc = ['t' => $field];
+        Validator::validate($tpl, $desc, ['t' => 'foo']);
+        $this->assertTrue($called);
+    }
 }


### PR DESCRIPTION
## Summary
- Separate normalizers and validators with dedicated `VALIDATORS` map and resolver.
- Replace `validate()` switch with registered validator callables and add specific validators (email, URL, ZIP, etc.).
- Populate descriptor handler callables and form IDs during template validation.
- Extend tests for handler resolution and validator execution.

## Testing
- `tests/run.sh` *(fails: ASSERT FAIL and non-zero exit code for several scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_68c3059e7cdc832da78dabee3d4052d9