### PR TITLE
Reset token on operational error

### DIFF
--- a/tests/integration/test_operational_rerender.php
+++ b/tests/integration/test_operational_rerender.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../bootstrap.php';
+set_config([
+    'security' => ['submission_token' => ['required' => true]],
+]);
+putenv('EFORMS_FORCE_MAIL_FAIL=1');
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$origInstance = 'instOP1';
+$origToken = '00000000-0000-4000-8000-00000000abcd';
+$_POST = [
+    'form_id' => 'contact_us',
+    'instance_id' => $origInstance,
+    'timestamp' => time(),
+    'eforms_hp' => '',
+    'eforms_token' => $origToken,
+    'contact_us' => [
+        'name' => 'Zed',
+        'email' => 'zed@example.com',
+        'message' => 'Ping',
+    ],
+    'js_ok' => '1',
+];
+ob_start();
+register_shutdown_function(function () use ($origInstance, $origToken) {
+    $html = ob_get_clean();
+    $ok = true;
+    if (strpos($html, 'Operational error.') === false) $ok = false;
+    if (strpos($html, 'value="Zed"') === false) $ok = false;
+    if (strpos($html, 'value="zed@example.com"') === false) $ok = false;
+    if (strpos($html, '>Ping<') === false) $ok = false;
+    if (!preg_match('/name="instance_id" value="([^"]+)"/', $html, $m) || $m[1] === $origInstance) $ok = false;
+    if (!preg_match('/name="eforms_token" value="([^"]+)"/', $html, $t) || $t[1] === $origToken) $ok = false;
+    $hash = sha1('contact_us:' . $origToken);
+    $ledger = __DIR__ . '/../tmp/uploads/eforms-private/ledger/' . substr($hash,0,2) . '/' . $hash . '.used';
+    if (!is_file($ledger)) $ok = false;
+    echo $ok ? 'OK' : 'FAIL';
+});
+$sh = new \EForms\Submission\SubmitHandler();
+$sh->handleSubmit();

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -330,6 +330,12 @@ ok=0
 assert_grep tmp/ua.txt '^A{256}$' || ok=1
 record_result "logging: user-agent sanitized" $ok
 
+# 8d) Operational error rerender
+run_test test_operational_rerender
+ok=0
+assert_grep tmp/stdout.txt '^OK$' || ok=1
+record_result "rerender: new token on failure" $ok
+
 # 9) Upload valid
 run_test test_upload_valid
 ok=0


### PR DESCRIPTION
## Summary
- Regenerate instance and submission token when storage or email steps fail after token reservation
- Preserve canonical field values and show operational error on rerender
- Add integration test covering rerender after email failure

## Testing
- `composer install`
- `cd tests && ./run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6f6d31d18832daba96d8b3c90aaef