### PR TITLE
Add PHPStan static analysis and CI step

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,9 @@ jobs:
           coverage: none
       - name: Install dependencies
         run: composer install --no-progress
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse --memory-limit=1G
       - name: Run PHPUnit with random order
         run: >-
           vendor/bin/phpunit -c phpunit.xml.dist --order-by=random
-          --fail-on-warning --testdox
+            --fail-on-warning --testdox

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "Electronic Forms",
     "type": "library",
     "require-dev": {
-        "phpunit/phpunit": "^10.5 || ^11.0"
+        "phpunit/phpunit": "^10.5 || ^11.0",
+        "phpstan/phpstan": "^1.11"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1ca2aa274147353bd27bcd3ee9bf702",
+    "content-hash": "9d3df156bc7fa1ec2e14229a780ce3e5",
     "packages": [],
     "packages-dev": [
         {
@@ -242,6 +242,64 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.28",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-17T17:15:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,9 @@
+parameters:
+    level: 0
+    paths:
+        - src
+        - tests
+    bootstrapFiles:
+        - eforms.php
+    ignoreErrors:
+        - '#Function esc_url_raw not found#'


### PR DESCRIPTION
## Summary
- add phpstan/phpstan to composer dev dependencies
- configure PHPStan with paths and bootstrap
- run PHPStan in CI

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `vendor/bin/phpunit -c phpunit.xml.dist --order-by=random --fail-on-warning --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68c59afd6f24832db3ce8ee627b61f90