### PR TITLE
Add alias mapping for name fields and verify handler parity

### DIFF
--- a/src/Spec.php
+++ b/src/Spec.php
@@ -107,6 +107,7 @@ class Spec
         return [
             'name' => [
                 'type' => 'name',
+                'alias_of' => 'text',
                 'is_multivalue' => false,
                 'html' => ['tag'=>'input','type'=>'text','autocomplete'=>'name'],
                 'constants' => [],
@@ -115,6 +116,7 @@ class Spec
             ],
             'first_name' => [
                 'type' => 'first_name',
+                'alias_of' => 'text',
                 'is_multivalue' => false,
                 'html' => ['tag'=>'input','type'=>'text','autocomplete'=>'given-name'],
                 'constants' => [],
@@ -123,6 +125,7 @@ class Spec
             ],
             'last_name' => [
                 'type' => 'last_name',
+                'alias_of' => 'text',
                 'is_multivalue' => false,
                 'html' => ['tag'=>'input','type'=>'text','autocomplete'=>'family-name'],
                 'constants' => [],

--- a/tests/integration/test_schema_parity.php
+++ b/tests/integration/test_schema_parity.php
@@ -38,12 +38,26 @@ if ($schemaRequired !== ['type']) {
     exit(1);
 }
 
-// Descriptor structural shape
-$expectedKeys = ['constants','handlers','html','is_multivalue','type','validate'];
+// Descriptor structural shape & alias parity
+$baseKeys = ['constants','handlers','html','is_multivalue','type','validate'];
 foreach ($specDescriptors as $t => $desc) {
+    $expected = $baseKeys;
+    if (isset($desc['alias_of'])) {
+        $expected[] = 'alias_of';
+        $target = $desc['alias_of'];
+        if (!isset($specDescriptors[$target])) {
+            fwrite(STDERR, "alias target missing: $t\n");
+            exit(1);
+        }
+        if (($specDescriptors[$target]['handlers'] ?? []) !== ($desc['handlers'] ?? [])) {
+            fwrite(STDERR, "alias handler mismatch: $t\n");
+            exit(1);
+        }
+    }
     $keys = array_keys($desc);
     sort($keys);
-    if ($keys !== $expectedKeys) {
+    sort($expected);
+    if ($keys !== $expected) {
         fwrite(STDERR, "descriptor shape drift: $t\n");
         exit(1);
     }

--- a/tests/unit/DescriptorsResolutionTest.php
+++ b/tests/unit/DescriptorsResolutionTest.php
@@ -39,4 +39,17 @@ final class DescriptorsResolutionTest extends BaseTestCase
         $this->expectExceptionMessage('fields.foo.validator');
         Validator::resolve('unknown', 'fields.foo.validator');
     }
+
+    public function testAliasHandlersMatchTargets(): void
+    {
+        $all = Spec::typeDescriptors();
+        foreach ($all as $desc) {
+            if (!isset($desc['alias_of'])) {
+                continue;
+            }
+            $target = $desc['alias_of'];
+            $this->assertArrayHasKey($target, $all);
+            $this->assertSame($all[$target]['handlers'], $desc['handlers'], $desc['type'] . ' handlers');
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- mark `name`, `first_name`, and `last_name` descriptors as aliases of `text`
- check alias handler parity in CI script
- add PHPUnit test ensuring alias handlers match targets

## Testing
- `vendor/bin/phpunit`
- `php tests/integration/test_schema_parity.php`
- `vendor/bin/phpstan analyse`


------
https://chatgpt.com/codex/tasks/task_e_68c7120a095c832db20b0ba8b8aee492