### PR TITLE
Replace autoloader with explicit bootstrap requires

### DIFF
--- a/eforms.php
+++ b/eforms.php
@@ -48,15 +48,21 @@ namespace {
         return;
     }
 
-    spl_autoload_register(function (string $class): void {
-        if (strpos($class, 'EForms\\') !== 0) {
-            return;
-        }
-        $path = __DIR__ . '/src/' . str_replace('\\', '/', substr($class, 7)) . '.php';
-        if (is_file($path)) {
-            require $path;
-        }
-    });
+    require_once __DIR__ . '/src/Config.php';
+    require_once __DIR__ . '/src/Helpers.php';
+    require_once __DIR__ . '/src/Logging.php';
+    require_once __DIR__ . '/src/Spec.php';
+    require_once __DIR__ . '/src/Rendering/Renderer.php';
+    require_once __DIR__ . '/src/Validation/Normalizer.php';
+    require_once __DIR__ . '/src/Validation/Validator.php';
+    require_once __DIR__ . '/src/Validation/TemplateValidator.php';
+    require_once __DIR__ . '/src/Security/Security.php';
+    require_once __DIR__ . '/src/Security/Throttle.php';
+    require_once __DIR__ . '/src/Security/Challenge.php';
+    require_once __DIR__ . '/src/Uploads/Uploads.php';
+    require_once __DIR__ . '/src/Email/Emailer.php';
+    require_once __DIR__ . '/src/Rendering/FormRenderer.php';
+    require_once __DIR__ . '/src/Submission/SubmitHandler.php';
 
     Config::bootstrap();
 


### PR DESCRIPTION
## Summary
- Remove `spl_autoload_register` from plugin bootstrap
- Manually include required classes from `src/` with explicit `require_once`
- Ensure classes load in dependency order for form rendering and submission

## Testing
- `composer install`
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c73cb17c8c832d8c8187a389ecb6ce