### PR TITLE
Refactor tests to use config overrides instead of env vars

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -303,6 +303,32 @@ function register_test_env_filter(): void {
         return $defaults;
     });
 }
+function set_config(array $overrides): void {
+    global $TEST_FILTERS;
+    $TEST_FILTERS = [];
+    register_test_env_filter();
+    $ref = new \ReflectionClass(\EForms\Config::class);
+    $boot = $ref->getProperty('bootstrapped');
+    $boot->setAccessible(true);
+    $boot->setValue(null, false);
+    $data = $ref->getProperty('data');
+    $data->setAccessible(true);
+    $data->setValue(null, []);
+    $lref = new \ReflectionClass(\EForms\Logging::class);
+    $prop = $lref->getProperty('init');
+    $prop->setAccessible(true);
+    $prop->setValue(null, false);
+    $prop = $lref->getProperty('file');
+    $prop->setAccessible(true);
+    $prop->setValue(null, '');
+    $prop = $lref->getProperty('dir');
+    $prop->setAccessible(true);
+    $prop->setValue(null, '');
+    add_filter('eforms_config', function ($defaults) use ($overrides) {
+        return array_replace_recursive($defaults, $overrides);
+    });
+    \EForms\Config::bootstrap();
+}
 register_test_env_filter();
 
 // Define ABSPATH to satisfy plugin guard

