### PR TITLE
Load challenge resources when auto or cookie policy requires

### DIFF
--- a/tests/integration/challenge_rerender.php
+++ b/tests/integration/challenge_rerender.php
@@ -3,13 +3,17 @@ declare(strict_types=1);
 require __DIR__ . '/../bootstrap.php';
 set_config([
     'security' => ['cookie_missing_policy' => 'challenge'],
-    'logging' => ['level' => 1],
+    'challenge' => [
+        'mode' => 'off',
+        'provider' => 'turnstile',
+        'turnstile' => ['site_key' => 'site', 'secret_key' => 'secret'],
+    ],
 ]);
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_POST = [
     'form_id' => 'contact_us',
-    'instance_id' => 'instCCHAL1',
+    'instance_id' => 'instRR1',
     'timestamp' => time(),
     'eforms_hp' => '',
     'contact_us' => [
@@ -18,7 +22,10 @@ $_POST = [
         'message' => 'Ping',
     ],
     'js_ok' => '1',
-    'cf-turnstile-response' => 'dummy',
 ];
+// ensure we can inspect scripts after exit
+register_shutdown_function(function () {
+    echo "\nSCRIPTS:" . json_encode($GLOBALS['wp_enqueued_scripts']);
+});
 $sh = new \EForms\Submission\SubmitHandler();
 $sh->handleSubmit();

--- a/tests/unit/ChallengeInitTest.php
+++ b/tests/unit/ChallengeInitTest.php
@@ -45,30 +45,34 @@ final class ChallengeInitTest extends BaseTestCase
         $prop->setValue(null, $data);
     }
 
-    public function testChallengeModeAutoDoesNotEnqueueScript(): void
+    public function testChallengeModeAutoEnqueuesScriptAndMarkup(): void
     {
         $this->setConfig('challenge.mode', 'auto');
         $fm = new FormRenderer();
         $GLOBALS['wp_enqueued_scripts'] = [];
-        $fm->render('contact_us');
-        $this->assertNotContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $html = $fm->render('contact_us');
+        $this->assertContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $this->assertStringContainsString('<div class="cf-challenge"', $html);
     }
 
-    public function testPolicyChallengeDoesNotEnqueueScript(): void
+    public function testPolicyChallengeEnqueuesScriptWhenCookieMissing(): void
     {
         $this->setConfig('security.cookie_missing_policy', 'challenge');
+        unset($_COOKIE['eforms_t_contact_us']);
         $fm = new FormRenderer();
         $GLOBALS['wp_enqueued_scripts'] = [];
-        $fm->render('contact_us');
-        $this->assertNotContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $html = $fm->render('contact_us');
+        $this->assertContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $this->assertStringContainsString('<div class="cf-challenge"', $html);
     }
 
-    public function testChallengeModeAlwaysEnqueuesScript(): void
+    public function testChallengeModeAlwaysEnqueuesScriptAndMarkup(): void
     {
         $this->setConfig('challenge.mode', 'always');
         $fm = new FormRenderer();
         $GLOBALS['wp_enqueued_scripts'] = [];
-        $fm->render('contact_us');
+        $html = $fm->render('contact_us');
         $this->assertContains('eforms-challenge-turnstile', $GLOBALS['wp_enqueued_scripts']);
+        $this->assertStringContainsString('<div class="cf-challenge"', $html);
     }
 }

--- a/tests/unit/ChallengeRerenderTest.php
+++ b/tests/unit/ChallengeRerenderTest.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+final class ChallengeRerenderTest extends \PHPUnit\Framework\TestCase
+{
+    public function testRerenderIncludesChallengeAndScripts(): void
+    {
+        $script = __DIR__ . '/../integration/challenge_rerender.php';
+        $cmd = escapeshellcmd(PHP_BINARY) . ' ' . escapeshellarg($script);
+        $output = shell_exec($cmd);
+        $this->assertIsString($output);
+        $this->assertStringContainsString('<div class="cf-challenge"', $output);
+        $this->assertStringContainsString('SCRIPTS:["eforms-challenge-turnstile"', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- load challenge resources and metadata whenever challenge mode is not "off" or a missing/invalid token cookie requires it
- ensure server-side re-renders include challenge meta and scripts when challenge is required
- cover first-load and re-render cases for challenge mode auto and cookie-missing policy with new integration/unit tests

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c6eda4312c832dad4245c163d4ebc3