### PR TITLE
Apply enterkeyhint to last text-like field

### DIFF
--- a/src/Rendering/Renderer.php
+++ b/src/Rendering/Renderer.php
@@ -156,9 +156,23 @@ class Renderer
         }
 
         $lastText = null;
+        $textTypes = [
+            'text',
+            'name',
+            'first_name',
+            'last_name',
+            'email',
+            'tel',
+            'tel_us',
+            'url',
+            'textarea',
+            'textarea_html',
+            'zip',
+            'zip_us',
+        ];
         foreach ($tpl['fields'] as $tf) {
             $tt = $tf['type'];
-            if (in_array($tt, ['textarea','textarea_html','email','name','tel_us','zip_us'], true)) {
+            if (in_array($tt, $textTypes, true)) {
                 $lastText = $tf['key'];
             }
         }

--- a/tests/unit/RendererEnterKeyHintTest.php
+++ b/tests/unit/RendererEnterKeyHintTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+use EForms\Spec;
+use EForms\Rendering\Renderer;
+
+final class RendererEnterKeyHintTest extends BaseTestCase
+{
+    public function testEnterKeyHintAppliedToLastTextTypes(): void
+    {
+        $ctxBase = [
+            'id' => 'fid',
+            'nameAttr' => 'form[foo]',
+            'labelHtml' => 'Label',
+            'labelAttr' => '',
+            'errAttr' => '',
+            'value' => '',
+            'isMulti' => false,
+            'key' => 'foo',
+            'formId' => 'form',
+            'instanceId' => 'i',
+            'lastText' => 'foo',
+            'fieldErrors' => [],
+            'errId' => 'err',
+        ];
+
+        $types = ['text','first_name','last_name','email','tel','tel_us','url','textarea','textarea_html'];
+
+        foreach ($types as $type) {
+            $desc = Spec::descriptorFor($type);
+            $method = $desc['html']['tag'] === 'textarea'
+                ? new \ReflectionMethod(Renderer::class, 'renderTextarea')
+                : new \ReflectionMethod(Renderer::class, 'renderInput');
+            $method->setAccessible(true);
+            $html = $method->invoke(null, array_merge($ctxBase, ['desc' => $desc, 'f' => ['type' => $type, 'key' => 'foo']]));
+            $this->assertStringContainsString('enterkeyhint="send"', $html, $type);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- broaden lastText detection to cover all text-like types
- ensure enterkeyhint="send" is applied to the final text-like control
- add unit test verifying enterkeyhint for text-like types

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse`


------
https://chatgpt.com/codex/tasks/task_e_68c728e149a4832d9dcd1fcbba476e67