### PR TITLE
Validate IPv4 segments in mask_ip

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -152,6 +152,14 @@ class Helpers
             return implode(':', $parts);
         }
         $parts = explode('.', $ip);
+        if (count($parts) !== 4) {
+            return '';
+        }
+        foreach ($parts as $p) {
+            if (!ctype_digit($p)) {
+                return '';
+            }
+        }
         $parts[3] = '0';
         return implode('.', $parts);
     }

--- a/tests/unit/HelpersMaskIpTest.php
+++ b/tests/unit/HelpersMaskIpTest.php
@@ -15,4 +15,9 @@ final class HelpersMaskIpTest extends TestCase
     {
         $this->assertSame('2001:db8:85a3::', Helpers::mask_ip('2001:db8:85a3:0:0:8a2e:370:7334'));
     }
+
+    public function testInvalidInput(): void
+    {
+        $this->assertSame('', Helpers::mask_ip('192.0.2.foo'));
+    }
 }


### PR DESCRIPTION
## Summary
- Ensure `mask_ip` only masks valid IPv4 addresses by checking segment count and numeric values
- Cover invalid IPv4 input with a new unit test

## Testing
- `phpunit tests/unit/HelpersMaskIpTest.php`
- `tests/run.sh` *(fails: 'alice@example.com.*alice@example.com' not found in tmp/mail.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c357cf6390832db6b40e712f9c4531