### PR TITLE
Add tests for uploads limits and success cookies

### DIFF
--- a/tests/EmailAttachmentOverflowTest.php
+++ b/tests/EmailAttachmentOverflowTest.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Emailer;
+use EForms\Config;
+
+final class EmailAttachmentOverflowTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $TEST_ARTIFACTS;
+        @file_put_contents($TEST_ARTIFACTS['mail_file'], '[]');
+        $ref = new \ReflectionClass(Config::class);
+        $boot = $ref->getProperty('bootstrapped');
+        $boot->setAccessible(true);
+        $boot->setValue(false);
+        $data = $ref->getProperty('data');
+        $data->setAccessible(true);
+        $data->setValue([]);
+        add_filter('eforms_config', function ($defaults) {
+            $defaults['uploads']['max_email_bytes'] = 100;
+            return $defaults;
+        });
+        Config::bootstrap();
+    }
+
+    public function testOverflowAttachmentsSummarized(): void
+    {
+        $tpl = [
+            'id' => 't1',
+            'version' => '1',
+            'title' => 't',
+            'success' => ['mode' => 'inline'],
+            'email' => ['to' => 'a@example.com', 'subject' => 's', 'email_template' => 'default', 'include_fields' => []],
+            'fields' => [
+                ['type' => 'file', 'key' => 'doc1', 'accept' => ['pdf'], 'email_attach' => true],
+                ['type' => 'file', 'key' => 'doc2', 'accept' => ['pdf'], 'email_attach' => true],
+            ],
+            'submit_button_text' => 'Send',
+            'rules' => [],
+        ];
+        $canonical = [
+            '_uploads' => [
+                'doc1' => [
+                    ['path' => 'a/a.pdf', 'size' => 60, 'mime' => 'application/pdf', 'original_name' => 'a.pdf', 'original_name_safe' => 'a.pdf'],
+                ],
+                'doc2' => [
+                    ['path' => 'a/b.pdf', 'size' => 60, 'mime' => 'application/pdf', 'original_name' => 'b.pdf', 'original_name_safe' => 'b.pdf'],
+                ],
+            ],
+        ];
+        $meta = ['form_id' => 't1', 'instance_id' => 'i1'];
+        Emailer::send($tpl, $canonical, $meta);
+        global $TEST_ARTIFACTS;
+        $mail = json_decode((string) file_get_contents($TEST_ARTIFACTS['mail_file']), true);
+        $this->assertCount(1, $mail[0]['attachments']);
+        $this->assertSame('a.pdf', $mail[0]['attachments'][0]['name']);
+        $this->assertStringContainsString('Omitted attachments: b.pdf', $mail[0]['message']);
+    }
+}
+

--- a/tests/SuccessAntiSpoofTest.php
+++ b/tests/SuccessAntiSpoofTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Config;
+
+final class SuccessAntiSpoofTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Config::bootstrap();
+    }
+
+    public function testNoSuccessWithQueryOnly(): void
+    {
+        header_remove();
+        $_GET = ['eforms_success' => 'contact_us'];
+        $_COOKIE = [];
+        $fm = new \EForms\FormManager();
+        $html = $fm->render('contact_us');
+        $this->assertStringNotContainsString('Thanks! We got your message.', $html);
+    }
+
+    public function testNoSuccessWithCookieOnly(): void
+    {
+        header_remove();
+        $_GET = [];
+        $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
+        $fm = new \EForms\FormManager();
+        $html = $fm->render('contact_us');
+        $this->assertStringNotContainsString('Thanks! We got your message.', $html);
+    }
+
+    public function testNoSuccessWithMismatchedCookie(): void
+    {
+        header_remove();
+        $_GET = ['eforms_success' => 'contact_us'];
+        $_COOKIE = ['eforms_s_contact_us' => 'other:inst'];
+        $fm = new \EForms\FormManager();
+        $html = $fm->render('contact_us');
+        $this->assertStringNotContainsString('Thanks! We got your message.', $html);
+    }
+
+    public function testSuccessWithMatchingCookieAndQuery(): void
+    {
+        header_remove();
+        $_GET = ['eforms_success' => 'contact_us'];
+        $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
+        $fm = new \EForms\FormManager();
+        $html = $fm->render('contact_us');
+        $this->assertStringContainsString('Thanks! We got your message.', $html);
+    }
+}
+

