### PR TITLE
Add logging sanitization tests and email metadata redaction

### DIFF
--- a/src/Logging.php
+++ b/src/Logging.php
@@ -134,7 +134,10 @@ class Logging
             }
         }
         $meta = $ctx;
-        unset($meta['form_id'], $meta['instance_id'], $meta['msg'], $meta['ip'], $meta['spam'], $meta['email']);
+        unset($meta['form_id'], $meta['instance_id'], $meta['msg'], $meta['ip'], $meta['spam']);
+        if (isset($meta['email']) && is_array($meta['email'])) {
+            unset($meta['email']);
+        }
         if (Config::get('logging.headers', false)) {
             $headers = [];
             if (!empty($_SERVER['HTTP_USER_AGENT'])) {

--- a/tests/unit/LoggingSanitizeTest.php
+++ b/tests/unit/LoggingSanitizeTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+use EForms\Logging;
+
+final class LoggingSanitizeTest extends BaseTestCase
+{
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/eforms-logtest-' . uniqid('', true);
+        @mkdir($dir, 0700, true);
+        return $dir;
+    }
+
+    public function testHeadersUserAgentSanitized(): void
+    {
+        $dir = $this->tempDir();
+        set_config([
+            'uploads' => ['dir' => $dir],
+            'logging' => [
+                'mode' => 'jsonl',
+                'level' => 1,
+                'headers' => true,
+            ],
+        ]);
+        $_SERVER['HTTP_USER_AGENT'] = "Good\x01Bad\nUA";
+        Logging::write('error', 'CODE');
+        $logFile = $dir . '/eforms.log';
+        $line = trim((string) file_get_contents($logFile));
+        $data = json_decode($line, true);
+        $ua = $data['meta']['headers']['user_agent'] ?? '';
+        $this->assertSame('GoodBadUA', $ua);
+        @unlink($logFile);
+        @rmdir($dir);
+    }
+
+    public function testEmailRedactedWhenPiiDisabled(): void
+    {
+        $dir = $this->tempDir();
+        set_config([
+            'uploads' => ['dir' => $dir],
+            'logging' => [
+                'mode' => 'jsonl',
+                'level' => 1,
+                'pii' => false,
+            ],
+        ]);
+        Logging::write('error', 'CODE', ['email' => 'user@example.com']);
+        $logFile = $dir . '/eforms.log';
+        $line = trim((string) file_get_contents($logFile));
+        $data = json_decode($line, true);
+        $email = $data['meta']['email'] ?? '';
+        $this->assertSame('u***@example.com', $email);
+        @unlink($logFile);
+        @rmdir($dir);
+    }
+
+    public function testEmailPreservedWhenPiiEnabled(): void
+    {
+        $dir = $this->tempDir();
+        set_config([
+            'uploads' => ['dir' => $dir],
+            'logging' => [
+                'mode' => 'jsonl',
+                'level' => 1,
+                'pii' => true,
+            ],
+        ]);
+        Logging::write('error', 'CODE', ['email' => 'user@example.com']);
+        $logFile = $dir . '/eforms.log';
+        $line = trim((string) file_get_contents($logFile));
+        $data = json_decode($line, true);
+        $email = $data['meta']['email'] ?? '';
+        $this->assertSame('user@example.com', $email);
+        @unlink($logFile);
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary
- Allow string `email` values in logging metadata and redact them when `logging.pii` is disabled
- Add unit tests for sanitized user agent logging and email PII redaction/preservation

## Testing
- `vendor/bin/phpunit tests/unit/LoggingSanitizeTest.php`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c5dee47eac832dba3594a3343c2296