### PR TITLE
Load challenge resources when auto or cookie policy requires

### DIFF
--- a/tests/integration/challenge_cookie_policy.php
+++ b/tests/integration/challenge_cookie_policy.php
@@ -18,6 +18,7 @@ $_POST = [
         'message' => 'Ping',
     ],
     'js_ok' => '1',
+    'cf-turnstile-response' => 'dummy',
 ];
 $sh = new \EForms\Submission\SubmitHandler();
 $sh->handleSubmit();

--- a/tests/unit/ChallengeInitTest.php
+++ b/tests/unit/ChallengeInitTest.php
@@ -45,30 +45,34 @@ final class ChallengeInitTest extends BaseTestCase
         $prop->setValue(null, $data);
     }
 
-    public function testChallengeModeAutoDoesNotEnqueueScript(): void
+    public function testChallengeModeAutoEnqueuesScriptAndMarkup(): void
     {
         $this->setConfig('challenge.mode', 'auto');
         $fm = new FormRenderer();
         $GLOBALS['wp_enqueued_scripts'] = [];
-        $fm->render('contact_us');
-        $this->assertNotContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $html = $fm->render('contact_us');
+        $this->assertContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $this->assertStringContainsString('<div class="cf-challenge"', $html);
     }
 
-    public function testPolicyChallengeDoesNotEnqueueScript(): void
+    public function testPolicyChallengeEnqueuesScriptWhenCookieMissing(): void
     {
         $this->setConfig('security.cookie_missing_policy', 'challenge');
+        unset($_COOKIE['eforms_t_contact_us']);
         $fm = new FormRenderer();
         $GLOBALS['wp_enqueued_scripts'] = [];
-        $fm->render('contact_us');
-        $this->assertNotContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $html = $fm->render('contact_us');
+        $this->assertContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $this->assertStringContainsString('<div class="cf-challenge"', $html);
     }
 
-    public function testChallengeModeAlwaysEnqueuesScript(): void
+    public function testChallengeModeAlwaysEnqueuesScriptAndMarkup(): void
     {
         $this->setConfig('challenge.mode', 'always');
         $fm = new FormRenderer();
         $GLOBALS['wp_enqueued_scripts'] = [];
-        $fm->render('contact_us');
+        $html = $fm->render('contact_us');
         $this->assertContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $this->assertStringContainsString('<div class="cf-challenge"', $html);
     }
 }


### PR DESCRIPTION
## Summary
- load challenge resources and metadata whenever challenge mode is not "off" or a missing/invalid token cookie requires it
- ensure server-side re-renders include challenge meta and scripts when challenge is required
- cover first-load cases for challenge mode auto and missing-token cookie policy with unit tests

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c6eda4312c832dad4245c163d4ebc3