### PR TITLE
Mirror email length attributes

### DIFF
--- a/src/Spec.php
+++ b/src/Spec.php
@@ -145,7 +145,7 @@ class Spec
                     'type'=>'email',
                     'inputmode'=>'email',
                     'autocomplete'=>'email',
-                    'attrs_mirror'=>[],
+                    'attrs_mirror'=>['maxlength'=>null,'minlength'=>null],
                 ],
                 'constants' => [
                     'spellcheck' => 'false',

--- a/tests/unit/RendererEmailAttrTest.php
+++ b/tests/unit/RendererEmailAttrTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+use EForms\Spec;
+use EForms\Rendering\Renderer;
+
+final class RendererEmailAttrTest extends BaseTestCase
+{
+    public function testLengthAttributesMirrored(): void
+    {
+        $desc = Spec::descriptorFor('email');
+        $this->assertSame('email', $desc['type']);
+
+        $field = [
+            'type' => 'email',
+            'key' => 'foo',
+            'max_length' => 20,
+            'min_length' => 3,
+        ];
+        $ctx = [
+            'id' => 'fid',
+            'nameAttr' => 'form[email]',
+            'labelHtml' => 'Label',
+            'labelAttr' => '',
+            'errAttr' => '',
+            'value' => '',
+            'isMulti' => false,
+            'key' => 'foo',
+            'formId' => 'form',
+            'instanceId' => 'i',
+            'lastText' => 'foo',
+            'fieldErrors' => [],
+            'errId' => 'err',
+            'desc' => $desc,
+            'f' => $field,
+        ];
+        $ref = new \ReflectionClass(Renderer::class);
+        $mi = $ref->getMethod('renderInput');
+        $mi->setAccessible(true);
+        $html = $mi->invoke(null, $ctx);
+
+        $this->assertStringContainsString('maxlength="20"', $html);
+        $this->assertStringContainsString('minlength="3"', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- mirror `max_length` and `min_length` to `maxlength`/`minlength` for email fields
- test renderer reflects email length limits in output

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c6ffb168c0832d8a90087996211d27