--- a/tests/integration/challenge_cookie_policy.php
+++ b/tests/integration/challenge_cookie_policy.php
@@ -1,8 +1,10 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_COOKIE_MISSING_POLICY=challenge');
-putenv('EFORMS_LOG_LEVEL=1');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'security' => ['cookie_missing_policy' => 'challenge'],
+    'logging' => ['level' => 1],
+]);
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_POST = [

--- a/tests/integration/challenge_fail.php
+++ b/tests/integration/challenge_fail.php
@@ -1,11 +1,14 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_COOKIE_MISSING_POLICY=challenge');
-putenv('EFORMS_CHALLENGE_MODE=auto');
-putenv('EFORMS_CHALLENGE_PROVIDER=turnstile');
-putenv('EFORMS_TURNSTILE_SITE_KEY=site');
-putenv('EFORMS_TURNSTILE_SECRET_KEY=secret');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'security' => ['cookie_missing_policy' => 'challenge'],
+    'challenge' => [
+        'mode' => 'auto',
+        'provider' => 'turnstile',
+        'turnstile' => ['site_key' => 'site', 'secret_key' => 'secret'],
+    ],
+]);
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_POST = [

--- a/tests/integration/challenge_success.php
+++ b/tests/integration/challenge_success.php
@@ -1,11 +1,14 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_COOKIE_MISSING_POLICY=challenge');
-putenv('EFORMS_CHALLENGE_MODE=auto');
-putenv('EFORMS_CHALLENGE_PROVIDER=turnstile');
-putenv('EFORMS_TURNSTILE_SITE_KEY=site');
-putenv('EFORMS_TURNSTILE_SECRET_KEY=secret');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'security' => ['cookie_missing_policy' => 'challenge'],
+    'challenge' => [
+        'mode' => 'auto',
+        'provider' => 'turnstile',
+        'turnstile' => ['site_key' => 'site', 'secret_key' => 'secret'],
+    ],
+]);
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_POST = [

--- a/tests/integration/test_challenge_fail.php
+++ b/tests/integration/test_challenge_fail.php
@@ -1,12 +1,15 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_COOKIE_MISSING_POLICY=challenge');
-putenv('EFORMS_CHALLENGE_MODE=auto');
-putenv('EFORMS_CHALLENGE_PROVIDER=turnstile');
-putenv('EFORMS_TURNSTILE_SITE_KEY=site');
-putenv('EFORMS_TURNSTILE_SECRET_KEY=secret');
-putenv('EFORMS_LOG_LEVEL=1');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'security' => ['cookie_missing_policy' => 'challenge'],
+    'challenge' => [
+        'mode' => 'auto',
+        'provider' => 'turnstile',
+        'turnstile' => ['site_key' => 'site', 'secret_key' => 'secret'],
+    ],
+    'logging' => ['level' => 1],
+]);
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_POST = [

--- a/tests/integration/test_challenge_success.php
+++ b/tests/integration/test_challenge_success.php
@@ -1,12 +1,15 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_COOKIE_MISSING_POLICY=challenge');
-putenv('EFORMS_CHALLENGE_MODE=auto');
-putenv('EFORMS_CHALLENGE_PROVIDER=turnstile');
-putenv('EFORMS_TURNSTILE_SITE_KEY=site');
-putenv('EFORMS_TURNSTILE_SECRET_KEY=secret');
-putenv('EFORMS_LOG_LEVEL=1');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'security' => ['cookie_missing_policy' => 'challenge'],
+    'challenge' => [
+        'mode' => 'auto',
+        'provider' => 'turnstile',
+        'turnstile' => ['site_key' => 'site', 'secret_key' => 'secret'],
+    ],
+    'logging' => ['level' => 1],
+]);
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_POST = [

--- a/tests/integration/test_cookie_policy_challenge.php
+++ b/tests/integration/test_cookie_policy_challenge.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_COOKIE_MISSING_POLICY=challenge');
 require __DIR__ . '/../bootstrap.php';
+set_config(['security' => ['cookie_missing_policy' => 'challenge']]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_cookie_policy_hard.php
+++ b/tests/integration/test_cookie_policy_hard.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_COOKIE_MISSING_POLICY=hard');
 require __DIR__ . '/../bootstrap.php';
+set_config(['security' => ['cookie_missing_policy' => 'hard']]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_email_dkim.php
+++ b/tests/integration/test_email_dkim.php
@@ -3,10 +3,14 @@ declare(strict_types=1);
 $pk = __DIR__ . '/../tmp/dkim.key';
 file_put_contents($pk, 'key');
 
-putenv('EFORMS_EMAIL_DKIM_DOMAIN=example.com');
-putenv('EFORMS_EMAIL_DKIM_SELECTOR=sel');
-putenv('EFORMS_EMAIL_DKIM_PRIVATE_KEY_PATH=' . $pk);
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'email' => ['dkim' => [
+        'domain' => 'example.com',
+        'selector' => 'sel',
+        'private_key_path' => $pk,
+    ]],
+]);
 
 $captured = null;
 $hook = function($phpmailer) use (&$captured) { $captured = clone $phpmailer; };

--- a/tests/integration/test_email_smtp_retry.php
+++ b/tests/integration/test_email_smtp_retry.php
@@ -1,9 +1,8 @@
 <?php
 declare(strict_types=1);
 putenv('EFORMS_FORCE_MAIL_FAIL=1');
-putenv('EFORMS_EMAIL_SMTP_MAX_RETRIES=2');
-putenv('EFORMS_EMAIL_SMTP_RETRY_BACKOFF_SECONDS=0');
 require __DIR__ . '/../bootstrap.php';
+set_config(['email' => ['smtp' => ['max_retries' => 2, 'retry_backoff_seconds' => 0]]]);
 
 $tpl = [
     'email' => [

--- a/tests/integration/test_honeypot.php
+++ b/tests/integration/test_honeypot.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
 require __DIR__ . '/../bootstrap.php';
+set_config(['logging' => ['level' => 1]]);
 
 // Honeypot: non-empty should result in PRG 303 and no email
 $_SERVER['REQUEST_METHOD'] = 'POST';

--- a/tests/integration/test_honeypot_capture.php
+++ b/tests/integration/test_honeypot_capture.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
 require __DIR__ . '/../bootstrap.php';
+set_config(['logging' => ['level' => 1]]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_honeypot_hard.php
+++ b/tests/integration/test_honeypot_hard.php
@@ -1,8 +1,10 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_HONEYPOT_RESPONSE=hard_fail');
-putenv('EFORMS_LOG_LEVEL=1');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'security' => ['honeypot_response' => 'hard_fail'],
+    'logging' => ['level' => 1],
+]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_honeypot_throttle_first.php
+++ b/tests/integration/test_honeypot_throttle_first.php
@@ -1,9 +1,13 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
-putenv('EFORMS_THROTTLE_ENABLE=1');
-putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'logging' => ['level' => 1],
+    'throttle' => [
+        'enable' => true,
+        'per_ip' => ['max_per_minute' => 1],
+    ],
+]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_honeypot_throttle_second.php
+++ b/tests/integration/test_honeypot_throttle_second.php
@@ -1,9 +1,13 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
-putenv('EFORMS_THROTTLE_ENABLE=1');
-putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'logging' => ['level' => 1],
+    'throttle' => [
+        'enable' => true,
+        'per_ip' => ['max_per_minute' => 1],
+    ],
+]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_js_hard.php
+++ b/tests/integration/test_js_hard.php
@@ -1,8 +1,10 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
-putenv('EFORMS_JS_HARD_MODE=1');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'logging' => ['level' => 1],
+    'security' => ['js_hard_mode' => true],
+]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_js_soft.php
+++ b/tests/integration/test_js_soft.php
@@ -1,8 +1,10 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
-putenv('EFORMS_JS_HARD_MODE=0');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'logging' => ['level' => 1],
+    'security' => ['js_hard_mode' => false],
+]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_origin_hard.php
+++ b/tests/integration/test_origin_hard.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
 // Hard origin mode should block cross-origin
