### PR TITLE
test: guard JSON schema parity

### DIFF
--- a/tests/SchemaParityTest.php
+++ b/tests/SchemaParityTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+
+use EForms\Spec;
+
+// Load JSON schema
+$schemaPath = realpath(__DIR__ . '/../src/schema/template.schema.json');
+if (!is_string($schemaPath)) {
+    fwrite(STDERR, "schema not found\n");
+    exit(1);
+}
+$schema = json_decode(file_get_contents($schemaPath), true);
+if (!is_array($schema)) {
+    fwrite(STDERR, "schema parse fail\n");
+    exit(1);
+}
+
+// Compare field type enum
+$schemaTypes = $schema['definitions']['field']['properties']['type']['enum'] ?? [];
+sort($schemaTypes);
+
+$specDescriptors = Spec::typeDescriptors();
+$specTypes = array_keys($specDescriptors);
+$specTypes[] = 'row_group';
+sort($specTypes);
+
+if ($schemaTypes !== $specTypes) {
+    fwrite(STDERR, "field type enum mismatch\n");
+    exit(1);
+}
+
+// Schema required keys for field object
+$schemaRequired = $schema['definitions']['field']['required'] ?? [];
+sort($schemaRequired);
+if ($schemaRequired !== ['type']) {
+    fwrite(STDERR, "schema required keys drift\n");
+    exit(1);
+}
+
+// Descriptor structural shape
+$expectedKeys = ['handlers','html','is_multivalue','type','validate'];
+foreach ($specDescriptors as $t => $desc) {
+    $keys = array_keys($desc);
+    sort($keys);
+    if ($keys !== $expectedKeys) {
+        fwrite(STDERR, "descriptor shape drift: $t\n");
+        exit(1);
+    }
+    if (($desc['type'] ?? '') !== $t) {
+        fwrite(STDERR, "descriptor type mismatch: $t\n");
+        exit(1);
+    }
+}
+
+echo "OK\n";

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -79,6 +79,12 @@ ok=0
 assert_grep tmp/stdout.txt '^OK$' || ok=1
 record_result "template schema parity" $ok
 
+# Spec vs schema parity
+run_test SchemaParityTest
+ok=0
+assert_grep tmp/stdout.txt '^OK$' || ok=1
+record_result "spec schema parity" $ok
+
 # Prime endpoint cookie attributes
 run_test test_prime_cookie
 ok=0

--- a/tests/tmp/headers.txt
+++ b/tests/tmp/headers.txt
@@ -1,1 +1,0 @@
-Cache-Control: private, no-store, max-age=0


### PR DESCRIPTION
## Summary
- add SchemaParityTest to ensure `Spec::typeDescriptors()` matches `template.schema.json`
- run schema/spec parity check in CI suite

## Testing
- `pip install --quiet jsonschema`
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c3318b801c832d996b7c1373879662