### PR TITLE
Run PHPUnit in CI with warnings treated as failures

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,6 +16,4 @@ jobs:
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse --memory-limit=1G
       - name: Run PHPUnit with random order
-        run: >-
-          vendor/bin/phpunit -c phpunit.xml.dist --order-by=random
-            --fail-on-warning --testdox
+        run: vendor/bin/phpunit -c phpunit.xml.dist --order-by=random --fail-on-warning


### PR DESCRIPTION
## Summary
- simplify phpunit step in GitHub Actions workflow to run with random order and fail on warnings

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist --order-by=random --fail-on-warning`

------
https://chatgpt.com/codex/tasks/task_e_68c5c017b0f4832d9c5ab72c03561a90