### PR TITLE
Use EFORMS_ERR_THROTTLED for throttle errors

### DIFF
--- a/src/Rendering/FormManager.php
+++ b/src/Rendering/FormManager.php
@@ -251,7 +251,7 @@ class FormManager
             $thr = Throttle::check($ip);
             $throttleState = $thr['state'] ?? 'ok';
             if ($throttleState !== 'ok') {
-                Logging::write('warn', 'EFORMS_THROTTLE', [
+                Logging::write('warn', 'EFORMS_ERR_THROTTLED', [
                     'form_id' => $formId,
                     'instance_id' => $_POST['instance_id'] ?? '',
                     'ip' => $ip,
@@ -264,7 +264,7 @@ class FormManager
                     }
                 }
                 if ($throttleState === 'hard') {
-                    $this->renderErrorAndExit($tpl, $formId, 'Security check failed.');
+                    $this->renderErrorAndExit($tpl, $formId, 'Please wait a moment and try again.');
                 }
                 $softFailCount++;
             }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -348,14 +348,14 @@ record_result "upload: retention GC" $ok
 EFORMS_THROTTLE_ENABLE=1 EFORMS_THROTTLE_MAX_PER_MINUTE=1 run_test test_throttle_soft_first
 EFORMS_THROTTLE_ENABLE=1 EFORMS_THROTTLE_MAX_PER_MINUTE=1 run_test_keep test_throttle_soft_second
 ok=0
-assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_THROTTLE' || ok=1
+assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_THROTTLED' || ok=1
 assert_grep tmp/uploads/eforms-private/eforms.log '"state":"over"' || ok=1
 record_result "throttle: soft over-limit" $ok
 
 EFORMS_THROTTLE_ENABLE=1 EFORMS_THROTTLE_MAX_PER_MINUTE=1 EFORMS_THROTTLE_HARD_MULTIPLIER=1.5 run_test test_throttle_hard_first
 EFORMS_THROTTLE_ENABLE=1 EFORMS_THROTTLE_MAX_PER_MINUTE=1 EFORMS_THROTTLE_HARD_MULTIPLIER=1.5 run_test_keep test_throttle_hard_second
 ok=0
-assert_grep tmp/stdout.txt 'Security check failed\.' || ok=1
+assert_grep tmp/stdout.txt 'Please wait a moment and try again\.' || ok=1
 ! assert_grep tmp/mail.json 'alice@example.com.*alice@example.com' || ok=1
 assert_grep tmp/uploads/eforms-private/eforms.log '"state":"hard"' || ok=1
 record_result "throttle: hard over-limit" $ok


### PR DESCRIPTION
## Summary
- log throttle events with code `EFORMS_ERR_THROTTLED`
- show user message "Please wait a moment and try again." on hard throttle
- adjust integration tests for new log code and message

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5e21e9440832d8314f1eb7fa04645