### PR TITLE
Implement cap_id helper and use for renderer IDs

### DIFF
--- a/src/Rendering/Renderer.php
+++ b/src/Rendering/Renderer.php
@@ -55,17 +55,7 @@ class Renderer
 
     private static function makeId(string $formId, string $key, string $instanceId): string
     {
-        $id = $formId . '-' . $key . '-' . $instanceId;
-        if (strlen($id) > 128) {
-            $hash = substr(md5($id), 0, 8);
-            $start = substr($id, 0, 60);
-            $end = substr($id, -60);
-            $id = $start . '-' . $hash . '-' . $end;
-            if (strlen($id) > 128) {
-                $id = substr($id, 0, 119) . '-' . $hash;
-            }
-        }
-        return $id;
+        return Helpers::cap_id($formId . '-' . $key . '-' . $instanceId);
     }
 
     public static function form(array $tpl, array $meta, array $errors, array $values): string

--- a/tests/unit/HelpersCapIdTest.php
+++ b/tests/unit/HelpersCapIdTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+use EForms\Helpers;
+
+final class HelpersCapIdTest extends BaseTestCase
+{
+    public function testShortIdUnchanged(): void
+    {
+        $id = str_repeat('a', 20);
+        $this->assertSame($id, Helpers::cap_id($id));
+    }
+
+    public function testExactLimitUnchanged(): void
+    {
+        $id = str_repeat('b', 128);
+        $this->assertSame($id, Helpers::cap_id($id));
+    }
+
+    public function testLongIdTruncated(): void
+    {
+        $id = str_repeat('c', 200);
+        $out = Helpers::cap_id($id, 128);
+        $this->assertSame(128, strlen($out));
+        $this->assertSame(substr($id, 0, 59), substr($out, 0, 59));
+        $this->assertSame(substr($id, -59), substr($out, -59));
+        $mid = substr($out, 60, 8);
+        $this->assertMatchesRegularExpression('/^[a-z2-7]{8}$/', $mid);
+    }
+
+    public function testDeterministic(): void
+    {
+        $id = str_repeat('xyz', 50);
+        $a = Helpers::cap_id($id);
+        $b = Helpers::cap_id($id);
+        $this->assertSame($a, $b);
+    }
+
+    public function testSmallMax(): void
+    {
+        $id = str_repeat('d', 100);
+        $out = Helpers::cap_id($id, 16);
+        $this->assertSame(16, strlen($out));
+        $this->assertSame(substr($id, 0, 3), substr($out, 0, 3));
+        $this->assertSame(substr($id, -3), substr($out, -3));
+        $mid = substr($out, 4, 8);
+        $this->assertMatchesRegularExpression('/^[a-z2-7]{8}$/', $mid);
+    }
+
+    public function testTinyMax(): void
+    {
+        $id = str_repeat('e', 20);
+        $out = Helpers::cap_id($id, 8);
+        $this->assertSame(8, strlen($out));
+        $this->assertMatchesRegularExpression('/^[a-z2-7]{8}$/', $out);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Helpers::cap_id` for middle truncation with deterministic base32 suffix
- Use new helper in `Renderer::makeId`
- Test helper for length limits and deterministic output

## Testing
- `tests/run.sh` *(failed: template schema parity)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ee28ad80832d8c6b41960ee0bd3c