### PR TITLE
Ignore size on non-text form controls

### DIFF
--- a/src/Rendering/Renderer.php
+++ b/src/Rendering/Renderer.php
@@ -287,7 +287,10 @@ class Renderer
         if (!empty($f['required'])) $attrs .= ' required';
         if (!empty($f['placeholder'])) $attrs .= ' placeholder="' . \esc_attr($f['placeholder']) . '"';
         if (!empty($f['autocomplete'])) $attrs .= ' autocomplete="' . \esc_attr($f['autocomplete']) . '"';
-        if (isset($f['size'])) $attrs .= ' size="' . (int)$f['size'] . '"';
+        $sizeTypes = ['text','email','url','tel','tel_us','number','range','date'];
+        if (isset($f['size']) && in_array($f['type'] ?? '', $sizeTypes, true)) {
+            $attrs .= ' size="' . (int)$f['size'] . '"';
+        }
         $extraHint = ($key === $lastText && ($desc['html']['type'] ?? '') !== 'file') ? ' enterkeyhint="send"' : '';
         $attrs .= $errAttr . $extraHint;
         $html = '<label for="' . \esc_attr($id) . '"' . $labelAttr . '>' . $labelHtml . '</label>';
@@ -335,7 +338,6 @@ class Renderer
         $attrs = self::controlAttrs($desc, $f);
         if (!empty($f['required'])) $attrs .= ' required';
         if (!empty($f['autocomplete'])) $attrs .= ' autocomplete="' . \esc_attr($f['autocomplete']) . '"';
-        if (!empty($f['size'])) $attrs .= ' size="' . (int)$f['size'] . '"';
         $vals = $isMulti ? (array)$value : (string)$value;
         $html = '<label for="' . \esc_attr($id) . '"' . $labelAttr . '>' . $labelHtml . '</label>';
         $html .= '<select id="' . \esc_attr($id) . '" name="' . \esc_attr($nameAttr) . '"' . $attrs . $errAttr . '>';

