### PR TITLE
Allow size attribute for text-like inputs

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -102,10 +102,10 @@ electronic_forms - Spec
 5. TEMPLATE MODEL
   1. Field Generation and Namespacing
     - Template field keys may include:
-      - key (slug), type, label?, placeholder?, required (bool), size (1-100; text-like only), autocomplete?, options (for radios/checkboxes/select), class?, max_length?, min?, max?, step?, pattern?, before_html?, after_html?
+      - key (slug), type, label?, placeholder?, required (bool), size (1-100; text-like only: text, search, tel, url, email, password), autocomplete?, options (for radios/checkboxes/select), class?, max_length?, min?, max?, step?, pattern?, before_html?, after_html?
     - key (slug): required; must match ^[a-z0-9_:-]{1,64}$ (lowercase); [] prohibited to prevent PHP array collisions; reserved keys remain disallowed.
     - autocomplete: exactly one token. "on"/"off" accepted; else must match WHATWG tokens (name, given-name, family-name, email, tel, postal-code, street-address, address-line1, address-line2, organization, …). Invalid tokens are dropped.
-    - size: 1-100; ignored for non-text types.
+    - size: 1-100; honored only for text-like controls (text, search, tel, url, email, password).
     - Hidden per-instance fields (renderer adds): form_id, instance_id, eforms_hp (POST name fixed; randomized id only), timestamp (used for UI/logs and as a best-effort age signal in hidden-token mode; see 7.3), js_ok; and when cacheable="false" also <input type="hidden" name="eforms_token" value="<UUIDv4>"> (see 7.1). When cacheable="true" no hidden token is rendered (cookie-only). timestamp is set on first render of the instance and preserved across validation re-renders; on error re-render, reuse the posted timestamp.
     - Form tag classes: <form class="eforms-form eforms-form-{form_id}"> (template id slug)
     - Renderer-generated attributes:

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -77,7 +77,7 @@
         {
           "if": {
             "properties": {
-              "type": {"enum": ["name","text","email","url","tel","tel_us","number","date","textarea","textarea_html"]}
+              "type": {"enum": ["text","email","url","tel","tel_us"]}
             },
             "required": ["type"]
           },

--- a/src/Rendering/Renderer.php
+++ b/src/Rendering/Renderer.php
@@ -287,7 +287,7 @@ class Renderer
         if (!empty($f['required'])) $attrs .= ' required';
         if (!empty($f['placeholder'])) $attrs .= ' placeholder="' . \esc_attr($f['placeholder']) . '"';
         if (!empty($f['autocomplete'])) $attrs .= ' autocomplete="' . \esc_attr($f['autocomplete']) . '"';
-        $sizeTypes = ['text','email','url','tel','tel_us','number','range','date'];
+        $sizeTypes = ['text','search','tel','tel_us','url','email','password'];
         if (isset($f['size']) && in_array($f['type'] ?? '', $sizeTypes, true)) {
             $attrs .= ' size="' . (int)$f['size'] . '"';
         }

--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -321,7 +321,7 @@ class TemplateValidator
             }
 
             if (isset($f['size'])) {
-                $allowedSizeTypes = ['text','email','url','tel','tel_us','number','range','date'];
+                $allowedSizeTypes = ['text','search','tel','tel_us','url','email','password'];
                 if (!in_array($type, $allowedSizeTypes, true)) {
                     $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>$path.'size'];
                     unset($f['size']);

--- a/tests/unit/RendererSizeAttrTest.php
+++ b/tests/unit/RendererSizeAttrTest.php
@@ -80,4 +80,27 @@ final class RendererSizeAttrTest extends BaseTestCase
         $html = $method->invoke(null, $ctx);
         $this->assertStringNotContainsString('size=', $html);
     }
+
+    public function testNumberInputIgnoresSize(): void
+    {
+        $desc = Spec::descriptorFor('number');
+        $field = ['type' => 'number', 'key' => 'foo', 'size' => 12];
+        $ctx = [
+            'desc' => $desc,
+            'f' => $field,
+            'id' => 'nid',
+            'nameAttr' => 'form[foo]',
+            'labelHtml' => 'Label',
+            'labelAttr' => '',
+            'errAttr' => '',
+            'value' => '',
+            'key' => 'foo',
+            'lastText' => 'foo',
+        ];
+        $ref = new \ReflectionClass(Renderer::class);
+        $method = $ref->getMethod('renderInput');
+        $method->setAccessible(true);
+        $html = $method->invoke(null, $ctx);
+        $this->assertStringNotContainsString('size=', $html);
+    }
 }

--- a/tests/unit/TemplateValidatorTest.php
+++ b/tests/unit/TemplateValidatorTest.php
@@ -344,12 +344,9 @@ class TemplateValidatorTest extends BaseTestCase
     {
         $tpl = $this->baseTpl();
         $tpl['fields'][] = [
-            'type' => 'select',
-            'key' => 'sel',
+            'type' => 'number',
+            'key' => 'qty',
             'size' => 10,
-            'options' => [
-                ['key' => 'a', 'label' => 'A'],
-            ],
         ];
         $res = TemplateValidator::preflight($tpl);
         $codes = array_column($res['errors'], 'code');


### PR DESCRIPTION
## Summary
- Only honor `size` on text-like controls: text, search, tel, url, email, password
- Document size usage for text-like controls
- Add tests ensuring non-text inputs ignore `size`

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c77a679974832da422531391b68c04