### PR TITLE
refactor: replace reflection-based resets with helpers

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -32,6 +32,12 @@ class Config
         return $value;
     }
 
+    public static function resetForTests(): void
+    {
+        self::$data = [];
+        self::$bootstrapped = false;
+    }
+
     private static function clampTypes(array $config, array $defaults): array
     {
         $cfg = array_replace_recursive($defaults, $config);

--- a/src/Logging.php
+++ b/src/Logging.php
@@ -9,6 +9,13 @@ class Logging
     private static bool $init = false;
     private static string $dir = '';
 
+    public static function resetForTests(): void
+    {
+        self::$file = '';
+        self::$init = false;
+        self::$dir = '';
+    }
+
     private static function init(): void
     {
         \EForms\Config::bootstrap();

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -19,10 +19,6 @@ class BaseTestCase extends TestCase
     private array $serverSnapshot = [];
     /** @var array<string,mixed> */
     private array $filtersSnapshot = [];
-    /** @var array<string,mixed> */
-    private array $configSnapshot = [];
-    /** @var array<string,mixed> */
-    private array $loggingSnapshot = [];
 
     protected function setUp(): void
     {
@@ -51,8 +47,8 @@ class BaseTestCase extends TestCase
                 }
             }
         }
-        $this->configSnapshot = $this->snapshotStatic(Config::class);
-        $this->loggingSnapshot = $this->snapshotStatic(Logging::class);
+        Config::resetForTests();
+        Logging::resetForTests();
     }
 
     protected function tearDown(): void
@@ -84,35 +80,8 @@ class BaseTestCase extends TestCase
         global $TEST_FILTERS;
         $TEST_FILTERS = $this->filtersSnapshot;
         register_test_env_filter();
-        $this->restoreStatic(Config::class, $this->configSnapshot);
-        $this->restoreStatic(Logging::class, $this->loggingSnapshot);
+        Config::resetForTests();
+        Logging::resetForTests();
         parent::tearDown();
