### PR TITLE
Use wp_kses_post for template fragments

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -104,9 +104,7 @@ electronic_forms - Spec
     - include_fields accepts template keys and meta keys:
       - allowed meta keys: ip, submitted_at, form_id, instance_id (available for email/logs only)
     - Template fragments (before_html / after_html):
-      - Sanitized via wp_kses() allow-list: div, span, p, br, strong, em, h1–h6, ul, ol, li, a.
-      - Attributes: class for all listed elements; for <a> allow href and class only.
-      - Allowed URL schemes: http, https, mailto (pass ['http','https','mailto'] as the third wp_kses() arg).
+      - Sanitized via wp_kses_post (same as textarea_html); sanitized result is canonical.
       - No inline styles. May not cross row_group boundaries.
     - Upload field options: for type=file/files, optional accept[], max_file_bytes, max_files (files only), email_attach (bool). Per-field values override global limits.
     - Attribute emission list (summary): maxlength, min, max, step, minlength, pattern, inputmode, multiple, accept are emitted when applicable from the template/registry traits.
@@ -345,10 +343,10 @@ electronic_forms - Spec
   6. Escape at sinks only (per map in §6)
 
 9. SPECIAL CASE: HTML-BEARING FIELDS
-  - textarea_html only
-  - Size bound via validation.textarea_html_max_bytes (default 32768 bytes)
+  - textarea_html and template fragments (before_html / after_html)
+  - textarea_html: size bound via validation.textarea_html_max_bytes (default 32768 bytes)
   - Sanitize with wp_kses_post; sanitized result is canonical; escape per sink.
-  - Post-sanitize bound: after wp_kses_post, re-check canonical size; if > max, fail with EFORMS_ERR_HTML_TOO_LARGE (no auto-truncate).
+  - textarea_html: post-sanitize bound – after wp_kses_post, re-check canonical size; if > max, fail with EFORMS_ERR_HTML_TOO_LARGE (no auto-truncate).
 
 10. CROSS-FIELD RULES (BOUNDED SET)
   - Supported:

--- a/src/Rendering/Renderer.php
+++ b/src/Rendering/Renderer.php
@@ -66,26 +66,7 @@ class Renderer
 
     private static function sanitizeFragment(string $html): string
     {
-        $common = ['class' => []];
-        $allowed = [
-            'a' => ['href' => [], 'class' => []],
-            'strong' => $common,
-            'em' => $common,
-            'span' => $common,
-            'p' => $common,
-            'br' => $common,
-            'div' => $common,
-            'h1' => $common,
-            'h2' => $common,
-            'h3' => $common,
-            'h4' => $common,
-            'h5' => $common,
-            'h6' => $common,
-            'ul' => $common,
-            'ol' => $common,
-            'li' => $common,
-        ];
-        return \wp_kses($html, $allowed, ['http','https','mailto']);
+        return \wp_kses_post($html);
     }
 
     public static function form(array $tpl, array $meta, array $errors, array $values): string

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -93,7 +93,8 @@ function wp_kses($html, $allowed, $allowed_protocols = []) {
     return strip_tags((string)$html, $tags);
 }
 function wp_kses_post($html) {
-    return strip_tags((string)$html);
+    $allowed = '<a><strong><em><span><p><br><div><h1><h2><h3><h4><h5><h6><ul><ol><li>';
+    return strip_tags((string)$html, $allowed);
 }
 function sanitize_key($key) { return preg_replace('/[^a-z0-9_\-]/', '', strtolower((string)$key)); }
 function shortcode_atts($pairs, $atts, $shortcode = '') {


### PR DESCRIPTION
## Summary
- Sanitize before_html and after_html using `wp_kses_post`
- Document that template fragments share the `wp_kses_post` sanitizer with `textarea_html`
- Adjust test harness to allow common tags through `wp_kses_post`

## Testing
- `phpunit --configuration phpunit.xml.dist` *(fails: Undefined property, missing files, and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c34273d968832db926afc0330745b5