### PR TITLE
Run PHPUnit in random order with testdox output

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,4 +14,6 @@ jobs:
       - name: Install dependencies
         run: composer install --no-progress
       - name: Run PHPUnit with random order
-        run: vendor/bin/phpunit --order-by=random
+        run: >-
+          vendor/bin/phpunit -c phpunit.xml.dist --order-by=random
+          --fail-on-warning --testdox


### PR DESCRIPTION
## Summary
- run phpunit with configuration, random order, and fail on warnings

## Testing
- `yamllint .github/workflows/php.yml` (warnings: missing document start, truthy value)
- `vendor/bin/phpunit -c phpunit.xml.dist --order-by=random --fail-on-warning --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68c597dec82c832da41c0457a446bb9d