### PR TITLE
Organize template directories for forms and emails

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -67,8 +67,9 @@ electronic_forms - Spec
     - /schema/
       - template.schema.json  // design-time only (editor/CI lint); kept in sync with PHP spec
   - /templates/
-    - default.json
-    - contact.json        // kebab-case filenames only
+    - forms/
+      - contact.json        // kebab-case filenames only
+    - email/
     - HARDENING: ship index.html and server deny rules (.htaccess, web.config) in this directory; enforce filename allow-list and prevent traversal outside /templates/.
   - /assets/
     - forms.css     // namespaced styles
@@ -124,7 +125,7 @@ electronic_forms - Spec
     - Mis-balance reporting: if the row_group stack is mis-balanced at form end, emit a single _global config error (do not duplicate per-field errors).
 
   3. Template JSON
-    - Location: /templates/
+    - Location: /templates/forms/
     - Filename allow-list: /^[a-z0-9-]+\.json$/
     - Design-time schema pointer (optional but recommended): use a stable web URL to the schema in your repo (e.g., "${SCHEMA_URL}/template.schema.json") or a local absolute path. Avoid hard-coded /wp-content/plugins/... paths.
     - Minimal shape:
@@ -152,7 +153,7 @@ electronic_forms - Spec
     - If JSON is malformed or missing keys, fail gracefully with a clear "Form configuration error" (no white-screen).
     - Unknown rule values are rejected by the PHP validator.
     - For file/files: accept[] ∩ global allow-list must be non-empty; else EFORMS_ERR_ACCEPT_EMPTY.
-    - CI MUST validate /templates/*.json against /schema/template.schema.json and assert parity with the PHP TEMPLATE_SPEC.
+    - CI MUST validate /templates/forms/*.json against /schema/template.schema.json and assert parity with the PHP TEMPLATE_SPEC.
     - Enforce email.display_format_tel enum; unknown values are dropped at runtime but flagged in preflight.
 
   7. TemplateContext (internal)
@@ -744,7 +745,7 @@ uploads.*
   - Security hardening: template PHP files include ABSPATH guard (defined('ABSPATH') || exit;).
 
 25. TEMPLATES TO INCLUDE
-  1. quote_request.json
+  1. forms/quote_request.json
     {
       "id":"quote_request",
       "version":"1",
@@ -768,7 +769,7 @@ uploads.*
       ],
       "submit_button_text":"Send"
     }
-  2. contact.json
+  2. forms/contact.json
     {
       "id":"contact_us",
       "version":"1",

--- a/eforms.php
+++ b/eforms.php
@@ -16,7 +16,7 @@ namespace EForms {
     const VERSION = '0.1.0';
     // Paths/URLs for assets & templates
     const PLUGIN_DIR = __DIR__;
-    const TEMPLATES_DIR = __DIR__ . '/templates';
+    const TEMPLATES_DIR = __DIR__ . '/templates/forms';
     const ASSETS_DIR = __DIR__ . '/assets';
     \define(__NAMESPACE__ . '\\PLUGIN_URL', \plugins_url('', __FILE__));
     \define(__NAMESPACE__ . '\\ASSETS_URL', PLUGIN_URL . '/assets');

--- a/src/Email/Emailer.php
+++ b/src/Email/Emailer.php
@@ -195,7 +195,7 @@ class Emailer
         if (!is_string($template) || !preg_match('/^[a-z0-9_-]+$/', $template)) {
             throw new \RuntimeException('Invalid email template');
         }
-        $file = __DIR__ . '/../templates/email/' . $template . ($html ? '.html.php' : '.txt.php');
+        $file = __DIR__ . '/../../templates/email/' . $template . ($html ? '.html.php' : '.txt.php');
         if (!is_file($file)) {
             throw new \RuntimeException('Email template not found');
         }

--- a/src/Rendering/FormManager.php
+++ b/src/Rendering/FormManager.php
@@ -13,6 +13,7 @@ use EForms\Security\Throttle;
 use EForms\Uploads\Uploads;
 use EForms\Validation\TemplateValidator;
 use EForms\Validation\Validator;
+use const EForms\{TEMPLATES_DIR, PLUGIN_DIR, ASSETS_DIR, VERSION};
 
 class FormManager
 {

--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -103,7 +103,7 @@ class TemplateValidator
         if (!is_string($tmpl) || !preg_match('/^[a-z0-9_-]+$/', $tmpl)) {
             $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>'email.email_template'];
         } else {
-            $base = __DIR__ . '/../templates/email/' . $tmpl;
+            $base = __DIR__ . '/../../templates/email/' . $tmpl;
             if (!is_file($base . '.txt.php') && !is_file($base . '.html.php')) {
                 $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>'email.email_template'];
             }

--- a/templates/forms/contact.json
+++ b/templates/forms/contact.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../schema/template.schema.json",
+  "$schema": "../../schema/template.schema.json",
   "id": "contact_us",
   "version": "1",
   "title": "Contact Us",

--- a/templates/forms/quote_request.json
+++ b/templates/forms/quote_request.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../schema/template.schema.json",
+  "$schema": "../../schema/template.schema.json",
   "id": "quote_request",
   "version": "1",
   "title": "Quote Request",

--- a/templates/forms/upload_test.json
+++ b/templates/forms/upload_test.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../schema/template.schema.json",
+  "$schema": "../../schema/template.schema.json",
   "id": "upload_test",
   "version": "1",
   "title": "Upload Test",

--- a/tests/integration/template_schema_check.php
+++ b/tests/integration/template_schema_check.php
@@ -4,7 +4,7 @@ require __DIR__ . '/../bootstrap.php';
 use EForms\Validation\TemplateValidator;
 
 $schema = realpath(__DIR__ . '/../../schema/template.schema.json');
-$templates = glob(__DIR__ . '/../../templates/*.json') ?: [];
+$templates = glob(__DIR__ . '/../../templates/forms/*.json') ?: [];
 foreach ($templates as $tplFile) {
     $cmd = 'python3 -m jsonschema ' . escapeshellarg($schema) . ' -i ' . escapeshellarg($tplFile);
     exec($cmd, $out, $code);

--- a/tests/unit/NoBehaviorChangeGoldenTest.php
+++ b/tests/unit/NoBehaviorChangeGoldenTest.php
@@ -10,8 +10,8 @@ final class NoBehaviorChangeGoldenTest extends TestCase
 {
     public function testContactTemplateRenderingAndValidation(): void
     {
-        $tpl = json_decode(file_get_contents(__DIR__ . '/../../templates/contact.json'), true);
-        $pre = TemplateValidator::preflight($tpl, __DIR__ . '/../../templates/contact.json');
+        $tpl = json_decode(file_get_contents(__DIR__ . '/../../templates/forms/contact.json'), true);
+        $pre = TemplateValidator::preflight($tpl, __DIR__ . '/../../templates/forms/contact.json');
         $this->assertTrue($pre['ok'], 'preflight failed');
         $context = $pre['context'];
 


### PR DESCRIPTION
## Summary
- move JSON form definitions into `templates/forms` and adjust schema pointers
- update plugin and validators to load email templates from the correct directory
- fix tests and documentation to reference the new template paths

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c3350612e8832db9c1d75172277497