### PR TITLE
Handle arrays for scalar fields

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -266,7 +266,9 @@ class Validator
             } else {
                 $v = $post[$k] ?? '';
                 if (is_array($v)) {
-                    $v = '';
+                    // Preserve arrays for scalar fields so validation can detect invalid input
+                    $values[$k] = $v;
+                    continue;
                 }
                 $sv = function_exists('\\wp_unslash') ? \wp_unslash($v) : stripslashes((string) $v);
                 $sv = self::nfc((string) $sv);
@@ -308,6 +310,11 @@ class Validator
                     }
                 }
                 $canonical[$k] = $clean;
+                continue;
+            }
+            if (is_array($v)) {
+                $errors[$k][] = 'Invalid input.';
+                $canonical[$k] = '';
                 continue;
             }
             if (!empty($f['required']) && $v === '') {

--- a/tests/unit/ValidatorFieldValidationTest.php
+++ b/tests/unit/ValidatorFieldValidationTest.php
@@ -81,4 +81,21 @@ final class ValidatorFieldValidationTest extends BaseTestCase
         Renderer::form($tpl, $meta, [], []);
         $this->assertTrue($called);
     }
+
+    public function testArraySubmissionInvalidForScalarField(): void
+    {
+        $field = [
+            'type' => 'text',
+            'key' => 't',
+            'required' => true,
+            'pattern' => '[A-Z]+',
+        ];
+        $tpl = ['fields' => [$field]];
+        $desc = Validator::descriptors($tpl);
+        $values = Validator::normalize($tpl, ['t' => ['foo']], $desc);
+        $this->assertIsArray($values['t']);
+        $res = Validator::validate($tpl, $desc, $values);
+        $this->assertSame(['Invalid input.'], $res['errors']['t']);
+        $this->assertSame('', $res['values']['t']);
+    }
 }


### PR DESCRIPTION
## Summary
- Preserve array values during normalization of scalar fields
- Report "Invalid input." when a scalar field receives an array and skip other checks
- Add unit test covering array submissions for scalar fields

## Testing
- `./tests/run.sh` *(unit tests pass; integration tests: 41 passed, 1 failed: template schema parity)*
- `./vendor/bin/phpstan analyse --no-progress`


------
https://chatgpt.com/codex/tasks/task_e_68c62d544144832d9d111e9f66293274