--- a/tests/UploadsLimitTest.php
+++ b/tests/UploadsLimitTest.php
@@ -3,9 +3,28 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use EForms\Uploads;
+use EForms\Config;
 
 final class UploadsLimitTest extends TestCase
 {
+    private function rebootstrap(array $overrides): void
+    {
+        global $TEST_FILTERS;
+        $TEST_FILTERS = [];
+        $ref = new \ReflectionClass(Config::class);
+        $boot = $ref->getProperty('bootstrapped');
+        $boot->setAccessible(true);
+        $boot->setValue(false);
+        $data = $ref->getProperty('data');
+        $data->setAccessible(true);
+        $data->setValue([]);
+        add_filter('eforms_config', function ($defaults) use ($overrides) {
+            $defaults['uploads'] = array_replace($defaults['uploads'], $overrides);
+            return $defaults;
+        });
+        Config::bootstrap();
+    }
+
     public function testMaxFileBytesPerField(): void
     {
         $tpl = [
@@ -53,6 +72,70 @@ final class UploadsLimitTest extends TestCase
         $res = Uploads::normalizeAndValidate($tpl, $files);
         $this->assertArrayHasKey('docs', $res['errors']);
         $this->assertSame('Too many files.', $res['errors']['docs'][0]);
+        @unlink($tmp1);
+        @unlink($tmp2);
+    }
+
+    public function testMaxFieldTotalBytes(): void
+    {
+        $this->rebootstrap(['total_field_bytes' => 100]);
+        $tpl = [
+            'fields' => [
+                ['type' => 'files', 'key' => 'docs', 'accept' => ['pdf']],
+            ],
+        ];
+        $tmp1 = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp1, "%PDF-1.4\n" . str_repeat('A', 60));
+        $tmp2 = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp2, "%PDF-1.4\n" . str_repeat('A', 60));
+        $files = [
+            'docs' => [
+                'name' => ['a.pdf', 'b.pdf'],
+                'type' => ['application/pdf', 'application/pdf'],
+                'tmp_name' => [$tmp1, $tmp2],
+                'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_OK],
+                'size' => [filesize($tmp1), filesize($tmp2)],
+            ],
+        ];
+        $res = Uploads::normalizeAndValidate($tpl, $files);
+        $this->assertArrayHasKey('docs', $res['errors']);
+        $this->assertSame('This file exceeds the size limit.', $res['errors']['docs'][0]);
+        @unlink($tmp1);
+        @unlink($tmp2);
+    }
+
+    public function testMaxTotalRequestBytes(): void
+    {
+        $this->rebootstrap(['total_request_bytes' => 100]);
+        $tpl = [
+            'fields' => [
+                ['type' => 'file', 'key' => 'a', 'accept' => ['pdf']],
+                ['type' => 'file', 'key' => 'b', 'accept' => ['pdf']],
+            ],
+        ];
+        $tmp1 = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp1, "%PDF-1.4\n" . str_repeat('A', 60));
+        $tmp2 = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp2, "%PDF-1.4\n" . str_repeat('A', 60));
+        $files = [
+            'a' => [
+                'name' => 'a.pdf',
+                'type' => 'application/pdf',
+                'tmp_name' => $tmp1,
+                'error' => UPLOAD_ERR_OK,
+                'size' => filesize($tmp1),
+            ],
+            'b' => [
+                'name' => 'b.pdf',
+                'type' => 'application/pdf',
+                'tmp_name' => $tmp2,
+                'error' => UPLOAD_ERR_OK,
+                'size' => filesize($tmp2),
+            ],
+        ];
+        $res = Uploads::normalizeAndValidate($tpl, $files);
+        $this->assertArrayHasKey('_global', $res['errors']);
+        $this->assertSame('File upload failed. Please try again.', $res['errors']['_global'][0]);
         @unlink($tmp1);
         @unlink($tmp2);
     }


### PR DESCRIPTION
## Summary
- cover upload caps for field and request totals
- test email attachment overflow summarization
- ensure success message only shows with matching cookie and query

## Testing
- `/root/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/UploadsLimitTest.php tests/EmailAttachmentOverflowTest.php tests/SuccessAntiSpoofTest.php`
- `bash tests/run.sh` *(fails: template schema parity)*

------
https://chatgpt.com/codex/tasks/task_e_68c314d10a30832d969a8285fabddbdb