### PR TITLE
Run tests with random order in CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-progress
+      - name: Run PHPUnit with random order
+        run: vendor/bin/phpunit --order-by=random


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that runs PHPUnit with `--order-by=random`

## Testing
- `composer install --no-progress`
- `vendor/bin/phpunit --order-by=random`

------
https://chatgpt.com/codex/tasks/task_e_68c5839bbde4832d83564bff8563a69c