-    }
-
-    /**
-     * @return array<string,mixed>
-     */
-    private function snapshotStatic(string $class): array
-    {
-        $rc = new ReflectionClass($class);
-        $props = [];
-        foreach ($rc->getProperties(ReflectionProperty::IS_STATIC) as $prop) {
-            $prop->setAccessible(true);
-            $props[$prop->getName()] = $prop->getValue();
-        }
-        return $props;
-    }
-
-    /**
-     * @param array<string,mixed> $snapshot
-     */
-    private function restoreStatic(string $class, array $snapshot): void
-    {
-        $rc = new ReflectionClass($class);
-        foreach ($snapshot as $name => $value) {
-            $prop = $rc->getProperty($name);
-            $prop->setAccessible(true);
-            $prop->setValue($value);
-        }
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -307,23 +307,8 @@ function set_config(array $overrides): void {
     global $TEST_FILTERS;
     $TEST_FILTERS = [];
     register_test_env_filter();
-    $ref = new \ReflectionClass(\EForms\Config::class);
-    $boot = $ref->getProperty('bootstrapped');
-    $boot->setAccessible(true);
-    $boot->setValue(null, false);
-    $data = $ref->getProperty('data');
-    $data->setAccessible(true);
-    $data->setValue(null, []);
-    $lref = new \ReflectionClass(\EForms\Logging::class);
-    $prop = $lref->getProperty('init');
-    $prop->setAccessible(true);
-    $prop->setValue(null, false);
-    $prop = $lref->getProperty('file');
-    $prop->setAccessible(true);
-    $prop->setValue(null, '');
-    $prop = $lref->getProperty('dir');
-    $prop->setAccessible(true);
-    $prop->setValue(null, '');
+    \EForms\Config::resetForTests();
+    \EForms\Logging::resetForTests();
     add_filter('eforms_config', function ($defaults) use ($overrides) {
         return array_replace_recursive($defaults, $overrides);
     });

--- a/tests/unit/EmailAttachmentNameTest.php
+++ b/tests/unit/EmailAttachmentNameTest.php
@@ -17,13 +17,7 @@ final class EmailAttachmentNameTest extends BaseTestCase
 
     public function testAttachmentUsesRfc5987WhenNotTransliterated(): void
     {
-        Config::bootstrap();
-        $ref = new \ReflectionClass(Config::class);
-        $prop = $ref->getProperty('data');
-        $prop->setAccessible(true);
-        $cfg = $prop->getValue();
-        $cfg['uploads']['transliterate'] = false;
-        $prop->setValue($cfg);
+        set_config(['uploads' => ['transliterate' => false]]);
 
         $tpl = [
             'id' => 't1',

--- a/tests/unit/EmailAttachmentOverflowTest.php
+++ b/tests/unit/EmailAttachmentOverflowTest.php
@@ -12,18 +12,7 @@ final class EmailAttachmentOverflowTest extends BaseTestCase
 
         global $TEST_ARTIFACTS;
         @file_put_contents($TEST_ARTIFACTS['mail_file'], '[]');
-        $ref = new \ReflectionClass(Config::class);
-        $boot = $ref->getProperty('bootstrapped');
-        $boot->setAccessible(true);
-        $boot->setValue(false);
-        $data = $ref->getProperty('data');
-        $data->setAccessible(true);
-        $data->setValue([]);
-        add_filter('eforms_config', function ($defaults) {
-            $defaults['uploads']['max_email_bytes'] = 100;
-            return $defaults;
-        });
-        Config::bootstrap();
+        set_config(['uploads' => ['max_email_bytes' => 100]]);
     }
 
     public function testOverflowAttachmentsSummarized(): void
@@ -59,13 +48,5 @@ final class EmailAttachmentOverflowTest extends BaseTestCase
         $this->assertSame('a.pdf', $mail[0]['attachments'][0]['name']);
         $this->assertStringContainsString('Omitted attachments: b.pdf', $mail[0]['message']);
     }
-    protected function tearDown(): void
-    {
-        global $TEST_FILTERS;
-        $TEST_FILTERS = [];
-        register_test_env_filter();
-        parent::tearDown();
-    }
-
 }
 

--- a/tests/unit/Fail2banLoggingTest.php
+++ b/tests/unit/Fail2banLoggingTest.php
@@ -37,13 +37,7 @@ final class Fail2banLoggingTest extends BaseTestCase
 
     private function boot(array $opts): void
     {
-        $ref = new \ReflectionClass(Config::class);
-        $boot = $ref->getProperty('bootstrapped');
-        $boot->setAccessible(true);
-        $boot->setValue(false);
-        $data = $ref->getProperty('data');
-        $data->setAccessible(true);
-        $data->setValue([]);
+        Config::resetForTests();
         add_filter('eforms_config', function ($defaults) use ($opts) {
             $defaults['logging']['mode'] = 'off';
             $defaults['logging']['fail2ban'] = array_replace($defaults['logging']['fail2ban'], $opts);

--- a/tests/unit/RendererLabelTest.php
+++ b/tests/unit/RendererLabelTest.php
@@ -1,26 +1,11 @@
 <?php
 declare(strict_types=1);
 
-use EForms\Config;
 use EForms\Rendering\Renderer;
 use EForms\Validation\TemplateValidator;
 
 final class RendererLabelTest extends BaseTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $ref = new \ReflectionClass(Config::class);
-        $boot = $ref->getProperty('bootstrapped');
-        $boot->setAccessible(true);
-        $boot->setValue(false);
-        $data = $ref->getProperty('data');
-        $data->setAccessible(true);
-        $data->setValue([]);
-        Config::bootstrap();
-    }
-
     public function testRequiredAndHiddenLabels(): void
     {
         $tpl = [

--- a/tests/unit/RendererRowGroupTest.php
+++ b/tests/unit/RendererRowGroupTest.php
@@ -4,24 +4,12 @@ declare(strict_types=1);
 use EForms\Config;
 use EForms\Rendering\Renderer;
 use EForms\Validation\TemplateValidator;
-use EForms\Logging;
 
 final class RendererRowGroupTest extends BaseTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-
-        $lref = new \ReflectionClass(Logging::class);
-        $lin = $lref->getProperty('init');
-        $lin->setAccessible(true);
-        $lin->setValue(false);
-        $lfile = $lref->getProperty('file');
-        $lfile->setAccessible(true);
-        $lfile->setValue('');
-        $ldir = $lref->getProperty('dir');
-        $ldir->setAccessible(true);
-        $ldir->setValue('');
         set_config(['logging' => ['level' => 1]]);
     }
 

--- a/tests/unit/RendererStepTest.php
+++ b/tests/unit/RendererStepTest.php
@@ -1,26 +1,11 @@
 <?php
 declare(strict_types=1);
 
-use EForms\Config;
 use EForms\Rendering\Renderer;
 use EForms\Validation\TemplateValidator;
 
 final class RendererStepTest extends BaseTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $ref = new \ReflectionClass(Config::class);
-        $boot = $ref->getProperty('bootstrapped');
-        $boot->setAccessible(true);
-        $boot->setValue(false);
-        $data = $ref->getProperty('data');
-        $data->setAccessible(true);
-        $data->setValue([]);
-        Config::bootstrap();
-    }
-
     public function testStepAttributeMirrored(): void
     {
         $tpl = [

--- a/tests/unit/UploadsLimitTest.php
+++ b/tests/unit/UploadsLimitTest.php
@@ -8,29 +8,7 @@ final class UploadsLimitTest extends BaseTestCase
 {
     private function rebootstrap(array $overrides): void
     {
-        global $TEST_FILTERS;
-        $TEST_FILTERS = [];
-        register_test_env_filter();
-        $ref = new \ReflectionClass(Config::class);
-        $boot = $ref->getProperty('bootstrapped');
-        $boot->setAccessible(true);
-        $boot->setValue(false);
-        $data = $ref->getProperty('data');
-        $data->setAccessible(true);
-        $data->setValue([]);
-        add_filter('eforms_config', function ($defaults) use ($overrides) {
-            $defaults['uploads'] = array_replace($defaults['uploads'], $overrides);
-            return $defaults;
-        });
-        Config::bootstrap();
-    }
-
-    protected function tearDown(): void
-    {
-        global $TEST_FILTERS;
-        $TEST_FILTERS = [];
-        register_test_env_filter();
-        parent::tearDown();
+        set_config(['uploads' => $overrides]);
     }
 
     public function testMaxFileBytesPerField(): void

--- a/tests/unit/UploadsUtf8NameTest.php
+++ b/tests/unit/UploadsUtf8NameTest.php
@@ -8,13 +8,7 @@ final class UploadsUtf8NameTest extends BaseTestCase
 {
     public function testUtf8NamesPreservedWhenNotTransliterated(): void
     {
-        Config::bootstrap();
-        $ref = new \ReflectionClass(Config::class);
-        $prop = $ref->getProperty('data');
-        $prop->setAccessible(true);
-        $data = $prop->getValue();
-        $data['uploads']['transliterate'] = false;
-        $prop->setValue($data);
+        set_config(['uploads' => ['transliterate' => false]]);
 
         $tpl = [
             'fields' => [

--- a/tests/unit/ValidatorRulesTest.php
+++ b/tests/unit/ValidatorRulesTest.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 use EForms\Config;
-use EForms\Logging;
 use EForms\Validation\TemplateValidator;
 use EForms\Validation\Validator;
 
@@ -11,17 +10,6 @@ final class ValidatorRulesTest extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        $lref = new \ReflectionClass(Logging::class);
-        $lin = $lref->getProperty('init');
-        $lin->setAccessible(true);
-        $lin->setValue(false);
-        $lfile = $lref->getProperty('file');
-        $lfile->setAccessible(true);
-        $lfile->setValue('');
-        $ldir = $lref->getProperty('dir');
-        $ldir->setAccessible(true);
-        $ldir->setValue('');
         set_config(['logging' => ['level' => 1, 'mode' => 'jsonl']]);
     }
 


### PR DESCRIPTION
## Summary
- add Config::resetForTests() and Logging::resetForTests() to safely clear static state
- call new helpers from BaseTestCase and tests/bootstrap instead of using Reflection
- drop reflection hacks in unit tests and rely on set_config overrides

## Testing
- `vendor/bin/phpunit --display-deprecations`


------
https://chatgpt.com/codex/tasks/task_e_68c5d24942d8832d8458e69dc0552f46