### PR TITLE
Add BaseTestCase for isolated test environment

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use EForms\Config;
+use EForms\Logging;
+
+class BaseTestCase extends TestCase
+{
+    /** @var array<string,string> */
+    private array $envSnapshot = [];
+    /** @var array<string,mixed> */
+    private array $filtersSnapshot = [];
+    /** @var array<string,mixed> */
+    private array $configSnapshot = [];
+    /** @var array<string,mixed> */
+    private array $loggingSnapshot = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        foreach ((array) getenv() as $k => $v) {
+            if (is_string($k) && str_starts_with($k, 'EFORMS_')) {
+                $this->envSnapshot[$k] = (string) $v;
+            }
+        }
+        global $TEST_FILTERS;
+        $this->filtersSnapshot = $TEST_FILTERS;
+        if (isset($this->filtersSnapshot['eforms_config'][10])) {
+            $cbs = $this->filtersSnapshot['eforms_config'][10];
+            array_shift($cbs);
+            if (!empty($cbs)) {
+                $this->filtersSnapshot['eforms_config'][10] = $cbs;
+            } else {
+                unset($this->filtersSnapshot['eforms_config'][10]);
+                if (empty($this->filtersSnapshot['eforms_config'])) {
+                    unset($this->filtersSnapshot['eforms_config']);
+                }
+            }
+        }
+        $this->configSnapshot = $this->snapshotStatic(Config::class);
+        $this->loggingSnapshot = $this->snapshotStatic(Logging::class);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ((array) getenv() as $k => $v) {
+            if (is_string($k) && str_starts_with($k, 'EFORMS_')) {
+                putenv($k);
+                unset($_ENV[$k], $_SERVER[$k]);
+            }
+        }
+        foreach ($this->envSnapshot as $k => $v) {
+            putenv("$k=$v");
+            $_ENV[$k] = $v;
+            $_SERVER[$k] = $v;
+        }
+        global $TEST_FILTERS;
+        $TEST_FILTERS = $this->filtersSnapshot;
+        register_test_env_filter();
+        $this->restoreStatic(Config::class, $this->configSnapshot);
+        $this->restoreStatic(Logging::class, $this->loggingSnapshot);
+        parent::tearDown();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function snapshotStatic(string $class): array
+    {
+        $rc = new ReflectionClass($class);
+        $props = [];
+        foreach ($rc->getProperties(ReflectionProperty::IS_STATIC) as $prop) {
+            $prop->setAccessible(true);
+            $props[$prop->getName()] = $prop->getValue();
+        }
+        return $props;
+    }
+
+    /**
+     * @param array<string,mixed> $snapshot
+     */
+    private function restoreStatic(string $class, array $snapshot): void
+    {
+        $rc = new ReflectionClass($class);
+        foreach ($snapshot as $name => $value) {
+            $prop = $rc->getProperty($name);
+            $prop->setAccessible(true);
+            $prop->setValue($value);
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,12 @@
 <?php
 declare(strict_types=1);
 
+spl_autoload_register(function ($class) {
+    if ($class === 'BaseTestCase') {
+        require __DIR__ . '/BaseTestCase.php';
+    }
+});
+
 // Minimal WP stubs and test harness utilities for running plugin in CLI.
 
 // Globals used by harness

--- a/tests/unit/AliasTypesParityTest.php
+++ b/tests/unit/AliasTypesParityTest.php
@@ -1,13 +1,12 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Spec;
 use EForms\Validation\Validator;
 use EForms\Rendering\Renderer;
 use EForms\Validation\Normalizer;
 
-final class AliasTypesParityTest extends TestCase
+final class AliasTypesParityTest extends BaseTestCase
 {
     public function testAliasTypesShareHandlersButDifferTraits(): void
     {

--- a/tests/unit/ChallengeInitTest.php
+++ b/tests/unit/ChallengeInitTest.php
@@ -1,14 +1,15 @@
 <?php
-use PHPUnit\Framework\TestCase;
 use EForms\Config;
 use EForms\Rendering\FormManager;
 
-final class ChallengeInitTest extends TestCase
+final class ChallengeInitTest extends BaseTestCase
 {
     private array $origConfig;
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $ref = new \ReflectionClass(Config::class);
         $prop = $ref->getProperty('data');
         $prop->setAccessible(true);
@@ -22,6 +23,7 @@ final class ChallengeInitTest extends TestCase
         $prop->setAccessible(true);
         $prop->setValue(null, $this->origConfig);
         $GLOBALS['wp_enqueued_scripts'] = [];
+        parent::tearDown();
     }
 
     private function setConfig(string $path, $value): void

--- a/tests/unit/ChallengeVerifierTest.php
+++ b/tests/unit/ChallengeVerifierTest.php
@@ -1,7 +1,6 @@
 <?php
-use PHPUnit\Framework\TestCase;
 
-class ChallengeVerifierTest extends TestCase
+class ChallengeVerifierTest extends BaseTestCase
 {
     private function runScript(string $script): array
     {

--- a/tests/unit/ClientIpHeaderTest.php
+++ b/tests/unit/ClientIpHeaderTest.php
@@ -1,14 +1,15 @@
 <?php
-use PHPUnit\Framework\TestCase;
 use EForms\Config;
 use EForms\Helpers;
 
-final class ClientIpHeaderTest extends TestCase
+final class ClientIpHeaderTest extends BaseTestCase
 {
     private array $origConfig;
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $ref = new \ReflectionClass(Config::class);
         $prop = $ref->getProperty('data');
         $prop->setAccessible(true);
@@ -22,6 +23,7 @@ final class ClientIpHeaderTest extends TestCase
         $prop->setAccessible(true);
         $prop->setValue(null, $this->origConfig);
         unset($_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_X_FORWARDED_FOR']);
+        parent::tearDown();
     }
 
     private function setConfig(string $path, $value): void

--- a/tests/unit/DescriptorsResolutionTest.php
+++ b/tests/unit/DescriptorsResolutionTest.php
@@ -1,13 +1,12 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Spec;
 use EForms\Validation\Validator;
 use EForms\Rendering\Renderer;
 use EForms\Validation\Normalizer;
 
-final class DescriptorsResolutionTest extends TestCase
+final class DescriptorsResolutionTest extends BaseTestCase
 {
     public function testAllHandlerIdsResolve(): void
     {

--- a/tests/unit/EmailAttachmentNameTest.php
+++ b/tests/unit/EmailAttachmentNameTest.php
@@ -1,14 +1,15 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Email\Emailer;
 use EForms\Config;
 
-final class EmailAttachmentNameTest extends TestCase
+final class EmailAttachmentNameTest extends BaseTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         // reset mail file
         global $TEST_ARTIFACTS;
         @file_put_contents($TEST_ARTIFACTS['mail_file'], '[]');

--- a/tests/unit/EmailAttachmentOverflowTest.php
+++ b/tests/unit/EmailAttachmentOverflowTest.php
@@ -1,14 +1,15 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Email\Emailer;
 use EForms\Config;
 
-final class EmailAttachmentOverflowTest extends TestCase
+final class EmailAttachmentOverflowTest extends BaseTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         global $TEST_ARTIFACTS;
         @file_put_contents($TEST_ARTIFACTS['mail_file'], '[]');
         $ref = new \ReflectionClass(Config::class);

--- a/tests/unit/EmailBodySanitizeTest.php
+++ b/tests/unit/EmailBodySanitizeTest.php
@@ -1,14 +1,15 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Email\Emailer;
 use EForms\Config;
 
-final class EmailBodySanitizeTest extends TestCase
+final class EmailBodySanitizeTest extends BaseTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         // reset mail file
         global $TEST_ARTIFACTS;
         @file_put_contents($TEST_ARTIFACTS['mail_file'], '[]');

--- a/tests/unit/Fail2banLoggingTest.php
+++ b/tests/unit/Fail2banLoggingTest.php
@@ -11,14 +11,15 @@ namespace EForms {
 namespace {
 // bootstrap handled by phpunit.xml
 
-use PHPUnit\Framework\TestCase;
 use EForms\Config;
 use EForms\Logging;
 
-final class Fail2banLoggingTest extends TestCase
+final class Fail2banLoggingTest extends BaseTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         global $TEST_FILTERS, $TEST_F2B_SYSLOG, $TEST_ARTIFACTS;
         $TEST_F2B_SYSLOG = [];
         $TEST_FILTERS = [];
@@ -42,6 +43,7 @@ final class Fail2banLoggingTest extends TestCase
         $data->setAccessible(true);
         $data->setValue([]);
         Config::bootstrap();
+        parent::tearDown();
     }
 
     private function boot(array $opts): void

--- a/tests/unit/HelpersBytesFromIniTest.php
+++ b/tests/unit/HelpersBytesFromIniTest.php
@@ -1,8 +1,7 @@
 <?php
-use PHPUnit\Framework\TestCase;
 use EForms\Helpers;
 
-class HelpersBytesFromIniTest extends TestCase
+class HelpersBytesFromIniTest extends BaseTestCase
 {
     public function testConversions(): void
     {

--- a/tests/unit/HelpersMaskIpTest.php
+++ b/tests/unit/HelpersMaskIpTest.php
@@ -1,10 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Helpers;
 
-final class HelpersMaskIpTest extends TestCase
+final class HelpersMaskIpTest extends BaseTestCase
 {
     public function testIpv4Mask(): void
     {

--- a/tests/unit/HoneypotBehaviorTest.php
+++ b/tests/unit/HoneypotBehaviorTest.php
@@ -1,7 +1,6 @@
 <?php
-use PHPUnit\Framework\TestCase;
 
-class HoneypotBehaviorTest extends TestCase
+class HoneypotBehaviorTest extends BaseTestCase
 {
     public function testStealthHeaderAndTokenBurn(): void
     {

--- a/tests/unit/NoBehaviorChangeGoldenTest.php
+++ b/tests/unit/NoBehaviorChangeGoldenTest.php
@@ -1,12 +1,11 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Validation\TemplateValidator;
 use EForms\Rendering\Renderer;
 use EForms\Validation\Validator;
 
-final class NoBehaviorChangeGoldenTest extends TestCase
+final class NoBehaviorChangeGoldenTest extends BaseTestCase
 {
     public function testContactTemplateRenderingAndValidation(): void
     {

--- a/tests/unit/RendererFragmentTest.php
+++ b/tests/unit/RendererFragmentTest.php
@@ -1,11 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Validation\TemplateValidator;
 use EForms\Rendering\Renderer;
 
-final class RendererFragmentTest extends TestCase
+final class RendererFragmentTest extends BaseTestCase
 {
     public function testFragmentsAreSanitizedOnce(): void
     {

--- a/tests/unit/RendererLabelTest.php
+++ b/tests/unit/RendererLabelTest.php
@@ -1,15 +1,16 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Config;
 use EForms\Rendering\Renderer;
 use EForms\Validation\TemplateValidator;
 
-final class RendererLabelTest extends TestCase
+final class RendererLabelTest extends BaseTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $ref = new \ReflectionClass(Config::class);
         $boot = $ref->getProperty('bootstrapped');
         $boot->setAccessible(true);

--- a/tests/unit/RendererParityTest.php
+++ b/tests/unit/RendererParityTest.php
@@ -1,11 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Spec;
 use EForms\Rendering\Renderer;
 
-final class RendererParityTest extends TestCase
+final class RendererParityTest extends BaseTestCase
 {
     public function testSharedAttributesMirrored(): void
     {

--- a/tests/unit/RendererRowGroupTest.php
+++ b/tests/unit/RendererRowGroupTest.php
@@ -1,16 +1,17 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Config;
 use EForms\Rendering\Renderer;
 use EForms\Validation\TemplateValidator;
 use EForms\Logging;
 
-final class RendererRowGroupTest extends TestCase
+final class RendererRowGroupTest extends BaseTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $ref = new \ReflectionClass(Config::class);
         $boot = $ref->getProperty('bootstrapped');
         $boot->setAccessible(true);

--- a/tests/unit/RendererStepTest.php
+++ b/tests/unit/RendererStepTest.php
@@ -1,15 +1,16 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Config;
 use EForms\Rendering\Renderer;
 use EForms\Validation\TemplateValidator;
 
-final class RendererStepTest extends TestCase
+final class RendererStepTest extends BaseTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $ref = new \ReflectionClass(Config::class);
         $boot = $ref->getProperty('bootstrapped');
         $boot->setAccessible(true);

--- a/tests/unit/RulesTest.php
+++ b/tests/unit/RulesTest.php
@@ -1,8 +1,7 @@
 <?php
-use PHPUnit\Framework\TestCase;
 use EForms\Validation\Validator;
 
-class RulesTest extends TestCase
+class RulesTest extends BaseTestCase
 {
     private function runRules(array $tpl, array $post): array
     {

--- a/tests/unit/SecurityOriginTest.php
+++ b/tests/unit/SecurityOriginTest.php
@@ -1,9 +1,8 @@
 <?php
-use PHPUnit\Framework\TestCase;
 use EForms\Security\Security;
 use EForms\Config;
 
-class SecurityOriginTest extends TestCase
+class SecurityOriginTest extends BaseTestCase
 {
     private function resetConfig(): void
     {
@@ -77,5 +76,6 @@ class SecurityOriginTest extends TestCase
     {
         putenv('EFORMS_ORIGIN_MODE');
         putenv('EFORMS_ORIGIN_MISSING_HARD');
+        parent::tearDown();
     }
 }

--- a/tests/unit/SecurityTokenModesTest.php
+++ b/tests/unit/SecurityTokenModesTest.php
@@ -1,14 +1,15 @@
 <?php
-use PHPUnit\Framework\TestCase;
 use EForms\Security\Security;
 use EForms\Config;
 
-class SecurityTokenModesTest extends TestCase
+class SecurityTokenModesTest extends BaseTestCase
 {
     private array $origConfig;
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $ref = new \ReflectionClass(Config::class);
         $prop = $ref->getProperty('data');
         $prop->setAccessible(true);
@@ -21,6 +22,7 @@ class SecurityTokenModesTest extends TestCase
         $prop = $ref->getProperty('data');
         $prop->setAccessible(true);
         $prop->setValue(null, $this->origConfig);
+        parent::tearDown();
     }
 
     private function setConfig(string $path, $value): void

--- a/tests/unit/SuccessAntiSpoofTest.php
+++ b/tests/unit/SuccessAntiSpoofTest.php
@@ -1,13 +1,14 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Config;
 
-final class SuccessAntiSpoofTest extends TestCase
+final class SuccessAntiSpoofTest extends BaseTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         Config::bootstrap();
     }
 

--- a/tests/unit/TemplateValidatorTest.php
+++ b/tests/unit/TemplateValidatorTest.php
@@ -1,8 +1,7 @@
 <?php
-use PHPUnit\Framework\TestCase;
 use EForms\Validation\TemplateValidator;
 
-class TemplateValidatorTest extends TestCase
+class TemplateValidatorTest extends BaseTestCase
 {
     private function baseTpl(): array
     {

--- a/tests/unit/TokenLoggingTest.php
+++ b/tests/unit/TokenLoggingTest.php
@@ -1,7 +1,6 @@
 <?php
-use PHPUnit\Framework\TestCase;
 
-class TokenLoggingTest extends TestCase
+class TokenLoggingTest extends BaseTestCase
 {
     private function runScript(string $script): array
     {

--- a/tests/unit/UploadFailCleanupTest.php
+++ b/tests/unit/UploadFailCleanupTest.php
@@ -1,9 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 
-final class UploadFailCleanupTest extends TestCase
+final class UploadFailCleanupTest extends BaseTestCase
 {
     public function testFilesRemovedWhenEmailFailsAndNoRetention(): void
     {

--- a/tests/unit/UploadsFinfoUnavailableTest.php
+++ b/tests/unit/UploadsFinfoUnavailableTest.php
@@ -1,10 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Uploads\Uploads;
 
-final class UploadsFinfoUnavailableTest extends TestCase
+final class UploadsFinfoUnavailableTest extends BaseTestCase
 {
     /**
      * @runInSeparateProcess

--- a/tests/unit/UploadsLimitTest.php
+++ b/tests/unit/UploadsLimitTest.php
@@ -1,11 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Uploads\Uploads;
 use EForms\Config;
 
-final class UploadsLimitTest extends TestCase
+final class UploadsLimitTest extends BaseTestCase
 {
     private function rebootstrap(array $overrides): void
     {
@@ -42,6 +41,7 @@ final class UploadsLimitTest extends TestCase
         $data->setAccessible(true);
         $data->setValue([]);
         Config::bootstrap();
+        parent::tearDown();
     }
 
     public function testMaxFileBytesPerField(): void

--- a/tests/unit/UploadsMaxImagePxTest.php
+++ b/tests/unit/UploadsMaxImagePxTest.php
@@ -1,16 +1,17 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Uploads\Uploads;
 use EForms\Config;
 
-final class UploadsMaxImagePxTest extends TestCase
+final class UploadsMaxImagePxTest extends BaseTestCase
 {
     private array $origConfig;
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         Config::bootstrap();
         $ref = new \ReflectionClass(Config::class);
         $prop = $ref->getProperty('data');
@@ -27,6 +28,7 @@ final class UploadsMaxImagePxTest extends TestCase
         $prop = $ref->getProperty('data');
         $prop->setAccessible(true);
         $prop->setValue(null, $this->origConfig);
+        parent::tearDown();
     }
 
     public function testRejectsOversizedImages(): void

--- a/tests/unit/UploadsNameDedupTest.php
+++ b/tests/unit/UploadsNameDedupTest.php
@@ -1,11 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Uploads\Uploads;
 use EForms\Config;
 
-final class UploadsNameDedupTest extends TestCase
+final class UploadsNameDedupTest extends BaseTestCase
 {
     public function testDuplicateNamesAreUniquified(): void
     {

--- a/tests/unit/UploadsOctetStreamTest.php
+++ b/tests/unit/UploadsOctetStreamTest.php
@@ -1,10 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Uploads\Uploads;
 
-final class UploadsOctetStreamTest extends TestCase
+final class UploadsOctetStreamTest extends BaseTestCase
 {
     public function testOctetStreamAllowedWhenExtensionMatches(): void
     {

--- a/tests/unit/UploadsReservedNameTest.php
+++ b/tests/unit/UploadsReservedNameTest.php
@@ -1,11 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Uploads\Uploads;
 use EForms\Config;
 
-final class UploadsReservedNameTest extends TestCase
+final class UploadsReservedNameTest extends BaseTestCase
 {
     public function testReservedWindowsNamesAreModified(): void
     {

--- a/tests/unit/UploadsUtf8NameTest.php
+++ b/tests/unit/UploadsUtf8NameTest.php
@@ -1,11 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Uploads\Uploads;
 use EForms\Config;
 
-final class UploadsUtf8NameTest extends TestCase
+final class UploadsUtf8NameTest extends BaseTestCase
 {
     public function testUtf8NamesPreservedWhenNotTransliterated(): void
     {

--- a/tests/unit/ValidatorFieldValidationTest.php
+++ b/tests/unit/ValidatorFieldValidationTest.php
@@ -1,9 +1,8 @@
 <?php
-use PHPUnit\Framework\TestCase;
 use EForms\Validation\Validator;
 use EForms\Validation\Normalizer;
 
-final class ValidatorFieldValidationTest extends TestCase
+final class ValidatorFieldValidationTest extends BaseTestCase
 {
     private function validate(array $field, $value): array
     {

--- a/tests/unit/ValidatorNormalizerTest.php
+++ b/tests/unit/ValidatorNormalizerTest.php
@@ -1,10 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Validation\Validator;
 
-final class ValidatorNormalizerTest extends TestCase
+final class ValidatorNormalizerTest extends BaseTestCase
 {
     public function testEmailNormalizerApplied(): void
     {

--- a/tests/unit/ValidatorRulesTest.php
+++ b/tests/unit/ValidatorRulesTest.php
@@ -1,16 +1,17 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use EForms\Config;
 use EForms\Logging;
 use EForms\Validation\TemplateValidator;
 use EForms\Validation\Validator;
 
-final class ValidatorRulesTest extends TestCase
+final class ValidatorRulesTest extends BaseTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $ref = new \ReflectionClass(Config::class);
         $boot = $ref->getProperty('bootstrapped');
         $boot->setAccessible(true);


### PR DESCRIPTION
## Summary
- Add BaseTestCase to snapshot and restore env vars, filter registry, and static state
- Autoload BaseTestCase via tests bootstrap
- Update all PHPUnit tests to extend BaseTestCase

## Testing
- `./vendor/bin/phpunit`
- `tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c58a73f0b8832d9f8fa34f0f01c5b3