### PR TITLE
Refactor normalization logic into dedicated Normalizer

### DIFF
--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace EForms;
+
+class Normalizer
+{
+    /**
+     * Registry mapping normalizer IDs to callable handlers.
+     */
+    private const HANDLERS = [
+        '' => [self::class, 'identity'],
+        'text' => [self::class, 'identity'],
+        'email' => [self::class, 'normalizeEmail'],
+        'url' => [self::class, 'identity'],
+        'tel' => [self::class, 'identity'],
+        'tel_us' => [self::class, 'normalizeTelUs'],
+        'number' => [self::class, 'identity'],
+        'range' => [self::class, 'identity'],
+        'date' => [self::class, 'identity'],
+        'textarea' => [self::class, 'identity'],
+        'textarea_html' => [self::class, 'identity'],
+        'zip' => [self::class, 'identity'],
+        'zip_us' => [self::class, 'identity'],
+        'select' => [self::class, 'identity'],
+        'radio' => [self::class, 'identity'],
+        'checkbox' => [self::class, 'identity'],
+        'file' => [self::class, 'identity'],
+        'files' => [self::class, 'identity'],
+    ];
+
+    /**
+     * Resolve a normalizer handler by identifier.
+     *
+     * @throws \RuntimeException when the identifier is unknown
+     */
+    public static function resolve(string $id): callable
+    {
+        if (!isset(self::HANDLERS[$id])) {
+            throw new \RuntimeException('Unknown normalizer ID: ' . $id);
+        }
+        return self::HANDLERS[$id];
+    }
+
+    /**
+     * Default passthrough handler used for types that do not require
+     * additional normalization.
+     *
+     * @param mixed $v
+     * @return mixed
+     */
+    public static function identity($v)
+    {
+        return $v;
+    }
+
+    /**
+     * Normalize email addresses by lowercasing the domain component.
+     */
+    public static function normalizeEmail(string $v): string
+    {
+        if ($v !== '' && strpos($v, '@') !== false) {
+            [$local, $domain] = explode('@', $v, 2);
+            return $local . '@' . strtolower($domain);
+        }
+        return $v;
+    }
+
+    /**
+     * Normalize US telephone numbers by stripping non-digits and
+     * removing a leading country code of 1.
+     */
+    public static function normalizeTelUs(string $v): string
+    {
+        $digits = preg_replace('/\D+/', '', $v);
+        if (strlen($digits) === 11 && str_starts_with($digits, '1')) {
+            $digits = substr($digits, 1);
+        }
+        return $digits;
+    }
+}

