### PR TITLE
Validate size only on text-like fields

### DIFF
--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -71,7 +71,20 @@
         "max_file_bytes": {"type": "integer"},
         "max_files": {"type": "integer"},
         "step": {"type": ["number","string"]}
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {"enum": ["name","text","email","url","tel","tel_us","number","date","textarea","textarea_html"]}
+            },
+            "required": ["type"]
+          },
+          "else": {
+            "properties": {"size": false}
+          }
+        }
+      ]
     },
     "option": {
       "type": "object",

--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -300,7 +300,11 @@ class TemplateValidator
             }
 
             if (isset($f['size'])) {
-                if (!is_int($f['size'])) {
+                $allowedSizeTypes = ['name','text','email','url','tel','tel_us','number','date','textarea','textarea_html'];
+                if (!in_array($type, $allowedSizeTypes, true)) {
+                    $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>$path.'size'];
+                    unset($f['size']);
+                } elseif (!is_int($f['size'])) {
                     $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$path.'size'];
                     unset($f['size']);
                 } elseif ($f['size'] < 1 || $f['size'] > 100) {

--- a/tests/integration/test_schema_parity.php
+++ b/tests/integration/test_schema_parity.php
@@ -39,7 +39,7 @@ if ($schemaRequired !== ['type']) {
 }
 
 // Descriptor structural shape
-$expectedKeys = ['handlers','html','is_multivalue','type','validate'];
+$expectedKeys = ['constants','handlers','html','is_multivalue','type','validate'];
 foreach ($specDescriptors as $t => $desc) {
     $keys = array_keys($desc);
     sort($keys);

--- a/tests/unit/TemplateValidatorTest.php
+++ b/tests/unit/TemplateValidatorTest.php
@@ -333,6 +333,18 @@ class TemplateValidatorTest extends BaseTestCase
         $this->assertNull($res['context']['fields'][0]['size']);
     }
 
+    public function testSizeDisallowedOnNonTextFields(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][] = ['type' => 'range', 'key' => 'rng', 'size' => 10];
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $paths = array_column($res['errors'], 'path');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_ENUM, $codes);
+        $this->assertContains('fields[2].size', $paths);
+        $this->assertNull($res['context']['fields'][2]['size']);
+    }
+
     public function testFileLimitsAndStepAllowed(): void
     {
         $tpl = $this->baseTpl();


### PR DESCRIPTION
## Summary
- allow `size` attribute only for text-like form fields
- enforce schema parity and test coverage

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c5d7efc928832dacc5d8cbf8248d50