### PR TITLE
test: reset filters after logging tests

### DIFF
--- a/tests/unit/EmailAttachmentOverflowTest.php
+++ b/tests/unit/EmailAttachmentOverflowTest.php
@@ -59,5 +59,13 @@ final class EmailAttachmentOverflowTest extends BaseTestCase
         $this->assertSame('a.pdf', $mail[0]['attachments'][0]['name']);
         $this->assertStringContainsString('Omitted attachments: b.pdf', $mail[0]['message']);
     }
+    protected function tearDown(): void
+    {
+        global $TEST_FILTERS;
+        $TEST_FILTERS = [];
+        register_test_env_filter();
+        parent::tearDown();
+    }
+
 }
 

--- a/tests/unit/Fail2banLoggingTest.php
+++ b/tests/unit/Fail2banLoggingTest.php
@@ -31,18 +31,7 @@ final class Fail2banLoggingTest extends BaseTestCase
     {
         global $TEST_FILTERS;
         $TEST_FILTERS = [];
-        foreach (array_keys(getenv()) as $k) {
-            if (str_starts_with($k, 'EFORMS_')) putenv($k);
-        }
         register_test_env_filter();
-        $ref = new \ReflectionClass(Config::class);
-        $boot = $ref->getProperty('bootstrapped');
-        $boot->setAccessible(true);
-        $boot->setValue(false);
-        $data = $ref->getProperty('data');
-        $data->setAccessible(true);
-        $data->setValue([]);
-        Config::bootstrap();
         parent::tearDown();
     }
 

--- a/tests/unit/UploadsLimitTest.php
+++ b/tests/unit/UploadsLimitTest.php
@@ -29,18 +29,7 @@ final class UploadsLimitTest extends BaseTestCase
     {
         global $TEST_FILTERS;
         $TEST_FILTERS = [];
-        foreach (array_keys(getenv()) as $k) {
-            if (str_starts_with($k, 'EFORMS_')) putenv($k);
-        }
         register_test_env_filter();
-        $ref = new \ReflectionClass(Config::class);
-        $boot = $ref->getProperty('bootstrapped');
-        $boot->setAccessible(true);
-        $boot->setValue(false);
-        $data = $ref->getProperty('data');
-        $data->setAccessible(true);
-        $data->setValue([]);
-        Config::bootstrap();
         parent::tearDown();
     }
 


### PR DESCRIPTION
## Summary
- reset `eforms_config` filters in logging-related tests
- rely on `BaseTestCase` to restore logging state

## Testing
- `vendor/bin/phpunit`
- `tests/run.sh` *(fails: 'ASSERT FAIL: ...')*

------
https://chatgpt.com/codex/tasks/task_e_68c58cd5f17c832da1e2bc6042be7f0b