### PR TITLE
Add tests for soft-fail email dispatch

### DIFF
--- a/tests/integration/test_challenge_success.php
+++ b/tests/integration/test_challenge_success.php
@@ -23,4 +23,13 @@ $_POST = [
     'cf-turnstile-response' => 'pass',
 ];
 $fm = new \EForms\Rendering\FormManager();
+ob_start();
 $fm->handleSubmit();
+ob_end_clean();
+
+// Ensure challenge success still dispatches email
+global $TEST_ARTIFACTS;
+$mail = json_decode((string) file_get_contents($TEST_ARTIFACTS['mail_file']), true);
+if (empty($mail) || strpos($mail[0]['to'], 'zed@example.com') === false) {
+    throw new RuntimeException('Email not sent to zed@example.com');
+}

--- a/tests/integration/test_js_soft.php
+++ b/tests/integration/test_js_soft.php
@@ -26,3 +26,10 @@ ob_start();
 $fm->handleSubmit();
 ob_end_clean();
 
+// Ensure email is still dispatched when JS disabled
+global $TEST_ARTIFACTS;
+$mail = json_decode((string) file_get_contents($TEST_ARTIFACTS['mail_file']), true);
+if (empty($mail) || strpos($mail[0]['to'], 'alice@example.com') === false) {
+    throw new RuntimeException('Email not sent to alice@example.com');
+}
+

--- a/tests/integration/test_origin_soft.php
+++ b/tests/integration/test_origin_soft.php
@@ -32,3 +32,10 @@ ob_start();
 $fm->handleSubmit();
 ob_end_clean();
 
+// Ensure email was dispatched to the expected recipient
+global $TEST_ARTIFACTS;
+$mail = json_decode((string) file_get_contents($TEST_ARTIFACTS['mail_file']), true);
+if (empty($mail) || strpos($mail[0]['to'], 'alice@example.com') === false) {
+    throw new RuntimeException('Email not sent to alice@example.com');
+}
+

--- a/tests/integration/test_timing_expired.php
+++ b/tests/integration/test_timing_expired.php
@@ -24,3 +24,10 @@ $fm = new \EForms\Rendering\FormManager();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();
+
+// Verify email is still sent to recipient
+global $TEST_ARTIFACTS;
+$mail = json_decode((string) file_get_contents($TEST_ARTIFACTS['mail_file']), true);
+if (empty($mail) || strpos($mail[0]['to'], 'zed@example.com') === false) {
+    throw new RuntimeException('Email not sent to zed@example.com');
+}

--- a/tests/integration/test_timing_min_fill.php
+++ b/tests/integration/test_timing_min_fill.php
@@ -23,3 +23,10 @@ $fm = new \EForms\Rendering\FormManager();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();
+
+// Verify mail dispatch despite soft fail
+global $TEST_ARTIFACTS;
+$mail = json_decode((string) file_get_contents($TEST_ARTIFACTS['mail_file']), true);
+if (empty($mail) || strpos($mail[0]['to'], 'alice@example.com') === false) {
+    throw new RuntimeException('Email not sent to alice@example.com');
+}


### PR DESCRIPTION
## Summary
- Verify FormManager emails for soft-fail scenarios like origin, min-fill, expired, JS disabled, and challenge success
- Assert expected recipients are written to tmp/mail.json in integration tests

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c42ca85b70832d9f6d3bacc152444e