### PR TITLE
Reinitialize log directory when uploads path changes

### DIFF
--- a/src/Logging.php
+++ b/src/Logging.php
@@ -7,16 +7,27 @@ class Logging
 {
     private static string $file = '';
     private static bool $init = false;
+    private static string $dir = '';
 
     private static function init(): void
     {
-        if (self::$init) return;
         \EForms\Config::bootstrap();
         $dir = rtrim((string) Config::get('uploads.dir', sys_get_temp_dir()), '/');
-        if (!is_dir($dir)) {
-            @mkdir($dir, 0700, true);
+
+        if (self::$dir !== $dir) {
+            self::$dir = $dir;
+            self::$file = '';
+            self::$init = false;
         }
-        self::$file = $dir . '/eforms.log';
+
+        if (self::$init && self::$file !== '' && is_dir(dirname(self::$file))) {
+            return;
+        }
+
+        if (!is_dir(self::$dir)) {
+            @mkdir(self::$dir, 0700, true);
+        }
+        self::$file = self::$dir . '/eforms.log';
         self::$init = true;
     }
 

--- a/tests/unit/RendererRowGroupTest.php
+++ b/tests/unit/RendererRowGroupTest.php
@@ -25,6 +25,9 @@ final class RendererRowGroupTest extends TestCase
         $lfile = $lref->getProperty('file');
         $lfile->setAccessible(true);
         $lfile->setValue('');
+        $ldir = $lref->getProperty('dir');
+        $ldir->setAccessible(true);
+        $ldir->setValue('');
         putenv('EFORMS_LOG_LEVEL=1');
         Config::bootstrap();
     }

--- a/tests/unit/TokenLoggingTest.php
+++ b/tests/unit/TokenLoggingTest.php
@@ -10,7 +10,7 @@ class TokenLoggingTest extends TestCase
             exec('rm -rf ' . escapeshellarg($tmpDir));
         }
         mkdir($tmpDir, 0777, true);
-        $cmd = 'php-cgi ' . escapeshellarg(__DIR__ . '/../integration/' . $script);
+        $cmd = 'EFORMS_LOG_MODE=jsonl php-cgi ' . escapeshellarg(__DIR__ . '/../integration/' . $script);
         $out = [];
         exec($cmd, $out, $code);
         return [$code, $out, $tmpDir];
@@ -20,7 +20,9 @@ class TokenLoggingTest extends TestCase
     {
         [$code, $out, $dir] = $this->runScript('token_hard_fail.php');
         $this->assertSame(0, $code);
-        $log = @file_get_contents($dir . '/uploads/eforms-private/eforms.log');
+        $logFile = $dir . '/uploads/eforms-private/eforms.log';
+        $this->assertFileExists($logFile);
+        $log = @file_get_contents($logFile);
         $this->assertStringContainsString('EFORMS_ERR_TOKEN', (string)$log);
     }
 }

--- a/tests/unit/ValidatorRulesTest.php
+++ b/tests/unit/ValidatorRulesTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use EForms\Config;
+use EForms\Logging;
 use EForms\Validation\TemplateValidator;
 use EForms\Validation\Validator;
 
@@ -17,6 +18,16 @@ final class ValidatorRulesTest extends TestCase
         $data = $ref->getProperty('data');
         $data->setAccessible(true);
         $data->setValue([]);
+        $lref = new \ReflectionClass(Logging::class);
+        $lin = $lref->getProperty('init');
+        $lin->setAccessible(true);
+        $lin->setValue(false);
+        $lfile = $lref->getProperty('file');
+        $lfile->setAccessible(true);
+        $lfile->setValue('');
+        $ldir = $lref->getProperty('dir');
+        $ldir->setAccessible(true);
+        $ldir->setValue('');
         putenv('EFORMS_LOG_LEVEL=1');
         putenv('EFORMS_LOG_MODE=jsonl');
         Config::bootstrap();


### PR DESCRIPTION
## Summary
- Recompute log file path when `uploads.dir` changes and recreate log directory if needed
- Reset logging state in ValidatorRulesTest and TokenLoggingTest so each test uses the expected log path
- Update RendererRowGroupTest to clear new Logging directory cache

## Testing
- ❌ `phpunit`
- ✅ `phpunit tests/unit/TokenLoggingTest.php`
- ✅ `phpunit tests/unit/ValidatorRulesTest.php`
- ✅ `phpunit tests/unit/RendererRowGroupTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3785f19b4832db194665e6f6574b5