### PR TITLE
Add WP-CLI scripts for origin and payload tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,19 @@ Requires PHP 8.0+ and Composer. Install dependencies and run the tiny PHPUnit su
 - `vendor/bin/phpunit -c phpunit.xml.dist --testdox`
 - Optional stricter run: `vendor/bin/phpunit -c phpunit.xml.dist --fail-on-warning --testdox`
 
+## WP-CLI scripts
+
+Helper scripts under `bin/wp-cli/` exercise a couple of security scenarios. Run
+them from the WordPress root where this plugin is installed:
+
+```sh
+# Submit without an Origin header; expects "Security check failed." in response
+wp eval-file wp-content/plugins/eform/bin/wp-cli/post-no-origin.php
+
+# Send a payload above the configured limit; expects HTTP 413
+wp eval-file wp-content/plugins/eform/bin/wp-cli/post-oversized.php
+```
+
+Both scripts exit with a non-zero status when the observed behaviour deviates
+from the expected result.
+

--- a/bin/wp-cli/post-no-origin.php
+++ b/bin/wp-cli/post-no-origin.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Submit a form without an Origin header.
+ *
+ * Usage:
+ *   wp eval-file wp-content/plugins/eform/bin/wp-cli/post-no-origin.php
+ */
+
+// Prime the form to obtain the submission cookie.
+$prime = wp_remote_get( home_url( '/eforms/prime?f=contact_us' ), [
+    'sslverify' => false,
+] );
+
+if ( is_wp_error( $prime ) ) {
+    WP_CLI::error( 'Prime request failed: ' . $prime->get_error_message() );
+}
+
+$cookies = wp_remote_retrieve_cookies( $prime );
+if ( empty( $cookies ) ) {
+    WP_CLI::error( 'Prime request failed to set cookie.' );
+}
+
+// Submit without an Origin header.
+$submit = wp_remote_post( home_url( '/eforms/submit' ), [
+    'sslverify' => false,
+    'cookies'  => $cookies,
+    'headers'  => [
+        // Intentionally no Origin header.
+    ],
+    'body'     => [
+        'form_id'     => 'contact_us',
+        'instance_id' => 'cli-test',
+        'name'        => 'Alice',
+        'email'       => 'alice@example.com',
+        'message'     => 'Hello from WP-CLI',
+    ],
+] );
+
+if ( is_wp_error( $submit ) ) {
+    WP_CLI::error( 'Submit request failed: ' . $submit->get_error_message() );
+}
+
+$body = wp_remote_retrieve_body( $submit );
+if ( strpos( $body, 'Security check failed.' ) !== false ) {
+    WP_CLI::success( 'Missing Origin was rejected as expected.' );
+    return;
+}
+
+WP_CLI::error( 'Missing Origin was not rejected.' );

--- a/bin/wp-cli/post-oversized.php
+++ b/bin/wp-cli/post-oversized.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Send an oversized payload to trigger a 413 response.
+ *
+ * Usage:
+ *   wp eval-file wp-content/plugins/eform/bin/wp-cli/post-oversized.php
+ */
+
+$payload = str_repeat( 'A', 26 * 1024 * 1024 ); // ~26MB
+
+$response = wp_remote_post( home_url( '/eforms/submit' ), [
+    'sslverify' => false,
+    'timeout'   => 60,
+    'headers'   => [
+        'Content-Type' => 'application/x-www-form-urlencoded',
+    ],
+    'body'      => [
+        'payload' => $payload,
+    ],
+] );
+
+if ( is_wp_error( $response ) ) {
+    WP_CLI::error( 'Request failed: ' . $response->get_error_message() );
+}
+
+$code = wp_remote_retrieve_response_code( $response );
+if ( $code === 413 ) {
+    WP_CLI::success( 'Received expected 413 response.' );
+    return;
+}
+
+WP_CLI::error( 'Expected 413 response, got ' . $code );


### PR DESCRIPTION
## Summary
- add WP-CLI script to submit forms without an Origin header
- add WP-CLI script to send oversized payloads and expect 413
- document running the new scripts in README

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml.dist --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68c5c363290c832d88be0e9f66cf1398