### PR TITLE
Use PHP error_log for minimal logging mode

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -318,12 +318,12 @@ assert_grep tmp/uploads/eforms-private/eforms.log '"severity":"error"' || ok=1
 assert_grep tmp/uploads/eforms-private/eforms.log '"code":"EFORMS_EMAIL_FAIL"' || ok=1
 record_result "logging: SMTP failure" $ok
 
-# 8b) Logging minimal file output
+# 8b) Logging minimal error_log output
 run_test test_logging_minimal
 ok=0
-assert_grep tmp/uploads/eforms-private/eforms.log 'severity=error' || ok=1
-assert_grep tmp/uploads/eforms-private/eforms.log 'code=EFORMS_EMAIL_FAIL' || ok=1
-record_result "logging: minimal file output" $ok
+assert_grep tmp/php_error.log 'severity=error' || ok=1
+assert_grep tmp/php_error.log 'code=EFORMS_EMAIL_FAIL' || ok=1
+record_result "logging: minimal error_log output" $ok
 
 # 8c) Logging User-Agent sanitization
 run_test test_logging_user_agent


### PR DESCRIPTION
## Summary
- Send compact minimal logs to PHP's `error_log` and skip file initialization/rotation
- Preserve JSONL logging with file rotation and initialize only in that mode
- Update tests to validate minimal logging via server error log

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c7414b7b38832db66cc09c0831a2c7