### PR TITLE
Add .htaccess to email templates and include in package

### DIFF
--- a/.distinclude
+++ b/.distinclude
@@ -1,0 +1,2 @@
+templates/.htaccess
+templates/email/.htaccess

--- a/templates/email/.htaccess
+++ b/templates/email/.htaccess
@@ -1,3 +1,4 @@
+# Deny direct access to email templates
 <IfModule mod_authz_core.c>
   Require all denied
 </IfModule>


### PR DESCRIPTION
## Summary
- Add `.htaccess` to `templates/email` to block direct access
- Ensure template security files are shipped by listing them in `.distinclude`

## Testing
- `phpunit` *(fails: Undefined property: stdClass::$Host)*
- `tests/run.sh` *(fails: 40 passed, 1 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4299bac24832d8d8d93dee5d56877