-putenv('EFORMS_ORIGIN_MODE=hard');
 require __DIR__ . '/../bootstrap.php';
+set_config(['security' => ['origin_mode' => 'hard']]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_ORIGIN'] = 'http://evil.example.com';

--- a/tests/integration/test_origin_soft.php
+++ b/tests/integration/test_origin_soft.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 require __DIR__ . '/../bootstrap.php';
 
 // Valid submit under soft origin mode with cross-origin should proceed (not blocked)
-putenv('EFORMS_ORIGIN_MODE=soft');
+set_config(['security' => ['origin_mode' => 'soft']]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_ORIGIN'] = 'http://evil.example.com';

--- a/tests/integration/test_throttle_hard_first.php
+++ b/tests/integration/test_throttle_hard_first.php
@@ -1,10 +1,13 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
-putenv('EFORMS_THROTTLE_ENABLE=1');
-putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
-putenv('EFORMS_THROTTLE_HARD_MULTIPLIER=1.5');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'logging' => ['level' => 1],
+    'throttle' => [
+        'enable' => true,
+        'per_ip' => ['max_per_minute' => 1, 'hard_multiplier' => 1.5],
+    ],
+]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_throttle_hard_second.php
+++ b/tests/integration/test_throttle_hard_second.php
@@ -1,10 +1,13 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
-putenv('EFORMS_THROTTLE_ENABLE=1');
-putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
-putenv('EFORMS_THROTTLE_HARD_MULTIPLIER=1.5');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'logging' => ['level' => 1],
+    'throttle' => [
+        'enable' => true,
+        'per_ip' => ['max_per_minute' => 1, 'hard_multiplier' => 1.5],
+    ],
+]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_throttle_soft_first.php
+++ b/tests/integration/test_throttle_soft_first.php
@@ -1,9 +1,13 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
-putenv('EFORMS_THROTTLE_ENABLE=1');
-putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'logging' => ['level' => 1],
+    'throttle' => [
+        'enable' => true,
+        'per_ip' => ['max_per_minute' => 1],
+    ],
+]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_throttle_soft_second.php
+++ b/tests/integration/test_throttle_soft_second.php
@@ -1,9 +1,13 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
-putenv('EFORMS_THROTTLE_ENABLE=1');
-putenv('EFORMS_THROTTLE_MAX_PER_MINUTE=1');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'logging' => ['level' => 1],
+    'throttle' => [
+        'enable' => true,
+        'per_ip' => ['max_per_minute' => 1],
+    ],
+]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_timing_expired.php
+++ b/tests/integration/test_timing_expired.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
 require __DIR__ . '/../bootstrap.php';
