### PR TITLE
Bootstrap config before logging initialization

### DIFF
--- a/src/Logging.php
+++ b/src/Logging.php
@@ -11,6 +11,7 @@ class Logging
     private static function init(): void
     {
         if (self::$init) return;
+        \EForms\Config::bootstrap();
         $dir = rtrim((string) Config::get('uploads.dir', sys_get_temp_dir()), '/');
         if (!is_dir($dir)) {
             @mkdir($dir, 0700, true);


### PR DESCRIPTION
## Summary
- Ensure logging initialization bootstraps configuration so log files respect configured upload directory.

## Testing
- `EFORMS_LOG_MODE=jsonl php tests/integration/test_logging.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3523688c4832d9daac57c7cc548a6