### PR TITLE
Randomize PHPUnit order and isolate heavy cleanup test

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit bootstrap="tests/bootstrap.php" colors="true" executionOrder="random">
   <testsuites>
     <testsuite name="EForms">
       <directory suffix="Test.php">tests/unit</directory>

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6,6 +6,12 @@ PHP="php"
 
 export EFORMS_LOG_MODE=jsonl
 
+# Run unit tests with PHPUnit and measure runtime
+echo "[UNIT] Running PHPUnit tests"
+UNIT_START=$(date +%s)
+$PHP ../vendor/bin/phpunit -c ../phpunit.xml.dist "$@"
+echo "[UNIT] Runtime: $(( $(date +%s) - UNIT_START ))s"
+
 pass=0
 fail=0
 
@@ -72,6 +78,9 @@ function record_result() {
     fail=$((fail+1))
   fi
 }
+
+# Measure integration test runtime
+INTEGRATION_START=$(date +%s)
 
 # Schema validation for templates
 run_test template_schema_check
@@ -363,5 +372,6 @@ assert_grep tmp/headers.txt 'Cache-Control: private, no-store, max-age=0' || ok=
 record_result "render non-cacheable: cache-control set" $ok
 
 echo
+echo "Integration tests runtime: $(( $(date +%s) - INTEGRATION_START ))s"
 echo "Summary: $pass passed, $fail failed"
 exit $(( fail > 0 ))

--- a/tests/unit/UploadFailCleanupTest.php
+++ b/tests/unit/UploadFailCleanupTest.php
@@ -2,6 +2,10 @@
 declare(strict_types=1);
 
 
+/**
+ * @runInSeparateProcess
+ * @preserveGlobalState disabled
+ */
 final class UploadFailCleanupTest extends BaseTestCase
 {
     public function testFilesRemovedWhenEmailFailsAndNoRetention(): void


### PR DESCRIPTION
## Summary
- Run PHPUnit suites in randomized order for better isolation
- Execute heavy upload cleanup test in a separate process
- Update test runner to execute PHPUnit and record runtimes

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c58e29eb68832db9a4aa8b828ae151