### PR TITLE
Add context to handler resolution diagnostics

### DIFF
--- a/src/Rendering/Renderer.php
+++ b/src/Rendering/Renderer.php
@@ -41,10 +41,14 @@ class Renderer
      *
      * @throws \RuntimeException when the identifier is unknown
      */
-    public static function resolve(string $id): callable
+    public static function resolve(string $id, ?string $context = null): callable
     {
         if (!isset(self::HANDLERS[$id])) {
-            throw new \RuntimeException('Unknown renderer ID: ' . $id);
+            $msg = 'Unknown renderer ID: ' . $id;
+            if ($context !== null && $context !== '') {
+                $msg .= ' (context: ' . $context . ')';
+            }
+            throw new \RuntimeException($msg);
         }
         return self::HANDLERS[$id];
     }
@@ -206,7 +210,7 @@ class Renderer
             $before = $f['before_html'] ?? '';
             $after = $f['after_html'] ?? '';
             $html .= $before;
-            $handler = $desc['handlers']['renderer'] ?? self::resolve($desc['handlers']['renderer_id'] ?? '');
+            $handler = $desc['handlers']['renderer'] ?? self::resolve($desc['handlers']['renderer_id'] ?? '', 'fields.' . $key . '.renderer');
             $ctx = [
                 'desc' => $desc,
                 'f' => $f,

--- a/src/Validation/Normalizer.php
+++ b/src/Validation/Normalizer.php
@@ -34,10 +34,14 @@ class Normalizer
      *
      * @throws \RuntimeException when the identifier is unknown
      */
-    public static function resolve(string $id): callable
+    public static function resolve(string $id, ?string $context = null): callable
     {
         if (!isset(self::HANDLERS[$id])) {
-            throw new \RuntimeException('Unknown normalizer ID: ' . $id);
+            $msg = 'Unknown normalizer ID: ' . $id;
+            if ($context !== null && $context !== '') {
+                $msg .= ' (context: ' . $context . ')';
+            }
+            throw new \RuntimeException($msg);
         }
         return self::HANDLERS[$id];
     }

--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -622,10 +622,11 @@ class TemplateValidator
             $handlers = $d['handlers'] ?? [];
             $d['handlers'] = [];
 
+            $ctxBase = 'fields.' . ($f['key'] ?? '') . '.';
             $handlerTypes = [
-                'validator'  => ['id' => $handlers['validator_id'] ?? '', 'resolver' => fn(string $id) => Validator::resolve($id)],
-                'normalizer' => ['id' => $handlers['normalizer_id'] ?? '', 'resolver' => fn(string $id) => Normalizer::resolve($id)],
-                'renderer'   => ['id' => $handlers['renderer_id'] ?? '', 'resolver' => fn(string $id) => Renderer::resolve($id)],
+                'validator'  => ['id' => $handlers['validator_id'] ?? '', 'resolver' => fn(string $id) => Validator::resolve($id, $ctxBase . 'validator')],
+                'normalizer' => ['id' => $handlers['normalizer_id'] ?? '', 'resolver' => fn(string $id) => Normalizer::resolve($id, $ctxBase . 'normalizer')],
+                'renderer'   => ['id' => $handlers['renderer_id'] ?? '', 'resolver' => fn(string $id) => Renderer::resolve($id, $ctxBase . 'renderer')],
             ];
 
             foreach ($handlerTypes as $kind => $info) {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -38,10 +38,14 @@ class Validator
      *
      * @throws \RuntimeException when the identifier is unknown
      */
-    public static function resolve(string $id): callable
+    public static function resolve(string $id, ?string $context = null): callable
     {
         if (!isset(self::VALIDATORS[$id])) {
-            throw new \RuntimeException('Unknown validator ID: ' . $id);
+            $msg = 'Unknown validator ID: ' . $id;
+            if ($context !== null && $context !== '') {
+                $msg .= ' (context: ' . $context . ')';
+            }
+            throw new \RuntimeException($msg);
         }
         return self::VALIDATORS[$id];
     }
@@ -225,12 +229,13 @@ class Validator
             $nid = $handlers['normalizer_id'] ?? ($f['type'] ?? '');
             $rid = $handlers['renderer_id'] ?? ($f['type'] ?? '');
             $f['form_id'] = $tpl['id'] ?? '';
+            $ctxBase = 'fields.' . ($f['key'] ?? '');
             $f['handlers'] = $handlers + [
-                'validator'  => self::resolve($hid),
-                'normalizer' => Normalizer::resolve($nid),
+                'validator'  => self::resolve($hid, $ctxBase . '.validator'),
+                'normalizer' => Normalizer::resolve($nid, $ctxBase . '.normalizer'),
             ];
             if (!array_key_exists('renderer', $handlers)) {
-                $f['handlers']['renderer'] = Renderer::resolve($rid);
+                $f['handlers']['renderer'] = Renderer::resolve($rid, $ctxBase . '.renderer');
             }
             $desc[$f['key']] = $f;
         }

--- a/tests/unit/DescriptorsResolutionTest.php
+++ b/tests/unit/DescriptorsResolutionTest.php
@@ -36,6 +36,7 @@ final class DescriptorsResolutionTest extends BaseTestCase
     public function testUnknownHandlerIdFails(): void
     {
         $this->expectException(\RuntimeException::class);
-        Validator::resolve('unknown');
+        $this->expectExceptionMessage('fields.foo.validator');
+        Validator::resolve('unknown', 'fields.foo.validator');
     }
 }


### PR DESCRIPTION
## Summary
- Extend renderer, normalizer, and validator handler resolution to accept optional context
- Include context in runtime errors for unknown handler IDs
- Pass field-specific context through descriptor builders and update tests

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse`


------
https://chatgpt.com/codex/tasks/task_e_68c5c73d2794832dbe57015eefb08d38