### PR TITLE
Handle missing fileinfo extension during upload

### DIFF
--- a/eforms.php
+++ b/eforms.php
@@ -59,6 +59,10 @@ namespace {
 
     Config::bootstrap();
 
+    if (!extension_loaded('fileinfo')) {
+        define('EFORMS_FINFO_UNAVAILABLE', true);
+    }
+
     // If the request includes any eforms_* query args, ensure responses are not cached.
     foreach (array_keys($_GET) as $key) {
         if (str_starts_with($key, 'eforms_')) {

--- a/src/Uploads/Uploads.php
+++ b/src/Uploads/Uploads.php
@@ -5,6 +5,7 @@ namespace EForms\Uploads;
 
 use EForms\Config;
 use EForms\Spec;
+use EForms\Logging;
 
 class Uploads
 {
@@ -46,6 +47,18 @@ class Uploads
 
     public static function normalizeAndValidate(array $tpl, array $files): array
     {
+        if (defined('EFORMS_FINFO_UNAVAILABLE')) {
+            Logging::write('warn', 'EFORMS_FINFO_UNAVAILABLE', ['form_id' => $tpl['id'] ?? '']);
+            $errors = [];
+            foreach ($tpl['fields'] as $f) {
+                $type = $f['type'] ?? '';
+                if ($type === 'file' || $type === 'files') {
+                    $errors[$f['key']][] = 'File uploads are unsupported on this server.';
+                }
+            }
+            return ['files' => [], 'errors' => $errors];
+        }
+
         $flat = self::flatten($files);
         $errors = [];
         $valid = [];

--- a/tests/unit/UploadsFinfoUnavailableTest.php
+++ b/tests/unit/UploadsFinfoUnavailableTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Uploads\Uploads;
+
+final class UploadsFinfoUnavailableTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFinfoUnavailableError(): void
+    {
+        if (!defined('EFORMS_FINFO_UNAVAILABLE')) {
+            define('EFORMS_FINFO_UNAVAILABLE', true);
+        }
+        @unlink(__DIR__ . '/../tmp/uploads/eforms-private/eforms.log');
+
+        $tpl = [
+            'id' => 'contact',
+            'fields' => [
+                ['type' => 'file', 'key' => 'up', 'accept' => ['pdf']],
+            ],
+        ];
+        $tmp = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp, random_bytes(10));
+        $files = [
+            'up' => [
+                'name' => 'a.pdf',
+                'type' => 'application/pdf',
+                'tmp_name' => $tmp,
+                'error' => UPLOAD_ERR_OK,
+                'size' => filesize($tmp),
+            ],
+        ];
+
+        $res = Uploads::normalizeAndValidate($tpl, $files);
+        $this->assertArrayHasKey('up', $res['errors']);
+        $this->assertSame(['File uploads are unsupported on this server.'], $res['errors']['up']);
+
+        @unlink($tmp);
+    }
+}


### PR DESCRIPTION
## Summary
- Detect lack of fileinfo extension at bootstrap and define `EFORMS_FINFO_UNAVAILABLE`
- Abort file validation when fileinfo is unavailable, logging and surfacing a clear error
- Add unit test covering behaviour when fileinfo is missing

## Testing
- `phpunit` *(fails: Undefined property: stdClass::$Host, Cannot modify header information, etc.)*
- `phpunit --filter UploadsFinfoUnavailableTest`
- `bash tests/run.sh` *(fails: 'alice@example.com.*alice@example.com' not found in tmp/mail.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c37ebc6c10832d91cdc7fe9f701f75