### PR TITLE
Add directory protection for templates

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,5 @@
+# Release Notes
+
+## Unreleased
+
+- Added protective files to template directories (`index.html`, `.htaccess`, `web.config`) to prevent directory listing across environments and ensure they are packaged with the plugin.

--- a/templates/.htaccess
+++ b/templates/.htaccess
@@ -1,2 +1,7 @@
-# Deny direct access to form templates
-Deny from all
+# Prevent directory listing of templates
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>

--- a/templates/forms/.htaccess
+++ b/templates/forms/.htaccess
@@ -1,4 +1,4 @@
-# Prevent directory listing of email templates
+# Prevent directory listing of form templates
 <IfModule mod_authz_core.c>
   Require all denied
 </IfModule>

--- a/templates/forms/index.html
+++ b/templates/forms/index.html
@@ -1,0 +1,1 @@
+<!doctype html><title></title>

--- a/templates/forms/web.config
+++ b/templates/forms/web.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <security>
+      <requestFiltering>
+        <hiddenSegments>
+          <add segment="." />
+        </hiddenSegments>
+      </requestFiltering>
+    </security>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
## Summary
- Block directory listing for template directories with `.htaccess`
- Add `index.html` and `web.config` guards to `templates/forms`
- Document new protections in release notes

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml.dist --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68c5beba7768832d832084e3260971b6