### PR TITLE
Document test commands and prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ Uploads are stored in `wp-content/uploads/eforms-private` with strict perms.
 
 ## Tests
 
-Install dependencies and run the tiny PHPUnit suite:
+Requires PHP 8.0+ and Composer. Install dependencies and run the tiny PHPUnit suite:
 
-```bash
-composer install
-vendor/bin/phpunit
-```
+- `composer install`
+- `vendor/bin/phpunit -c phpunit.xml.dist --testdox`
+- Optional stricter run: `vendor/bin/phpunit -c phpunit.xml.dist --fail-on-warning --testdox`
 


### PR DESCRIPTION
## Summary
- clarify PHP/composer prerequisites for running the test suite
- document phpunit invocation and optional stricter run in README

## Testing
- `composer install --no-progress`
- `vendor/bin/phpunit -c phpunit.xml.dist --testdox`
- `vendor/bin/phpunit -c phpunit.xml.dist --fail-on-warning --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68c5bbb8bd1c832d99c80584be6f6464