### PR TITLE
Preserve submission timestamp on security rerenders

### DIFF
--- a/src/Submission/SubmitHandler.php
+++ b/src/Submission/SubmitHandler.php
@@ -451,7 +451,7 @@ class SubmitHandler
         $meta = [
             'form_id' => $formId,
             'instance_id' => $_POST['instance_id'] ?? Helpers::random_id(16),
-            'timestamp' => time(),
+            'timestamp' => isset($_POST['timestamp']) ? (int) $_POST['timestamp'] : time(),
             'cacheable' => true,
             'client_validation' => (bool) Config::get('html5.client_validation', false),
             'action' => \home_url('/eforms/submit'),

--- a/tests/integration/test_challenge_fail.php
+++ b/tests/integration/test_challenge_fail.php
@@ -12,10 +12,11 @@ set_config([
 ]);
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$origTs = time() - 5;
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => 'instCHFAIL',
-    'timestamp' => time() - 5,
+    'timestamp' => $origTs,
     'eforms_hp' => '',
     'js_ok' => '1',
     'contact_us' => [
@@ -25,5 +26,13 @@ $_POST = [
     ],
     'cf-turnstile-response' => 'fail',
 ];
+ob_start();
+register_shutdown_function(function () use ($origTs) {
+    $html = ob_get_clean();
+    $ok = true;
+    if (strpos($html, 'Security challenge failed.') === false) $ok = false;
+    if (!preg_match('/name="timestamp" value="([^\"]+)"/', $html, $m) || (int)$m[1] !== $origTs) $ok = false;
+    echo $ok ? 'OK' : 'FAIL';
+});
 $fm = new \EForms\Submission\SubmitHandler();
 $fm->handleSubmit();

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -178,7 +178,7 @@ record_result "challenge success clears soft signal" $ok
 
 run_test test_challenge_fail
 ok=0
-assert_grep tmp/stdout.txt 'Security challenge failed\.' || ok=1
+assert_grep tmp/stdout.txt '^OK$' || ok=1
 assert_grep tmp/uploads/eforms-private/eforms.log 'EFORMS_ERR_CHALLENGE_FAILED' || ok=1
 ! assert_grep tmp/mail.json 'zed@example.com' || ok=1
 record_result "challenge failure logged" $ok


### PR DESCRIPTION
## Summary
- keep original timestamp when rerendering forms after security errors
- assert timestamp is preserved on challenge failures

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c72e5bb6b8832d884a97951644e420