### PR TITLE
Preserve renderer handlers in validation descriptors

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -5,6 +5,7 @@ namespace EForms\Validation;
 
 use EForms\Config;
 use EForms\Logging;
+use EForms\Rendering\Renderer;
 
 class Validator
 {
@@ -219,13 +220,18 @@ class Validator
             if (($f['type'] ?? '') === 'row_group') {
                 continue;
             }
-            $hid = $f['handlers']['validator_id'] ?? ($f['type'] ?? '');
-            $nid = $f['handlers']['normalizer_id'] ?? ($f['type'] ?? '');
+            $handlers = $f['handlers'] ?? [];
+            $hid = $handlers['validator_id'] ?? ($f['type'] ?? '');
+            $nid = $handlers['normalizer_id'] ?? ($f['type'] ?? '');
+            $rid = $handlers['renderer_id'] ?? ($f['type'] ?? '');
             $f['form_id'] = $tpl['id'] ?? '';
-            $f['handlers'] = [
+            $f['handlers'] = $handlers + [
                 'validator'  => self::resolve($hid),
                 'normalizer' => Normalizer::resolve($nid),
             ];
+            if (!array_key_exists('renderer', $handlers)) {
+                $f['handlers']['renderer'] = Renderer::resolve($rid);
+            }
             $desc[$f['key']] = $f;
         }
         return $desc;

--- a/tests/unit/ValidatorFieldValidationTest.php
+++ b/tests/unit/ValidatorFieldValidationTest.php
@@ -1,6 +1,7 @@
 <?php
 use EForms\Validation\Validator;
 use EForms\Validation\Normalizer;
+use EForms\Rendering\Renderer;
 
 final class ValidatorFieldValidationTest extends BaseTestCase
 {
@@ -48,6 +49,36 @@ final class ValidatorFieldValidationTest extends BaseTestCase
         $tpl = ['fields' => [$field]];
         $desc = ['t' => $field];
         Validator::validate($tpl, $desc, ['t' => 'foo']);
+        $this->assertTrue($called);
+    }
+
+    public function testRendererCallableExecutes(): void
+    {
+        $called = false;
+        $field = [
+            'type' => 'text',
+            'key' => 'r',
+            'handlers' => [
+                'renderer' => function (array $ctx) use (&$called) {
+                    $called = true;
+                    return '';
+                },
+            ],
+        ];
+        $tpl = ['fields' => [$field]];
+        $desc = Validator::descriptors($tpl);
+        $tpl['descriptors'] = $desc;
+        $meta = [
+            'form_id' => 'f',
+            'instance_id' => 'i',
+            'timestamp' => 0,
+            'cacheable' => true,
+            'client_validation' => false,
+            'action' => '/',
+            'hidden_token' => '',
+            'enctype' => 'application/x-www-form-urlencoded',
+        ];
+        Renderer::form($tpl, $meta, [], []);
         $this->assertTrue($called);
     }
 }


### PR DESCRIPTION
## Summary
- include renderer resolution in Validator descriptors
- merge existing handler data to preserve custom handlers
- test renderer callable availability through rendering pipeline

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --error-format=raw && echo 'PHPStan OK'`


------
https://chatgpt.com/codex/tasks/task_e_68c5c4f814d4832d8bdf48c2963c7466