### PR TITLE
Clarify textarea HTML validator message

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -168,13 +168,13 @@ class Validator
     {
         $max = (int) Config::get('validation.textarea_html_max_bytes', 32768);
         if (strlen($v) > $max) {
-            $errors[$f['key']][] = 'Content too long.';
+            $errors[$f['key']][] = 'This content is too long.';
             Logging::write('warn', 'EFORMS_ERR_HTML_TOO_LARGE', ['form_id'=>$f['form_id'] ?? '', 'field'=>$f['key']]);
             return '';
         }
         $san = \wp_kses_post($v);
         if (strlen($san) > $max) {
-            $errors[$f['key']][] = 'Content too long.';
+            $errors[$f['key']][] = 'This content is too long.';
             Logging::write('warn', 'EFORMS_ERR_HTML_TOO_LARGE', ['form_id'=>$f['form_id'] ?? '', 'field'=>$f['key']]);
             return '';
         }


### PR DESCRIPTION
## Summary
- use more descriptive message when textarea HTML exceeds size

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --configuration=phpstan.neon.dist` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e0e5ac44832d91b15c593dfd31a2