### PR TITLE
Handle email body sanitization errors

### DIFF
--- a/src/Email/Emailer.php
+++ b/src/Email/Emailer.php
@@ -75,8 +75,8 @@ class Emailer
                 $body .= "\nOmitted attachments: $note\n";
             }
         }
-        $body = preg_replace("/\r\n?/", "\n", $body);
-        $body = preg_replace("/[\x00-\x08\x0B\x0C\x0E-\x1F]/", '', $body);
+        $body = preg_replace('/\r\n?/', "\n", (string) $body) ?? (string) $body;
+        $body = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $body) ?? $body;
         $sender = Config::get('email.envelope_sender', '');
         $sender = is_string($sender) ? self::sanitizeHeader($sender) : '';
         $disableSend = (bool) Config::get('email.disable_send', false);


### PR DESCRIPTION
## Summary
- guard email body normalization against regex failures
- avoid double-quoted regex escape handling

## Testing
- `php -l src/Email/Emailer.php`
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpunit -c phpunit.xml.dist` *(fails: undefined property stdClass::$Host, missing log files, header modification warnings, assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68c383b3fd10832db49855c7960c10d0