### PR TITLE
Reset $_GET in tests to prevent global leakage

### DIFF
--- a/tests/integration/test_prime_cookie.php
+++ b/tests/integration/test_prime_cookie.php
@@ -4,6 +4,10 @@ require __DIR__ . '/../bootstrap.php';
 
 global $TEST_QUERY_VARS;
 $TEST_QUERY_VARS['eforms_prime'] = 1;
+// Snapshot and restore query parameters
+$getSnapshot = $_GET;
 $_GET['f'] = 'contact_us';
 
 do_action('template_redirect');
+
+$_GET = $getSnapshot;

--- a/tests/integration/test_success_inline.php
+++ b/tests/integration/test_success_inline.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 // Simulate that a success cookie is present and renderer should show success message
+$getSnapshot = $_GET;
+$cookieSnapshot = $_COOKIE;
 $_GET['eforms_success'] = 'contact_us';
 $_COOKIE['eforms_s_contact_us'] = 'contact_us:instOK';
 
@@ -9,4 +11,7 @@ require __DIR__ . '/../bootstrap.php';
 $fm = new \EForms\Rendering\FormManager();
 $html = $fm->render('contact_us');
 file_put_contents(__DIR__ . '/../tmp/out_success_inline.html', $html);
+
+$_GET = $getSnapshot;
+$_COOKIE = $cookieSnapshot;
 

--- a/tests/unit/SuccessAntiSpoofTest.php
+++ b/tests/unit/SuccessAntiSpoofTest.php
@@ -15,54 +15,79 @@ final class SuccessAntiSpoofTest extends BaseTestCase
     public function testNoSuccessWithQueryOnly(): void
     {
         header_remove();
-        $_GET = ['eforms_success' => 'contact_us'];
-        $_COOKIE = [];
-        $fm = new \EForms\Rendering\FormManager();
-        $html = $fm->render('contact_us');
-        $this->assertSame('', $html);
+        $getSnapshot = $_GET;
+        try {
+            $_GET = ['eforms_success' => 'contact_us'];
+            $_COOKIE = [];
+            $fm = new \EForms\Rendering\FormManager();
+            $html = $fm->render('contact_us');
+            $this->assertSame('', $html);
+        } finally {
+            $_GET = $getSnapshot;
+        }
     }
 
     public function testNoSuccessWithCookieOnly(): void
     {
         header_remove();
-        $_GET = [];
-        $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
-        $fm = new \EForms\Rendering\FormManager();
-        $html = $fm->render('contact_us');
-        $this->assertStringNotContainsString('Thanks! We got your message.', $html);
+        $getSnapshot = $_GET;
+        try {
+            $_GET = [];
+            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
+            $fm = new \EForms\Rendering\FormManager();
+            $html = $fm->render('contact_us');
+            $this->assertStringNotContainsString('Thanks! We got your message.', $html);
+        } finally {
+            $_GET = $getSnapshot;
+        }
     }
 
     public function testNoSuccessWithMismatchedCookie(): void
     {
         header_remove();
-        $_GET = ['eforms_success' => 'contact_us'];
-        $_COOKIE = ['eforms_s_contact_us' => 'other:inst'];
-        $fm = new \EForms\Rendering\FormManager();
-        $html = $fm->render('contact_us');
-        $this->assertSame('', $html);
+        $getSnapshot = $_GET;
+        try {
+            $_GET = ['eforms_success' => 'contact_us'];
+            $_COOKIE = ['eforms_s_contact_us' => 'other:inst'];
+            $fm = new \EForms\Rendering\FormManager();
+            $html = $fm->render('contact_us');
+            $this->assertSame('', $html);
+        } finally {
+            $_GET = $getSnapshot;
+        }
     }
 
     public function testSuccessWithMatchingCookieAndQuery(): void
     {
         header_remove();
-        $_GET = ['eforms_success' => 'contact_us'];
-        $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
-        $fm = new \EForms\Rendering\FormManager();
-        $html = $fm->render('contact_us');
-        $this->assertStringContainsString('Thanks! We got your message.', $html);
+        $getSnapshot = $_GET;
+        try {
+            $_GET = ['eforms_success' => 'contact_us'];
+            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
+            $fm = new \EForms\Rendering\FormManager();
+            $html = $fm->render('contact_us');
+            $this->assertStringContainsString('Thanks! We got your message.', $html);
+        } finally {
+            $_GET = $getSnapshot;
+        }
     }
 
     public function testSuccessCookieConsumedOnlyOnce(): void
     {
         header_remove();
-        $_GET = ['eforms_success' => 'contact_us'];
-        $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
-        $fm = new \EForms\Rendering\FormManager();
-        $html1 = $fm->render('contact_us');
-        $this->assertStringContainsString('Thanks! We got your message.', $html1);
-        $fm2 = new \EForms\Rendering\FormManager();
-        $html2 = $fm2->render('contact_us');
-        $this->assertSame('', $html2);
+        $getSnapshot = $_GET;
+        try {
+            $_GET = ['eforms_success' => 'contact_us'];
+            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
+            $fm = new \EForms\Rendering\FormManager();
+            $html1 = $fm->render('contact_us');
+            $this->assertStringContainsString('Thanks! We got your message.', $html1);
+            $fm2 = new \EForms\Rendering\FormManager();
+            $html2 = $fm2->render('contact_us');
+            $this->assertSame('', $html2);
+        } finally {
+            $_GET = $getSnapshot;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- snapshot and restore `$_GET` in integration tests
- isolate `$_GET` inside `SuccessAntiSpoofTest`
- verify `BaseTestCase` continues to manage global state

## Testing
- `composer install --no-interaction`
- `pip3 install jsonschema`
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c59c21c434832d97e531444b30ba14