### PR TITLE
test: drop FormManager from integration tests

### DIFF
--- a/tests/integration/debug_render.php
+++ b/tests/integration/debug_render.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
 require __DIR__ . '/../bootstrap.php';
-$fm = new EForms\Rendering\FormManager();
-echo $fm->render($argv[1] ?? 'contact_us');
+$renderer = new EForms\Rendering\FormRenderer();
+echo $renderer->render($argv[1] ?? 'contact_us', []);
 

--- a/tests/integration/test_challenge_fail.php
+++ b/tests/integration/test_challenge_fail.php
@@ -25,5 +25,5 @@ $_POST = [
     ],
     'cf-turnstile-response' => 'fail',
 ];
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 $fm->handleSubmit();

--- a/tests/integration/test_challenge_success.php
+++ b/tests/integration/test_challenge_success.php
@@ -25,7 +25,7 @@ $_POST = [
     ],
     'cf-turnstile-response' => 'pass',
 ];
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_cookie_policy_challenge.php
+++ b/tests/integration/test_cookie_policy_challenge.php
@@ -18,7 +18,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_cookie_policy_hard.php
+++ b/tests/integration/test_cookie_policy_hard.php
@@ -18,7 +18,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_dir_protect.php
+++ b/tests/integration/test_dir_protect.php
@@ -30,7 +30,7 @@ register_shutdown_function(function () {
     file_put_contents(__DIR__ . '/../tmp/protect.txt', $ok ? 'OK' : 'FAIL');
 });
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_email_attachment.php
+++ b/tests/integration/test_email_attachment.php
@@ -27,7 +27,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_honeypot.php
+++ b/tests/integration/test_honeypot.php
@@ -20,7 +20,7 @@ $_POST = [
     ],
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_honeypot_hard.php
+++ b/tests/integration/test_honeypot_hard.php
@@ -22,7 +22,7 @@ $_POST = [
     ],
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_honeypot_throttle_first.php
+++ b/tests/integration/test_honeypot_throttle_first.php
@@ -26,7 +26,7 @@ $_POST = [
     ],
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_honeypot_throttle_second.php
+++ b/tests/integration/test_honeypot_throttle_second.php
@@ -26,7 +26,7 @@ $_POST = [
     ],
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_js_hard.php
+++ b/tests/integration/test_js_hard.php
@@ -23,7 +23,7 @@ $_POST = [
     'js_ok' => '0',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_js_soft.php
+++ b/tests/integration/test_js_soft.php
@@ -23,7 +23,7 @@ $_POST = [
     'js_ok' => '0',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_ledger_dup_first.php
+++ b/tests/integration/test_ledger_dup_first.php
@@ -27,6 +27,6 @@ $_POST = [
     ],
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 $fm->handleSubmit();
 

--- a/tests/integration/test_ledger_dup_second.php
+++ b/tests/integration/test_ledger_dup_second.php
@@ -19,7 +19,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 $out = ob_get_clean();

--- a/tests/integration/test_ledger_duplicate.php
+++ b/tests/integration/test_ledger_duplicate.php
@@ -27,7 +27,7 @@ $_POST = [
         'message' => 'Hello',
     ],
 ];
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();
@@ -48,7 +48,7 @@ $_POST = [
         'message' => 'Hello again',
     ],
 ];
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 $out2 = ob_get_clean();

--- a/tests/integration/test_logging.php
+++ b/tests/integration/test_logging.php
@@ -21,7 +21,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_logging_minimal.php
+++ b/tests/integration/test_logging_minimal.php
@@ -24,7 +24,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_minimal_email.php
+++ b/tests/integration/test_minimal_email.php
@@ -19,7 +19,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_origin_hard.php
+++ b/tests/integration/test_origin_hard.php
@@ -22,7 +22,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 $out = ob_get_clean();

--- a/tests/integration/test_origin_soft.php
+++ b/tests/integration/test_origin_soft.php
@@ -27,7 +27,7 @@ $_POST = [
 ];
 
 // Call handler directly (router checks already passed)
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_render_cacheable.php
+++ b/tests/integration/test_render_cacheable.php
@@ -2,5 +2,5 @@
 declare(strict_types=1);
 require __DIR__ . '/../bootstrap.php';
 
