### PR TITLE
test: ensure email body control chars sanitized

### DIFF
--- a/tests/unit/EmailBodySanitizeTest.php
+++ b/tests/unit/EmailBodySanitizeTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Email\Emailer;
+use EForms\Config;
+
+final class EmailBodySanitizeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // reset mail file
+        global $TEST_ARTIFACTS;
+        @file_put_contents($TEST_ARTIFACTS['mail_file'], '[]');
+    }
+
+    public function testControlCharsRemoved(): void
+    {
+        Config::bootstrap();
+        $prep = function ($phpmailer) {
+            $phpmailer->Host = 'localhost';
+        };
+        add_action('phpmailer_init', $prep);
+        $tpl = [
+            'id' => 't1',
+            'version' => '1',
+            'title' => 't',
+            'success' => ['mode' => 'inline'],
+            'email' => [
+                'to' => 'a@example.com',
+                'subject' => 's',
+                'email_template' => 'default',
+                'include_fields' => ['body'],
+            ],
+            'fields' => [],
+            'submit_button_text' => 'Send',
+            'rules' => [],
+        ];
+        $rawBody = "Hello\rWorld\nAgain\x00\x1F";
+        $canonical = ['body' => $rawBody];
+        $meta = ['form_id' => 't1', 'instance_id' => 'i1'];
+        Emailer::send($tpl, $canonical, $meta);
+        remove_action('phpmailer_init', $prep);
+        global $TEST_ARTIFACTS;
+        $mail = json_decode((string) file_get_contents($TEST_ARTIFACTS['mail_file']), true);
+        $this->assertNotNull($mail[0]['message'] ?? null);
+        $message = $mail[0]['message'];
+        $this->assertStringNotContainsString("\r", $message);
+        $this->assertStringNotContainsString("\x00", $message);
+        $this->assertStringNotContainsString("\x1F", $message);
+        $this->assertStringContainsString("body: Hello\nWorld\nAgain\n", $message);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test to verify email message body strips control characters and CRs

## Testing
- `phpunit --configuration phpunit.xml.dist tests/unit/EmailBodySanitizeTest.php`
- `phpunit --configuration phpunit.xml.dist` *(fails: Undefined property: stdClass::$Host and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c384d905e0832dbf01ae0a9117541a