--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -321,7 +321,7 @@ class TemplateValidator
             }
 
             if (isset($f['size'])) {
-                $allowedSizeTypes = ['name','text','email','url','tel','tel_us','number','date','textarea','textarea_html'];
+                $allowedSizeTypes = ['text','email','url','tel','tel_us','number','range','date'];
                 if (!in_array($type, $allowedSizeTypes, true)) {
                     $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>$path.'size'];
                     unset($f['size']);

--- a/tests/unit/RendererSizeAttrTest.php
+++ b/tests/unit/RendererSizeAttrTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+use EForms\Spec;
+use EForms\Rendering\Renderer;
+
+final class RendererSizeAttrTest extends BaseTestCase
+{
+    public function testTextInputRendersSize(): void
+    {
+        $desc = Spec::descriptorFor('text');
+        $field = ['type' => 'text', 'key' => 'foo', 'size' => 12];
+        $ctx = [
+            'desc' => $desc,
+            'f' => $field,
+            'id' => 'fid',
+            'nameAttr' => 'form[foo]',
+            'labelHtml' => 'Label',
+            'labelAttr' => '',
+            'errAttr' => '',
+            'value' => '',
+            'key' => 'foo',
+            'lastText' => 'foo',
+        ];
+        $ref = new \ReflectionClass(Renderer::class);
+        $method = $ref->getMethod('renderInput');
+        $method->setAccessible(true);
+        $html = $method->invoke(null, $ctx);
+        $this->assertStringContainsString('size="12"', $html);
+    }
+
+    public function testTextareaIgnoresSize(): void
+    {
+        $desc = Spec::descriptorFor('textarea');
+        $field = ['type' => 'textarea', 'key' => 'foo', 'size' => 12];
+        $ctx = [
+            'desc' => $desc,
+            'f' => $field,
+            'id' => 'tid',
+            'nameAttr' => 'form[foo]',
+            'labelHtml' => 'Label',
+            'labelAttr' => '',
+            'errAttr' => '',
+            'value' => '',
+            'key' => 'foo',
+            'lastText' => 'foo',
+        ];
+        $ref = new \ReflectionClass(Renderer::class);
+        $method = $ref->getMethod('renderTextarea');
+        $method->setAccessible(true);
+        $html = $method->invoke(null, $ctx);
+        $this->assertStringNotContainsString('size=', $html);
+    }
+
+    public function testSelectIgnoresSize(): void
+    {
+        $desc = Spec::descriptorFor('select');
+        $field = [
+            'type' => 'select',
+            'key' => 'foo',
+            'size' => 5,
+            'options' => [
+                ['key' => 'a', 'label' => 'A'],
+            ],
+        ];
+        $ctx = [
+            'desc' => $desc,
+            'f' => $field,
+            'id' => 'sid',
+            'nameAttr' => 'form[foo]',
+            'labelHtml' => 'Label',
+            'labelAttr' => '',
+            'errAttr' => '',
+            'value' => '',
+            'isMulti' => false,
+        ];
+        $ref = new \ReflectionClass(Renderer::class);
+        $method = $ref->getMethod('renderSelect');
+        $method->setAccessible(true);
+        $html = $method->invoke(null, $ctx);
+        $this->assertStringNotContainsString('size=', $html);
+    }
+}

--- a/tests/unit/TemplateValidatorTest.php
+++ b/tests/unit/TemplateValidatorTest.php
@@ -316,27 +316,41 @@ class TemplateValidatorTest extends BaseTestCase
     public function testSizeValidation(): void
     {
         $tpl = $this->baseTpl();
-        $tpl['fields'][0]['size'] = 'big';
+        $tpl['fields'][1]['size'] = 'big';
         $res = TemplateValidator::preflight($tpl);
         $codes = array_column($res['errors'], 'code');
         $paths = array_column($res['errors'], 'path');
         $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_TYPE, $codes);
-        $this->assertContains('fields[0].size', $paths);
+        $this->assertContains('fields[1].size', $paths);
 
         $tpl = $this->baseTpl();
-        $tpl['fields'][0]['size'] = 0;
+        $tpl['fields'][1]['size'] = 0;
         $res = TemplateValidator::preflight($tpl);
         $codes = array_column($res['errors'], 'code');
         $paths = array_column($res['errors'], 'path');
         $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_ENUM, $codes);
-        $this->assertContains('fields[0].size', $paths);
-        $this->assertNull($res['context']['fields'][0]['size']);
+        $this->assertContains('fields[1].size', $paths);
+        $this->assertNull($res['context']['fields'][1]['size']);
+
+        $tpl = $this->baseTpl();
+        $tpl['fields'][1]['size'] = 20;
+        $res = TemplateValidator::preflight($tpl);
+        $paths = array_column($res['errors'], 'path');
+        $this->assertNotContains('fields[1].size', $paths);
+        $this->assertSame(20, $res['context']['fields'][1]['size']);
     }
 
     public function testSizeDisallowedOnNonTextFields(): void
     {
         $tpl = $this->baseTpl();
-        $tpl['fields'][] = ['type' => 'range', 'key' => 'rng', 'size' => 10];
+        $tpl['fields'][] = [
+            'type' => 'select',
+            'key' => 'sel',
+            'size' => 10,
+            'options' => [
+                ['key' => 'a', 'label' => 'A'],
+            ],
+        ];
         $res = TemplateValidator::preflight($tpl);
         $codes = array_column($res['errors'], 'code');
         $paths = array_column($res['errors'], 'path');


### PR DESCRIPTION
## Summary
- Drop `size` normalization for non-text field types
- Only render `size` attribute for text-like inputs; never for selects or textareas
- Add tests covering valid text `size` and ignoring on non-text controls

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68c7738eeb58832daf46c40a90e8f911