### PR TITLE
Load optional security modules only when needed

### DIFF
--- a/eforms.php
+++ b/eforms.php
@@ -58,8 +58,6 @@ namespace {
     require_once __DIR__ . '/src/Validation/Validator.php';
     require_once __DIR__ . '/src/Validation/TemplateValidator.php';
     require_once __DIR__ . '/src/Security/Security.php';
-    require_once __DIR__ . '/src/Security/Throttle.php';
-    require_once __DIR__ . '/src/Security/Challenge.php';
     require_once __DIR__ . '/src/Uploads/Uploads.php';
     require_once __DIR__ . '/src/Email/Emailer.php';
     require_once __DIR__ . '/src/Rendering/FormRenderer.php';

--- a/src/Rendering/FormRenderer.php
+++ b/src/Rendering/FormRenderer.php
@@ -36,6 +36,7 @@ class FormRenderer
             Uploads::gc();
         }
         if (Config::get('throttle.enable', false)) {
+            require_once __DIR__ . '/../Security/Throttle.php';
             Throttle::gc();
         }
         $cacheable = (bool) ($opts['cacheable'] ?? true);
@@ -69,6 +70,7 @@ class FormRenderer
             }
         }
         if ($needChallenge) {
+            require_once __DIR__ . '/../Security/Challenge.php';
             $prov = Config::get('challenge.provider', 'turnstile');
             $site = Config::get('challenge.' . $prov . '.site_key', '');
             $meta['challenge'] = ['provider' => $prov, 'site_key' => $site];

--- a/src/Submission/SubmitHandler.php
+++ b/src/Submission/SubmitHandler.php
@@ -55,6 +55,7 @@ class SubmitHandler
             Uploads::gc();
         }
         if (Config::get('throttle.enable', false)) {
+            require_once __DIR__ . '/../Security/Throttle.php';
             Throttle::gc();
         }
         // security gates
@@ -100,6 +101,7 @@ class SubmitHandler
             $requireChallenge = true;
         }
         if ($requireChallenge) {
+            require_once __DIR__ . '/../Security/Challenge.php';
             $provider = Config::get('challenge.provider', 'turnstile');
             $resp = $_POST['cf-turnstile-response'] ?? ($_POST['h-captcha-response'] ?? ($_POST['g-recaptcha-response'] ?? ''));
             if ($resp === '') {

--- a/tests/unit/ThrottleTest.php
+++ b/tests/unit/ThrottleTest.php
@@ -5,6 +5,8 @@ use EForms\Config;
 use EForms\Helpers;
 use EForms\Security\Throttle;
 
+require_once __DIR__ . '/../../src/Security/Throttle.php';
+
 final class ThrottleTest extends BaseTestCase
 {
     public function testKeyFromIpModes(): void


### PR DESCRIPTION
## Summary
- Load throttle and challenge modules only when the corresponding features are enabled
- Avoid registering challenge assets when unused
- Update throttle unit test to require module directly

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c77f8ac088832d817b3551c3de1cc5