### PR TITLE
Ensure success cookie cleared with secure attributes

### DIFF
--- a/src/Rendering/Renderer.php
+++ b/src/Rendering/Renderer.php
@@ -82,7 +82,13 @@ class Renderer
             if ($cookieVal && str_starts_with($cookieVal, $formId . ':')) {
                 $msg = $tpl['success']['message'] ?? 'Success';
                 $successHtml = '<div class="eforms-success">' . \esc_html($msg) . '</div>';
-                \setcookie($cookieName, '', time() - 3600, '/');
+                \setcookie($cookieName, '', [
+                    'expires' => time() - 3600,
+                    'path' => '/',
+                    'secure' => \is_ssl(),
+                    'httponly' => true,
+                    'samesite' => 'Lax',
+                ]);
                 unset($_COOKIE[$cookieName]);
                 return $successHtml;
             }


### PR DESCRIPTION
## Summary
- Use same secure attributes as FormManager when clearing success cookies

## Testing
- `tests/run.sh`
- `php -r '$_GET["eforms_success"]="contact_us"; $_COOKIE["eforms_s_contact_us"]="contact_us:instOK"; require __DIR__ . "/tests/bootstrap.php"; $fm=new \\EForms\\Rendering\\FormManager(); $h1=$fm->render("contact_us"); $cookie_after_first=$_COOKIE["eforms_s_contact_us"] ?? null; $h2=$fm->render("contact_us"); var_export(["first"=>$h1,"cookie"=>$cookie_after_first,"second"=>$h2]);'`


------
https://chatgpt.com/codex/tasks/task_e_68c3534b0eb4832dafe8a56b4aeca8b2