-$fm = new \EForms\Rendering\FormManager();
-$fm->render('contact_us', ['cacheable' => true]);
+$renderer = new \EForms\Rendering\FormRenderer();
+echo $renderer->render('contact_us', ['cacheable' => true]);

--- a/tests/integration/test_render_nocache.php
+++ b/tests/integration/test_render_nocache.php
@@ -2,5 +2,5 @@
 declare(strict_types=1);
 require __DIR__ . '/../bootstrap.php';
 
-$fm = new \EForms\Rendering\FormManager();
-$fm->render('contact_us', ['cacheable' => false]);
+$renderer = new \EForms\Rendering\FormRenderer();
+echo $renderer->render('contact_us', ['cacheable' => false]);

--- a/tests/integration/test_success_inline.php
+++ b/tests/integration/test_success_inline.php
@@ -8,8 +8,8 @@ $_COOKIE['eforms_s_contact_us'] = 'contact_us:instOK';
 
 require __DIR__ . '/../bootstrap.php';
 
-$fm = new \EForms\Rendering\FormManager();
-$html = $fm->render('contact_us');
+$renderer = new \EForms\Rendering\FormRenderer();
+$html = $renderer->render('contact_us', []);
 file_put_contents(__DIR__ . '/../tmp/out_success_inline.html', $html);
 
 $_GET = $getSnapshot;

--- a/tests/integration/test_throttle_hard_first.php
+++ b/tests/integration/test_throttle_hard_first.php
@@ -26,7 +26,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_throttle_hard_second.php
+++ b/tests/integration/test_throttle_hard_second.php
@@ -26,5 +26,5 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 $fm->handleSubmit();

--- a/tests/integration/test_throttle_soft_first.php
+++ b/tests/integration/test_throttle_soft_first.php
@@ -26,7 +26,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_throttle_soft_second.php
+++ b/tests/integration/test_throttle_soft_second.php
@@ -26,7 +26,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_timing_expired.php
+++ b/tests/integration/test_timing_expired.php
@@ -20,7 +20,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_timing_min_fill.php
+++ b/tests/integration/test_timing_min_fill.php
@@ -19,7 +19,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_upload_reject.php
+++ b/tests/integration/test_upload_reject.php
@@ -35,5 +35,5 @@ register_shutdown_function(function () {
     });
     file_put_contents(__DIR__ . '/../tmp/uploaded.txt', $files ? implode("\n", $files) : '');
 });
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 $fm->handleSubmit();

--- a/tests/integration/test_upload_valid.php
+++ b/tests/integration/test_upload_valid.php
@@ -31,7 +31,7 @@ register_shutdown_function(function () {
     });
     file_put_contents(__DIR__ . '/../tmp/uploaded.txt', $files[0] ?? '');
 });
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 ob_end_clean();

--- a/tests/integration/test_validation_formats.php
+++ b/tests/integration/test_validation_formats.php
@@ -22,7 +22,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 $out = ob_get_clean();

--- a/tests/integration/test_validation_required.php
+++ b/tests/integration/test_validation_required.php
@@ -20,7 +20,7 @@ $_POST = [
     'js_ok' => '1',
 ];
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 ob_start();
 $fm->handleSubmit();
 $out = ob_get_clean();

--- a/tests/integration/upload_fail_cleanup_runner.php
+++ b/tests/integration/upload_fail_cleanup_runner.php
@@ -44,5 +44,5 @@ register_shutdown_function(function () use ($tmp): void {
     @unlink($tmp);
 });
 
-$fm = new \EForms\Rendering\FormManager();
+$fm = new \EForms\Submission\SubmitHandler();
 $fm->handleSubmit();


### PR DESCRIPTION
## Summary
- replace deprecated EForms\Rendering\FormManager usage in integration tests
- render forms using EForms\Rendering\FormRenderer
- submit forms using EForms\Submission\SubmitHandler

## Testing
- `tests/run.sh` *(fails: template schema parity)*

------
https://chatgpt.com/codex/tasks/task_e_68c61ce4fb38832dac233a7d3ce699cb