### PR TITLE
Clamp config enums

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -59,7 +59,18 @@ class Config
         $sec['submission_token']['required'] = (bool)($sec['submission_token']['required'] ?? true);
 
         // challenge
-        $cfg['challenge']['http_timeout_seconds'] = self::clampInt($cfg['challenge']['http_timeout_seconds'], 1, 5);
+        $ch =& $cfg['challenge'];
+        $ch['mode'] = in_array($ch['mode'], ['off','auto','always'], true) ? $ch['mode'] : $defaults['challenge']['mode'];
+        $ch['provider'] = in_array($ch['provider'], ['turnstile','hcaptcha','recaptcha'], true) ? $ch['provider'] : $defaults['challenge']['provider'];
+        $ch['http_timeout_seconds'] = self::clampInt($ch['http_timeout_seconds'], 1, 5);
+
+        // email
+        $em =& $cfg['email'];
+        $em['policy'] = in_array($em['policy'], ['strict','autocorrect'], true) ? $em['policy'] : $defaults['email']['policy'];
+
+        // privacy
+        $prv =& $cfg['privacy'];
+        $prv['ip_mode'] = in_array($prv['ip_mode'], ['none','masked','hash','full'], true) ? $prv['ip_mode'] : $defaults['privacy']['ip_mode'];
 
         // logging
         $cfg['logging']['mode'] = in_array($cfg['logging']['mode'], ['off','minimal','jsonl'], true) ? $cfg['logging']['mode'] : $defaults['logging']['mode'];

--- a/tests/unit/ConfigClampTest.php
+++ b/tests/unit/ConfigClampTest.php
@@ -138,4 +138,25 @@ final class ConfigClampTest extends BaseTestCase
         $this->assertSame(1, Config::get('validation.max_items_per_multivalue'));
         $this->assertSame(1000000, Config::get('validation.textarea_html_max_bytes'));
     }
+
+    public function testChallengeEmailPrivacyClamp(): void
+    {
+        $this->boot([
+            'challenge' => [
+                'mode' => 'invalid',
+                'provider' => 'nope',
+            ],
+            'email' => [
+                'policy' => 'weird',
+            ],
+            'privacy' => [
+                'ip_mode' => 'bad',
+            ],
+        ]);
+
+        $this->assertSame('off', Config::get('challenge.mode'));
+        $this->assertSame('turnstile', Config::get('challenge.provider'));
+        $this->assertSame('strict', Config::get('email.policy'));
+        $this->assertSame('masked', Config::get('privacy.ip_mode'));
+    }
 }


### PR DESCRIPTION
## Summary
- validate challenge, email, and privacy enums in configuration
- default to safe values when config options are invalid
- test invalid challenge/email/privacy configuration values

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c62bedf914832da576f93bf1c44835