### PR TITLE
Ensure uploads and logs have protective files

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -201,4 +201,29 @@ class Helpers
         }
         return $path . $queryOut;
     }
+
+    public static function ensure_private_dir(string $dir): void
+    {
+        if ($dir === '') return;
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0700, true);
+        }
+        $index = $dir . '/index.html';
+        if (!file_exists($index)) {
+            @file_put_contents($index, '');
+            @chmod($index, 0600);
+        }
+        $ht = $dir . '/.htaccess';
+        if (!file_exists($ht)) {
+            $content = "Options -Indexes\n<IfModule mod_authz_core.c>\n  Require all denied\n</IfModule>\n<IfModule !mod_authz_core.c>\n  Deny from all\n</IfModule>\n";
+            @file_put_contents($ht, $content);
+            @chmod($ht, 0600);
+        }
+        $wc = $dir . '/web.config';
+        if (!file_exists($wc)) {
+            $content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<configuration>\n  <system.webServer>\n    <directoryBrowse enabled=\"false\" />\n    <authorization>\n      <deny users=\"*\" />\n    </authorization>\n  </system.webServer>\n</configuration>\n";
+            @file_put_contents($wc, $content);
+            @chmod($wc, 0600);
+        }
+    }
 }

--- a/src/Logging.php
+++ b/src/Logging.php
@@ -31,9 +31,7 @@ class Logging
             return;
         }
 
-        if (!is_dir(self::$dir)) {
-            @mkdir(self::$dir, 0700, true);
-        }
+        Helpers::ensure_private_dir(self::$dir);
         self::$file = self::$dir . '/eforms.log';
         self::$init = true;
     }
@@ -98,6 +96,7 @@ class Logging
             }
             return;
         }
+        self::init();
         $level = (int) Config::get('logging.level', 0);
         $sevLevel = 0;
         if ($severity === 'warn') $sevLevel = 1;
@@ -229,9 +228,7 @@ class Logging
                 $file = $base . '/' . ltrim($file, '/');
             }
             $dir = dirname($file);
-            if (!is_dir($dir)) {
-                @mkdir($dir, 0700, true);
-            }
+            Helpers::ensure_private_dir($dir);
             $max = (int) Config::get(
                 'logging.fail2ban.file_max_size',
                 (int) Config::get('logging.file_max_size', 5000000)

--- a/src/Uploads/Uploads.php
+++ b/src/Uploads/Uploads.php
@@ -6,6 +6,7 @@ namespace EForms\Uploads;
 use EForms\Config;
 use EForms\Spec;
 use EForms\Logging;
+use EForms\Helpers;
 
 class Uploads
 {
@@ -165,6 +166,7 @@ class Uploads
         if ($base === '') {
             return $out;
         }
+        Helpers::ensure_private_dir($base);
         $names = [];
         foreach ($files as $k => $list) {
             foreach ($list as $item) {

--- a/tests/integration/test_dir_protect.php
+++ b/tests/integration/test_dir_protect.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../bootstrap.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000099';
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => 'instPROTECT',
+    'timestamp' => time(),
+    'eforms_hp' => '',
+    'contact_us' => [
+        'name' => 'Zed',
+        'email' => 'zed@example.com',
+        'message' => 'Ping',
+    ],
+    'js_ok' => '1',
+];
+
+register_shutdown_function(function () {
+    $dir = __DIR__ . '/../tmp/uploads/eforms-private';
+    $files = ['index.html', '.htaccess', 'web.config'];
+    $ok = true;
+    foreach ($files as $f) {
+        if (!file_exists($dir . '/' . $f)) {
+            $ok = false;
+        }
+    }
+    file_put_contents(__DIR__ . '/../tmp/protect.txt', $ok ? 'OK' : 'FAIL');
+});
+
+$fm = new \EForms\Rendering\FormManager();
+ob_start();
+$fm->handleSubmit();
+ob_end_clean();

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -134,6 +134,12 @@ assert_equal_file tmp/status_code.txt "415" || ok=1
 assert_grep tmp/stdout.txt "Unsupported Media Type" || ok=1
 record_result "submit multipart empty boundary" $ok
 
+# 1e) Protective files created
+run_test test_dir_protect
+ok=0
+assert_equal_file tmp/protect.txt 'OK' || ok=1
+record_result "uploads dir protective files" $ok
+
 # 2) Origin soft default: allow cross origin
 run_test test_origin_soft
 ok=0


### PR DESCRIPTION
## Summary
- add helper to seed `index.html`, `.htaccess`, and `web.config` in private directories
- invoke directory protection from logging and upload paths
- test that first submission creates protective files

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c5e6cdc658832dae6cd31a842baea3