--- a/src/TemplateValidator.php
+++ b/src/TemplateValidator.php
@@ -589,8 +589,8 @@ class TemplateValidator
             $d['handlers'] = [];
 
             $handlerTypes = [
-                'validator'  => ['id' => $handlers['validator_id'] ?? '', 'resolver' => fn(string $id) => Validator::resolve($id, 'validator')],
-                'normalizer' => ['id' => $handlers['normalizer_id'] ?? '', 'resolver' => fn(string $id) => Validator::resolve($id, 'normalizer')],
+                'validator'  => ['id' => $handlers['validator_id'] ?? '', 'resolver' => fn(string $id) => Validator::resolve($id)],
+                'normalizer' => ['id' => $handlers['normalizer_id'] ?? '', 'resolver' => fn(string $id) => Normalizer::resolve($id)],
                 'renderer'   => ['id' => $handlers['renderer_id'] ?? '', 'resolver' => fn(string $id) => Renderer::resolve($id)],
             ];
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -6,30 +6,6 @@ namespace EForms;
 class Validator
 {
     /**
-     * Registry mapping normalizer IDs to callable handlers.
-     */
-    private const HANDLERS = [
-        '' => [self::class, 'identity'],
-        'text' => [self::class, 'identity'],
-        'email' => [self::class, 'normalizeEmail'],
-        'url' => [self::class, 'identity'],
-        'tel' => [self::class, 'identity'],
-        'tel_us' => [self::class, 'normalizeTelUs'],
-        'number' => [self::class, 'identity'],
-        'range' => [self::class, 'identity'],
-        'date' => [self::class, 'identity'],
-        'textarea' => [self::class, 'identity'],
-        'textarea_html' => [self::class, 'identity'],
-        'zip' => [self::class, 'identity'],
-        'zip_us' => [self::class, 'identity'],
-        'select' => [self::class, 'identity'],
-        'radio' => [self::class, 'identity'],
-        'checkbox' => [self::class, 'identity'],
-        'file' => [self::class, 'identity'],
-        'files' => [self::class, 'identity'],
-    ];
-
-    /**
      * Registry mapping validator IDs to callable handlers.
      */
     private const VALIDATORS = [
@@ -54,55 +30,16 @@ class Validator
     ];
 
     /**
-     * Resolve a handler by identifier.
+     * Resolve a validator handler by identifier.
      *
-     * @param string $kind Either 'normalizer' or 'validator'
      * @throws \RuntimeException when the identifier is unknown
      */
-    public static function resolve(string $id, string $kind = 'normalizer'): callable
+    public static function resolve(string $id): callable
     {
-        $map = $kind === 'validator' ? self::VALIDATORS : self::HANDLERS;
-        if (!isset($map[$id])) {
-            throw new \RuntimeException('Unknown ' . $kind . ' ID: ' . $id);
+        if (!isset(self::VALIDATORS[$id])) {
+            throw new \RuntimeException('Unknown validator ID: ' . $id);
         }
-        return $map[$id];
-    }
-
-    /**
-     * Default passthrough handler used for types that do not require
-     * additional normalization.
-     *
-     * @param mixed $v
-     * @return mixed
-     */
-    public static function identity($v)
-    {
-        return $v;
-    }
-
-    /**
-     * Normalize email addresses by lowercasing the domain component.
-     */
-    public static function normalizeEmail(string $v): string
-    {
-        if ($v !== '' && strpos($v, '@') !== false) {
-            [$local, $domain] = explode('@', $v, 2);
-            return $local . '@' . strtolower($domain);
-        }
-        return $v;
-    }
-
-    /**
-     * Normalize US telephone numbers by stripping non-digits and
-     * removing a leading country code of 1.
-     */
-    public static function normalizeTelUs(string $v): string
-    {
-        $digits = preg_replace('/\D+/', '', $v);
-        if (strlen($digits) === 11 && str_starts_with($digits, '1')) {
-            $digits = substr($digits, 1);
-        }
-        return $digits;
+        return self::VALIDATORS[$id];
     }
 
     /**
@@ -283,8 +220,8 @@ class Validator
             $nid = $f['handlers']['normalizer_id'] ?? ($f['type'] ?? '');
             $f['form_id'] = $tpl['id'] ?? '';
             $f['handlers'] = [
-                'validator'  => self::resolve($hid, 'validator'),
-                'normalizer' => self::resolve($nid, 'normalizer'),
+                'validator'  => self::resolve($hid),
+                'normalizer' => Normalizer::resolve($nid),
             ];
             $desc[$f['key']] = $f;
         }
@@ -296,7 +233,7 @@ class Validator
         $desc = $desc ?? self::descriptors($tpl);
         $values = [];
         foreach ($desc as $k => $f) {
-            $norm = $f['handlers']['normalizer'] ?? [self::class, 'identity'];
+            $norm = $f['handlers']['normalizer'] ?? [Normalizer::class, 'identity'];
             if (self::isMultivalue($f)) {
                 $raw = $post[$k] ?? [];
                 if (!is_array($raw)) {
@@ -384,7 +321,7 @@ class Validator
     {
         $out = [];
         foreach ($desc as $k => $f) {
-            $norm = $f['handlers']['normalizer'] ?? [self::class, 'identity'];
+            $norm = $f['handlers']['normalizer'] ?? [Normalizer::class, 'identity'];
             $v = $values[$k] ?? (self::isMultivalue($f) ? [] : '');
             if (self::isMultivalue($f)) {
                 $out[$k] = array_map($norm, is_array($v) ? $v : []);

--- a/tests/AliasTypesParityTest.php
+++ b/tests/AliasTypesParityTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 use EForms\Spec;
 use EForms\Validator;
 use EForms\Renderer;
+use EForms\Normalizer;
 
 final class AliasTypesParityTest extends TestCase
 {
@@ -18,8 +19,8 @@ final class AliasTypesParityTest extends TestCase
             $this->assertSame($t, $desc['type']);
             $handlers = $desc['handlers'];
             $callables[] = [
-                'validator' => Validator::resolve($handlers['validator_id'], 'validator'),
-                'normalizer' => Validator::resolve($handlers['normalizer_id'], 'normalizer'),
+                'validator' => Validator::resolve($handlers['validator_id']),
+                'normalizer' => Normalizer::resolve($handlers['normalizer_id']),
                 'renderer' => Renderer::resolve($handlers['renderer_id']),
             ];
             $autocomplete[$t] = $desc['html']['autocomplete'] ?? '';

--- a/tests/DescriptorsResolutionTest.php
+++ b/tests/DescriptorsResolutionTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 use EForms\Spec;
 use EForms\Validator;
 use EForms\Renderer;
+use EForms\Normalizer;
 
 final class DescriptorsResolutionTest extends TestCase
 {
@@ -15,8 +16,8 @@ final class DescriptorsResolutionTest extends TestCase
             $this->assertArrayHasKey('type', $desc);
             $type = $desc['type'];
             $handlers = $desc['handlers'];
-            $v = Validator::resolve($handlers['validator_id'] ?? '', 'validator');
-            $n = Validator::resolve($handlers['normalizer_id'] ?? '', 'normalizer');
+            $v = Validator::resolve($handlers['validator_id'] ?? '');
+            $n = Normalizer::resolve($handlers['normalizer_id'] ?? '');
             $r = Renderer::resolve($handlers['renderer_id'] ?? '');
             $this->assertTrue(is_callable($v), "$type validator");
             $this->assertTrue(is_callable($n), "$type normalizer");
@@ -36,6 +37,6 @@ final class DescriptorsResolutionTest extends TestCase
     public function testUnknownHandlerIdFails(): void
     {
         $this->expectException(\RuntimeException::class);
-        Validator::resolve('unknown', 'validator');
+        Validator::resolve('unknown');
     }
 }

--- a/tests/ValidatorFieldValidationTest.php
+++ b/tests/ValidatorFieldValidationTest.php
@@ -1,6 +1,7 @@
 <?php
 use PHPUnit\Framework\TestCase;
 use EForms\Validator;
+use EForms\Normalizer;
 
 final class ValidatorFieldValidationTest extends TestCase
 {
@@ -42,7 +43,7 @@ final class ValidatorFieldValidationTest extends TestCase
                     $called = true;
                     return $v;
                 },
-                'normalizer' => [Validator::class, 'identity'],
+                'normalizer' => [Normalizer::class, 'identity'],
             ],
         ];
         $tpl = ['fields' => [$field]];


### PR DESCRIPTION
## Summary
- add `Normalizer` class with map of normalization handlers and resolve helper
- update `Validator` and `TemplateValidator` to reference `Normalizer`
- adjust tests to call new `Normalizer` class

## Testing
- `phpunit -c phpunit.xml.dist tests/AliasTypesParityTest.php`
- `phpunit -c phpunit.xml.dist tests/DescriptorsResolutionTest.php`
- `phpunit -c phpunit.xml.dist tests/ValidatorFieldValidationTest.php`
- `phpunit -c phpunit.xml.dist tests/ValidatorNormalizerTest.php`
- `phpunit -c phpunit.xml.dist tests/TemplateValidatorTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c332d5ad50832da2e56edea9833293