### PR TITLE
Validate email attachments on file fields only

### DIFF
--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -83,6 +83,15 @@
           "else": {
             "properties": {"size": false}
           }
+        },
+        {
+          "if": {
+            "properties": {"email_attach": {}},
+            "required": ["email_attach"]
+          },
+          "then": {
+            "properties": {"type": {"enum": ["file","files"]}}
+          }
         }
       ]
     },

--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -178,6 +178,14 @@ class TemplateValidator
                 $path,
                 $errors
             );
+            if (isset($f['email_attach'])) {
+                if (!in_array($type, ['file','files'], true)) {
+                    $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$path.'email_attach'];
+                    unset($f['email_attach']);
+                } elseif (!is_bool($f['email_attach'])) {
+                    $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$path.'email_attach'];
+                }
+            }
             $key = $f['key'] ?? null;
             if (!is_string($key) || !preg_match('/^[a-z0-9_:-]{1,64}$/', $key)) {
                 $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$path.'key'];
@@ -259,9 +267,6 @@ class TemplateValidator
                 $intersection = array_intersect($accept, $global);
                 if (empty($accept) || empty($intersection)) {
                     $errors[] = ['code'=>self::EFORMS_ERR_ACCEPT_EMPTY,'path'=>$path.'accept'];
-                }
-                if (isset($f['email_attach']) && !is_bool($f['email_attach'])) {
-                    $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$path.'email_attach'];
                 }
                 if (isset($f['max_file_bytes'])) {
                     if (!is_int($f['max_file_bytes'])) {

--- a/tests/unit/TemplateValidatorTest.php
+++ b/tests/unit/TemplateValidatorTest.php
@@ -357,6 +357,17 @@ class TemplateValidatorTest extends BaseTestCase
         $this->assertTrue($res['ok']);
     }
 
+    public function testEmailAttachOnlyForFileFields(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['email_attach'] = true;
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $paths = array_column($res['errors'], 'path');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_TYPE, $codes);
+        $this->assertContains('fields[0].email_attach', $paths);
+    }
+
     public function testIncludeFieldsValidation(): void
     {
         $tpl = $this->baseTpl();


### PR DESCRIPTION
## Summary
- Reject `email_attach` on non-file fields and flag with `EFORMS_ERR_SCHEMA_TYPE`
- Restrict `email_attach` usage to file inputs in JSON schema
- Add unit test ensuring invalid `email_attach` usage triggers error

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c5da4ce028832da0c9f132133a4432