### PR TITLE
Log unbalanced row groups in template validation

### DIFF
--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -363,6 +363,7 @@ class TemplateValidator
             Logging::write('warn', self::EFORMS_ERR_ROW_GROUP_UNBALANCED, ['form_id'=>$tpl['id'] ?? '']);
         }
         if ($rowStack !== 0) {
+            Logging::write('warn', self::EFORMS_ERR_ROW_GROUP_UNBALANCED, ['form_id'=>$tpl['id'] ?? '']);
             $errors[] = ['code'=>self::EFORMS_ERR_ROW_GROUP_UNBALANCED,'path'=>'fields'];
         }
 

--- a/tests/unit/RendererRowGroupTest.php
+++ b/tests/unit/RendererRowGroupTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 use EForms\Config;
 use EForms\Rendering\Renderer;
 use EForms\Validation\TemplateValidator;
+use EForms\Logging;
 
 final class RendererRowGroupTest extends TestCase
 {
@@ -17,6 +18,13 @@ final class RendererRowGroupTest extends TestCase
         $data = $ref->getProperty('data');
         $data->setAccessible(true);
         $data->setValue([]);
+        $lref = new \ReflectionClass(Logging::class);
+        $lin = $lref->getProperty('init');
+        $lin->setAccessible(true);
+        $lin->setValue(false);
+        $lfile = $lref->getProperty('file');
+        $lfile->setAccessible(true);
+        $lfile->setValue('');
         putenv('EFORMS_LOG_LEVEL=1');
         Config::bootstrap();
     }


### PR DESCRIPTION
## Summary
- Log row group imbalance during template validation
- Reset logger state in row group renderer tests to capture expected log entry

## Testing
- `phpunit tests/unit/RendererRowGroupTest.php`
- `phpunit` *(fails: Undefined property stdClass::$Host; Missing log file in multiple tests; header modification warnings; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c3758f4a7c832d8cec89ab2ed024f0