### PR TITLE
Ignore non-http origins

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -51,10 +51,13 @@ class Security
             return null;
         }
         $scheme = strtolower($p['scheme']);
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            return null;
+        }
         $host = strtolower($p['host']);
         $port = $p['port'] ?? null;
         if ($port === null) {
-            $port = ($scheme === 'https') ? 443 : (($scheme === 'http') ? 80 : null);
+            $port = ($scheme === 'https') ? 443 : 80;
         }
         if ($scheme === 'http' && $port == 80) {
             $port = 80;


### PR DESCRIPTION
## Summary
- treat origins with non-http/https schemes as unknown
- keep origin evaluation consistent when encountering such origins

## Testing
- `phpunit tests/unit/SecurityOriginTest.php`
- `phpunit tests/unit` *(fails: Undefined property stdClass::$Host)*
- `tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c376e34e9c832dbe8d7eee8bdf8af2