### PR TITLE
Respect logging and ledger config; harden success and fragments

### DIFF
--- a/src/Logging.php
+++ b/src/Logging.php
@@ -173,7 +173,7 @@ class Logging
             if (!empty($meta)) {
                 $parts[] = 'meta=' . substr(json_encode($meta, JSON_UNESCAPED_SLASHES), 0, 200);
             }
-            error_log('eforms ' . implode(' ', $parts));
+            self::logLine('eforms ' . implode(' ', $parts) . "\n");
         }
         if (Config::get('logging.fail2ban.enable', false)) {
             self::emitFail2ban($code, $ctx);

--- a/src/Rendering/Renderer.php
+++ b/src/Rendering/Renderer.php
@@ -83,8 +83,10 @@ class Renderer
                 $msg = $tpl['success']['message'] ?? 'Success';
                 $successHtml = '<div class="eforms-success">' . \esc_html($msg) . '</div>';
                 \setcookie($cookieName, '', time() - 3600, '/');
+                unset($_COOKIE[$cookieName]);
                 return $successHtml;
             }
+            return '';
         }
 
         $clientValidation = $meta['client_validation'] ?? false;

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -101,6 +101,9 @@ class Security
 
     public static function ledger_reserve(string $formId, string $token): array
     {
+        if (!Config::get('security.token_ledger.enable', true)) {
+            return ['ok' => true, 'skipped' => true];
+        }
         $base = rtrim(Config::get('uploads.dir', ''), '/');
         $dir = $base . '/ledger';
         $hash = sha1($formId . ':' . $token);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -207,6 +207,10 @@ add_filter('eforms_config', function (array $defaults) {
     if (getenv('EFORMS_JS_HARD_MODE')) {
         $defaults['security']['js_hard_mode'] = (getenv('EFORMS_JS_HARD_MODE') === '1');
     }
+    $tlenv = getenv('EFORMS_TOKEN_LEDGER_ENABLE');
+    if ($tlenv !== false) {
+        $defaults['security']['token_ledger']['enable'] = ($tlenv === '1');
+    }
     if (getenv('EFORMS_LOG_LEVEL')) {
         $defaults['logging']['level'] = (int) getenv('EFORMS_LOG_LEVEL');
     }

--- a/tests/integration/test_ledger_disable.php
+++ b/tests/integration/test_ledger_disable.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../bootstrap.php';
+
+use EForms\Security\Security;
+
+$res = Security::ledger_reserve('contact_us', 'tok123');
+$base = __DIR__ . '/../tmp/uploads/eforms-private/ledger';
+$hash = sha1('contact_us:tok123');
+$path = $base . '/' . substr($hash, 0, 2) . '/' . $hash . '.used';
+echo file_exists($path) ? 'exists' : 'missing';

--- a/tests/integration/test_logging_minimal.php
+++ b/tests/integration/test_logging_minimal.php
@@ -1,0 +1,3 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/test_logging.php';

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -246,6 +246,12 @@ ok=0
 assert_grep tmp/stdout.txt 'Already submitted or expired\.' || ok=1
 record_result "ledger reserve: duplicate token" $ok
 
+# 5b) Ledger disabled skips file
+EFORMS_TOKEN_LEDGER_ENABLE=0 run_test test_ledger_disable
+ok=0
+assert_grep tmp/stdout.txt '^missing$' || ok=1
+record_result "ledger: disabled skips file" $ok
+
 # 6) Success inline: renderer shows message
 run_test test_success_inline
 ok=0
@@ -297,7 +303,14 @@ assert_grep tmp/uploads/eforms-private/eforms.log '"severity":"error"' || ok=1
 assert_grep tmp/uploads/eforms-private/eforms.log '"code":"EFORMS_EMAIL_FAIL"' || ok=1
 record_result "logging: SMTP failure" $ok
 
-# 8b) Logging User-Agent sanitization
+# 8b) Logging minimal file output
+EFORMS_LOG_MODE=minimal run_test test_logging_minimal
+ok=0
+assert_grep tmp/uploads/eforms-private/eforms.log 'severity=error' || ok=1
+assert_grep tmp/uploads/eforms-private/eforms.log 'code=EFORMS_EMAIL_FAIL' || ok=1
+record_result "logging: minimal file output" $ok
+
+# 8c) Logging User-Agent sanitization
 EFORMS_LOG_HEADERS=1 run_test test_logging_user_agent
 ok=0
 assert_grep tmp/ua.txt '^A{256}$' || ok=1

--- a/tests/unit/SuccessAntiSpoofTest.php
+++ b/tests/unit/SuccessAntiSpoofTest.php
@@ -18,7 +18,7 @@ final class SuccessAntiSpoofTest extends TestCase
         $_COOKIE = [];
         $fm = new \EForms\Rendering\FormManager();
         $html = $fm->render('contact_us');
-        $this->assertStringNotContainsString('Thanks! We got your message.', $html);
+        $this->assertSame('', $html);
     }
 
     public function testNoSuccessWithCookieOnly(): void
@@ -38,7 +38,7 @@ final class SuccessAntiSpoofTest extends TestCase
         $_COOKIE = ['eforms_s_contact_us' => 'other:inst'];
         $fm = new \EForms\Rendering\FormManager();
         $html = $fm->render('contact_us');
-        $this->assertStringNotContainsString('Thanks! We got your message.', $html);
+        $this->assertSame('', $html);
     }
 
     public function testSuccessWithMatchingCookieAndQuery(): void
@@ -49,6 +49,19 @@ final class SuccessAntiSpoofTest extends TestCase
         $fm = new \EForms\Rendering\FormManager();
         $html = $fm->render('contact_us');
         $this->assertStringContainsString('Thanks! We got your message.', $html);
+    }
+
+    public function testSuccessCookieConsumedOnlyOnce(): void
+    {
+        header_remove();
+        $_GET = ['eforms_success' => 'contact_us'];
+        $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
+        $fm = new \EForms\Rendering\FormManager();
+        $html1 = $fm->render('contact_us');
+        $this->assertStringContainsString('Thanks! We got your message.', $html1);
+        $fm2 = new \EForms\Rendering\FormManager();
+        $html2 = $fm2->render('contact_us');
+        $this->assertSame('', $html2);
     }
 }
 

--- a/tests/unit/TemplateValidatorTest.php
+++ b/tests/unit/TemplateValidatorTest.php
@@ -162,6 +162,21 @@ class TemplateValidatorTest extends TestCase
         $this->assertContains('fields[0].after_html', $paths);
     }
 
+    public function testFragmentsCannotContainRowTags(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['before_html'] = '<div></div>';
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_FRAGMENT_ROW_TAG, $codes);
+
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['after_html'] = '<section></section>';
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_FRAGMENT_ROW_TAG, $codes);
+    }
+
     public function testUnknownValidationRule(): void
     {
         $tpl = $this->baseTpl();


### PR DESCRIPTION
## Summary
- Write minimal log entries to the plugin log file instead of `error_log`
- Allow disabling token ledger writes via `security.token_ledger.enable`
- Suppress duplicate success renders and forbid row tags inside HTML fragments

## Testing
- `phpunit` *(fails: Undefined property, header warnings, and other failures)*
- `tests/run.sh` *(fails: template schema parity missing jsonschema module)*

------
https://chatgpt.com/codex/tasks/task_e_68c3406eab0c832d8574c700890f9384