### PR TITLE
Preserve submission details on email failure

### DIFF
--- a/src/Rendering/FormManager.php
+++ b/src/Rendering/FormManager.php
@@ -411,12 +411,12 @@ class FormManager
             $hasUploads = Uploads::enabled() && Uploads::hasUploadFields($tpl);
             $meta = [
                 'form_id' => $formId,
-                'instance_id' => Helpers::random_id(16),
-                'timestamp' => time(),
+                'instance_id' => $_POST['instance_id'] ?? '',
+                'timestamp' => $timestamp > 0 ? $timestamp : time(),
                 'cacheable' => !$hasHidden,
                 'client_validation' => (bool) Config::get('html5.client_validation', false),
                 'action' => \home_url('/eforms/submit'),
-                'hidden_token' => $hasHidden ? (function_exists('\wp_generate_uuid4') ? \wp_generate_uuid4() : Helpers::uuid4()) : null,
+                'hidden_token' => $hasHidden ? $postedToken : null,
                 'enctype' => $hasUploads ? 'multipart/form-data' : 'application/x-www-form-urlencoded',
             ];
             if ($requireChallenge) {


### PR DESCRIPTION
## Summary
- Reuse submitted instance ID, timestamp, and hidden token when email sending fails

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c5e6a665e0832d8799eed495850bb8