### PR TITLE
Log upload type mismatches

### DIFF
--- a/src/Uploads/Uploads.php
+++ b/src/Uploads/Uploads.php
@@ -108,14 +108,17 @@ class Uploads
                 $ext = strtolower((string) pathinfo($name, PATHINFO_EXTENSION));
                 if (!self::allowedToken($accept, $mime, $ext)) {
                     $errors[$k][] = "This file type isn't allowed.";
+                    Logging::write('warn', 'EFORMS_ERR_UPLOAD_TYPE', ['form_id' => $tpl['id'] ?? '', 'field' => $k]);
                     continue;
                 }
                 if ($allowedMime && !in_array($mime, $allowedMime, true)) {
                     $errors[$k][] = "This file type isn't allowed.";
+                    Logging::write('warn', 'EFORMS_ERR_UPLOAD_TYPE', ['form_id' => $tpl['id'] ?? '', 'field' => $k]);
                     continue;
                 }
                 if ($allowedExt && !in_array($ext, $allowedExt, true)) {
                     $errors[$k][] = "This file type isn't allowed.";
+                    Logging::write('warn', 'EFORMS_ERR_UPLOAD_TYPE', ['form_id' => $tpl['id'] ?? '', 'field' => $k]);
                     continue;
                 }
                 if (str_starts_with($mime, 'image/')) {


### PR DESCRIPTION
## Summary
- warn when upload mimetype or extension fails allowed list checks

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68c60e852250832d8f1381cc2fb13a13