### PR TITLE
Run challenge verifier against integration scripts

### DIFF
--- a/tests/unit/ChallengeVerifierTest.php
+++ b/tests/unit/ChallengeVerifierTest.php
@@ -10,7 +10,7 @@ class ChallengeVerifierTest extends TestCase
             exec('rm -rf ' . escapeshellarg($tmpDir));
         }
         mkdir($tmpDir, 0777, true);
-        $cmd = 'php-cgi ' . escapeshellarg(__DIR__ . '/' . $script);
+        $cmd = 'php-cgi ' . escapeshellarg(__DIR__ . '/../integration/' . $script);
         $out = [];
         exec($cmd, $out, $code);
         return [$code, $out, $tmpDir];


### PR DESCRIPTION
## Summary
- Update challenge verifier unit test to run scripts from integration directory using `php-cgi`

## Testing
- `phpunit tests/unit/ChallengeVerifierTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c36acb40d4832db0c12aa474a14512