+set_config(['logging' => ['level' => 1]]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/test_timing_min_fill.php
+++ b/tests/integration/test_timing_min_fill.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_LOG_LEVEL=1');
 require __DIR__ . '/../bootstrap.php';
+set_config(['logging' => ['level' => 1]]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';

--- a/tests/integration/token_hard_fail.php
+++ b/tests/integration/token_hard_fail.php
@@ -1,8 +1,10 @@
 <?php
 declare(strict_types=1);
-putenv('EFORMS_COOKIE_MISSING_POLICY=hard');
-putenv('EFORMS_LOG_LEVEL=1');
 require __DIR__ . '/../bootstrap.php';
+set_config([
+    'security' => ['cookie_missing_policy' => 'hard'],
+    'logging' => ['level' => 1],
+]);
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_POST = [

--- a/tests/unit/EnvBridgeTest.php
+++ b/tests/unit/EnvBridgeTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+use EForms\Config;
+
+final class EnvBridgeTest extends BaseTestCase
+{
+    public function testEnvOverridesConfig(): void
+    {
+        putenv('EFORMS_LOG_LEVEL=2');
+        $ref = new ReflectionClass(Config::class);
+        $boot = $ref->getProperty('bootstrapped');
+        $boot->setAccessible(true);
+        $boot->setValue(null, false);
+        $data = $ref->getProperty('data');
+        $data->setAccessible(true);
+        $data->setValue(null, []);
+        Config::bootstrap();
+        $this->assertSame(2, Config::get('logging.level'));
+    }
+}

--- a/tests/unit/RendererRowGroupTest.php
+++ b/tests/unit/RendererRowGroupTest.php
@@ -12,13 +12,6 @@ final class RendererRowGroupTest extends BaseTestCase
     {
         parent::setUp();
 
-        $ref = new \ReflectionClass(Config::class);
-        $boot = $ref->getProperty('bootstrapped');
-        $boot->setAccessible(true);
-        $boot->setValue(false);
-        $data = $ref->getProperty('data');
-        $data->setAccessible(true);
-        $data->setValue([]);
         $lref = new \ReflectionClass(Logging::class);
         $lin = $lref->getProperty('init');
         $lin->setAccessible(true);
@@ -29,8 +22,7 @@ final class RendererRowGroupTest extends BaseTestCase
         $ldir = $lref->getProperty('dir');
         $ldir->setAccessible(true);
         $ldir->setValue('');
-        putenv('EFORMS_LOG_LEVEL=1');
-        Config::bootstrap();
+        set_config(['logging' => ['level' => 1]]);
     }
 
     public function testRowGroupAutoCloseAndLogging(): void

--- a/tests/unit/ValidatorRulesTest.php
+++ b/tests/unit/ValidatorRulesTest.php
@@ -12,13 +12,6 @@ final class ValidatorRulesTest extends BaseTestCase
     {
         parent::setUp();
 
-        $ref = new \ReflectionClass(Config::class);
-        $boot = $ref->getProperty('bootstrapped');
-        $boot->setAccessible(true);
-        $boot->setValue(false);
-        $data = $ref->getProperty('data');
-        $data->setAccessible(true);
-        $data->setValue([]);
         $lref = new \ReflectionClass(Logging::class);
         $lin = $lref->getProperty('init');
         $lin->setAccessible(true);
@@ -29,9 +22,7 @@ final class ValidatorRulesTest extends BaseTestCase
         $ldir = $lref->getProperty('dir');
         $ldir->setAccessible(true);
         $ldir->setValue('');
-        putenv('EFORMS_LOG_LEVEL=1');
-        putenv('EFORMS_LOG_MODE=jsonl');
-        Config::bootstrap();
+        set_config(['logging' => ['level' => 1, 'mode' => 'jsonl']]);
     }
 
     public function testUnknownRuleLogsEnum(): void


### PR DESCRIPTION
## Summary
- add `set_config()` helper for tests
- switch tests from env variables to direct config overrides
- add dedicated env bridge test

## Testing
- `composer install`
- `php-cgi tests/integration/test_honeypot_capture.php | head -n 20`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68c58fbc8940832d9ed7c84fee621768