### PR TITLE
Sanitize template fragments during preflight

### DIFF
--- a/src/Rendering/Renderer.php
+++ b/src/Rendering/Renderer.php
@@ -64,11 +64,6 @@ class Renderer
         return $id;
     }
 
-    private static function sanitizeFragment(string $html): string
-    {
-        return \wp_kses_post($html);
-    }
-
     public static function form(array $tpl, array $meta, array $errors, array $values): string
     {
         $formId = $meta['form_id'];
@@ -208,8 +203,8 @@ class Renderer
             $fieldErrors = $errors[$key] ?? [];
             $errId = 'error-' . $id;
             $errAttr = $fieldErrors ? ' aria-describedby="' . \esc_attr($errId) . '" aria-invalid="true"' : '';
-            $before = isset($f['before_html']) ? self::sanitizeFragment($f['before_html']) : '';
-            $after = isset($f['after_html']) ? self::sanitizeFragment($f['after_html']) : '';
+            $before = $f['before_html'] ?? '';
+            $after = $f['after_html'] ?? '';
             $html .= $before;
             $handler = $desc['handlers']['renderer'] ?? self::resolve($desc['handlers']['renderer_id'] ?? '');
             $ctx = [

--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -232,6 +232,8 @@ class TemplateValidator
                     $errors[] = ['code'=>self::EFORMS_ERR_FRAGMENT_ROW_TAG,'path'=>$path.'before_html'];
                 } elseif (self::fragmentContainsStyleAttr($f['before_html'])) {
                     $errors[] = ['code'=>self::EFORMS_ERR_FRAGMENT_STYLE_ATTR,'path'=>$path.'before_html'];
+                } else {
+                    $f['before_html'] = \wp_kses_post($f['before_html']);
                 }
             }
             if (isset($f['after_html']) && is_string($f['after_html'])) {
@@ -241,6 +243,8 @@ class TemplateValidator
                     $errors[] = ['code'=>self::EFORMS_ERR_FRAGMENT_ROW_TAG,'path'=>$path.'after_html'];
                 } elseif (self::fragmentContainsStyleAttr($f['after_html'])) {
                     $errors[] = ['code'=>self::EFORMS_ERR_FRAGMENT_STYLE_ATTR,'path'=>$path.'after_html'];
+                } else {
+                    $f['after_html'] = \wp_kses_post($f['after_html']);
                 }
             }
 

--- a/tests/unit/RendererFragmentTest.php
+++ b/tests/unit/RendererFragmentTest.php
@@ -2,19 +2,48 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use EForms\Validation\TemplateValidator;
 use EForms\Rendering\Renderer;
 
 final class RendererFragmentTest extends TestCase
 {
-    public function testAllowedAndDisallowedTags(): void
+    public function testFragmentsAreSanitizedOnce(): void
     {
-        $ref = new \ReflectionClass(Renderer::class);
-        $m = $ref->getMethod('sanitizeFragment');
-        $m->setAccessible(true);
-        $input = '<p><strong>ok</strong><script>alert(1)</script><em>hi</em></p>';
-        $output = $m->invoke(null, $input);
-        $this->assertStringContainsString('<strong>ok</strong>', $output);
-        $this->assertStringContainsString('<em>hi</em>', $output);
-        $this->assertStringNotContainsString('<script>', $output);
+        $tpl = [
+            'id' => 'f1',
+            'version' => '1',
+            'title' => 'T',
+            'success' => ['mode' => 'inline'],
+            'email' => [],
+            'fields' => [
+                [
+                    'type' => 'name',
+                    'key' => 'name',
+                    'before_html' => '<p><strong>ok</strong><script>alert(1)</script></p>',
+                    'after_html' => '<span><em>end</em><script></script></span>',
+                ],
+            ],
+            'submit_button_text' => 'Send',
+        ];
+
+        $pre = TemplateValidator::preflight($tpl);
+        $this->assertTrue($pre['ok']);
+        $ctx = $pre['context'];
+
+        $meta = [
+            'form_id' => 'f1',
+            'instance_id' => 'i1',
+            'timestamp' => 0,
+            'cacheable' => true,
+            'client_validation' => false,
+            'action' => 'http://example.com',
+            'hidden_token' => 'tok',
+            'enctype' => 'application/x-www-form-urlencoded',
+        ];
+
+        $html = Renderer::form($ctx, $meta, [], []);
+        $this->assertStringContainsString('<p><strong>ok</strong>alert(1)</p>', $html);
+        $this->assertStringContainsString('<span><em>end</em></span>', $html);
+        $this->assertStringNotContainsString('<script>', $html);
     }
 }

--- a/tests/unit/TemplateValidatorTest.php
+++ b/tests/unit/TemplateValidatorTest.php
@@ -162,6 +162,18 @@ class TemplateValidatorTest extends TestCase
         $this->assertContains('fields[0].after_html', $paths);
     }
 
+    public function testFragmentsSanitizedAndPreserved(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['before_html'] = '<p><strong>ok</strong><script>alert(1)</script></p>';
+        $tpl['fields'][0]['after_html'] = '<span><em>end</em><script></script></span>';
+        $res = TemplateValidator::preflight($tpl);
+        $this->assertTrue($res['ok']);
+        $field = $res['context']['fields'][0];
+        $this->assertSame('<p><strong>ok</strong>alert(1)</p>', $field['before_html']);
+        $this->assertSame('<span><em>end</em></span>', $field['after_html']);
+    }
+
     public function testFragmentsCannotContainRowTags(): void
     {
         $tpl = $this->baseTpl();


### PR DESCRIPTION
## Summary
- Sanitize `before_html` and `after_html` fragments during template preflight with `wp_kses_post`, storing canonical HTML.
- Render pre-sanitized fragments directly to avoid repeated sanitization on re-renders.
- Add unit tests covering fragment sanitization and rendering behavior.

## Testing
- `./vendor/bin/phpunit` *(failed: 8 tests, cross-test contamination)*
- `./vendor/bin/phpunit --process-isolation`


------
https://chatgpt.com/codex/tasks/task_e_68c450a5b7cc832db892a2fa9bdd8555