### PR TITLE
Refactor cross-field rules to drop 'other' field

### DIFF
--- a/bin/build-template-schema.php
+++ b/bin/build-template-schema.php
@@ -138,9 +138,9 @@ $schema = [
             'additionalProperties' => false,
             'properties' => [
                 'rule' => ['enum' => TemplateSpec::ruleTypes()],
+                'target' => ['type' => 'string'],
                 'field' => ['type' => 'string'],
                 'fields' => ['type' => 'array', 'items' => ['type' => 'string']],
-                'other' => ['type' => 'string'],
                 'equals' => ['type' => 'string'],
                 'equals_any' => ['type' => 'array', 'items' => ['type' => 'string']],
             ],

--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -361,10 +361,10 @@ electronic_forms - Spec
 
 10. CROSS-FIELD RULES (BOUNDED SET)
   - Supported:
-    - required_if: { "rule":"required_if", "field":"other", "equals":"value" }
-    - required_if_any: { "rule":"required_if_any", "fields":[...], "equals_any":[...] }
-    - required_unless: { "rule":"required_unless", "field":"other", "equals":"value" }
-    - matches: { "rule":"matches", "field":"other" }
+    - required_if: { "rule":"required_if", "target":"field", "field":"other", "equals":"value" }
+    - required_if_any: { "rule":"required_if_any", "target":"field", "fields":[...], "equals_any":[...] }
+    - required_unless: { "rule":"required_unless", "target":"field", "field":"other", "equals":"value" }
+    - matches: { "rule":"matches", "target":"field", "field":"other" }
     - one_of: { "rule":"one_of", "fields":["a","b","c"] }
     - mutually_exclusive: { "rule":"mutually_exclusive", "fields":["a","b"] }
   - Deterministic evaluation order: top-to-bottom

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -359,6 +359,9 @@
                         "mutually_exclusive"
                     ]
                 },
+                "target": {
+                    "type": "string"
+                },
                 "field": {
                     "type": "string"
                 },
@@ -367,9 +370,6 @@
                     "items": {
                         "type": "string"
                     }
-                },
-                "other": {
-                    "type": "string"
                 },
                 "equals": {
                     "type": "string"

--- a/src/TemplateSpec.php
+++ b/src/TemplateSpec.php
@@ -65,20 +65,20 @@ class TemplateSpec
 
     private const RULES = [
         'required_if' => [
-            'allowed' => ['rule','field','other','equals'],
-            'required' => ['field','other','equals'],
+            'allowed' => ['rule','target','field','equals'],
+            'required' => ['target','field','equals'],
         ],
         'required_if_any' => [
-            'allowed' => ['rule','field','fields','equals_any'],
-            'required' => ['field','fields','equals_any'],
+            'allowed' => ['rule','target','fields','equals_any'],
+            'required' => ['target','fields','equals_any'],
         ],
         'required_unless' => [
-            'allowed' => ['rule','field','other','equals'],
-            'required' => ['field','other','equals'],
+            'allowed' => ['rule','target','field','equals'],
+            'required' => ['target','field','equals'],
         ],
         'matches' => [
-            'allowed' => ['rule','field','other'],
-            'required' => ['field','other'],
+            'allowed' => ['rule','target','field'],
+            'required' => ['target','field'],
         ],
         'one_of' => [
             'allowed' => ['rule','fields'],

--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -431,15 +431,15 @@ class TemplateValidator
             self::checkUnknown($rule, $ruleSpec['allowed'], $rpath, $errors);
             switch ($type) {
                 case 'required_if':
+                    if (!isset($rule['target'])) {
+                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'target'];
+                    } elseif (!is_string($rule['target'])) {
+                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$rpath.'target'];
+                    }
                     if (!isset($rule['field'])) {
                         $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'field'];
                     } elseif (!is_string($rule['field'])) {
                         $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$rpath.'field'];
-                    }
-                    if (!isset($rule['other'])) {
-                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'other'];
-                    } elseif (!is_string($rule['other'])) {
-                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$rpath.'other'];
                     }
                     if (!array_key_exists('equals', $rule)) {
                         $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'equals'];
@@ -448,10 +448,10 @@ class TemplateValidator
                     }
                     break;
                 case 'required_if_any':
-                    if (!isset($rule['field'])) {
-                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'field'];
-                    } elseif (!is_string($rule['field'])) {
-                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$rpath.'field'];
+                    if (!isset($rule['target'])) {
+                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'target'];
+                    } elseif (!is_string($rule['target'])) {
+                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$rpath.'target'];
                     }
                     if (!isset($rule['fields'])) {
                         $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'fields'];
@@ -465,15 +465,15 @@ class TemplateValidator
                     }
                     break;
                 case 'required_unless':
+                    if (!isset($rule['target'])) {
+                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'target'];
+                    } elseif (!is_string($rule['target'])) {
+                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$rpath.'target'];
+                    }
                     if (!isset($rule['field'])) {
                         $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'field'];
                     } elseif (!is_string($rule['field'])) {
                         $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$rpath.'field'];
-                    }
-                    if (!isset($rule['other'])) {
-                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'other'];
-                    } elseif (!is_string($rule['other'])) {
-                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$rpath.'other'];
                     }
                     if (!array_key_exists('equals', $rule)) {
                         $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'equals'];
@@ -482,15 +482,15 @@ class TemplateValidator
                     }
                     break;
                 case 'matches':
+                    if (!isset($rule['target'])) {
+                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'target'];
+                    } elseif (!is_string($rule['target'])) {
+                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$rpath.'target'];
+                    }
                     if (!isset($rule['field'])) {
                         $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'field'];
                     } elseif (!is_string($rule['field'])) {
                         $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$rpath.'field'];
-                    }
-                    if (!isset($rule['other'])) {
-                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_REQUIRED,'path'=>$rpath.'other'];
-                    } elseif (!is_string($rule['other'])) {
-                        $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$rpath.'other'];
                     }
                     break;
                 case 'one_of':

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -367,15 +367,15 @@ class Validator
             $type = $rule['rule'] ?? '';
             switch ($type) {
                 case 'required_if':
+                    $target = $rule['target'] ?? '';
                     $field = $rule['field'] ?? '';
-                    $other = $rule['other'] ?? '';
                     $equals = (string)($rule['equals'] ?? '');
-                    if ((string)($values[$other] ?? '') === $equals && self::isEmpty($values[$field] ?? null)) {
-                        $errors[$field][] = 'This field is required.';
+                    if ((string)($values[$field] ?? '') === $equals && self::isEmpty($values[$target] ?? null)) {
+                        $errors[$target][] = 'This field is required.';
                     }
                     break;
                 case 'required_if_any':
-                    $field = $rule['field'] ?? '';
+                    $target = $rule['target'] ?? '';
                     $fields = $rule['fields'] ?? [];
                     $equalsAny = $rule['equals_any'] ?? [];
                     $trigger = false;
@@ -383,23 +383,23 @@ class Validator
                         $val = (string)($values[$f] ?? '');
                         if (in_array($val, array_map('strval', $equalsAny), true)) { $trigger = true; break; }
                     }
-                    if ($trigger && self::isEmpty($values[$field] ?? null)) {
-                        $errors[$field][] = 'This field is required.';
+                    if ($trigger && self::isEmpty($values[$target] ?? null)) {
+                        $errors[$target][] = 'This field is required.';
                     }
                     break;
                 case 'required_unless':
+                    $target = $rule['target'] ?? '';
                     $field = $rule['field'] ?? '';
-                    $other = $rule['other'] ?? '';
                     $equals = (string)($rule['equals'] ?? '');
-                    if ((string)($values[$other] ?? '') !== $equals && self::isEmpty($values[$field] ?? null)) {
-                        $errors[$field][] = 'This field is required.';
+                    if ((string)($values[$field] ?? '') !== $equals && self::isEmpty($values[$target] ?? null)) {
+                        $errors[$target][] = 'This field is required.';
                     }
                     break;
                 case 'matches':
+                    $target = $rule['target'] ?? '';
                     $field = $rule['field'] ?? '';
-                    $other = $rule['other'] ?? '';
-                    if (($values[$field] ?? null) !== ($values[$other] ?? null)) {
-                        $errors[$field][] = 'Fields must match.';
+                    if (($values[$target] ?? null) !== ($values[$field] ?? null)) {
+                        $errors[$target][] = 'Fields must match.';
                     }
                     break;
                 case 'one_of':

--- a/tests/unit/RulesTest.php
+++ b/tests/unit/RulesTest.php
@@ -19,7 +19,7 @@ class RulesTest extends BaseTestCase
                 ['type'=>'text','key'=>'b'],
             ],
             'rules' => [
-                ['rule'=>'required_if','field'=>'a','other'=>'b','equals'=>'x']
+                ['rule'=>'required_if','target'=>'a','field'=>'b','equals'=>'x']
             ],
         ];
         $errors = $this->runRules($tpl, ['b'=>'x']);
@@ -35,7 +35,7 @@ class RulesTest extends BaseTestCase
                 ['type'=>'text','key'=>'c'],
             ],
             'rules' => [
-                ['rule'=>'required_if_any','field'=>'a','fields'=>['b','c'],'equals_any'=>['yes','y']]
+                ['rule'=>'required_if_any','target'=>'a','fields'=>['b','c'],'equals_any'=>['yes','y']]
             ],
         ];
         $errors = $this->runRules($tpl, ['b'=>'y']);
@@ -50,7 +50,7 @@ class RulesTest extends BaseTestCase
                 ['type'=>'text','key'=>'b'],
             ],
             'rules' => [
-                ['rule'=>'required_unless','field'=>'a','other'=>'b','equals'=>'skip']
+                ['rule'=>'required_unless','target'=>'a','field'=>'b','equals'=>'skip']
             ],
         ];
         $errors = $this->runRules($tpl, ['b'=>'no']);
@@ -65,7 +65,7 @@ class RulesTest extends BaseTestCase
                 ['type'=>'text','key'=>'b'],
             ],
             'rules' => [
-                ['rule'=>'matches','field'=>'a','other'=>'b']
+                ['rule'=>'matches','target'=>'a','field'=>'b']
             ],
         ];
         $errors = $this->runRules($tpl, ['a'=>'one','b'=>'two']);

--- a/tests/unit/TemplateValidatorTest.php
+++ b/tests/unit/TemplateValidatorTest.php
@@ -236,20 +236,20 @@ class TemplateValidatorTest extends BaseTestCase
     {
         $tpl = $this->baseTpl();
         $tpl['rules'] = [
-            ['rule' => 'matches', 'field' => 'name'],
+            ['rule' => 'matches', 'target' => 'name'],
         ];
         $res = TemplateValidator::preflight($tpl);
         $codes = array_column($res['errors'], 'code');
         $paths = array_column($res['errors'], 'path');
         $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_REQUIRED, $codes);
-        $this->assertContains('rules[0].other', $paths);
+        $this->assertContains('rules[0].field', $paths);
     }
 
     public function testRuleUnknownKey(): void
     {
         $tpl = $this->baseTpl();
         $tpl['rules'] = [
-            ['rule' => 'matches', 'field' => 'name', 'other' => 'email', 'bogus' => 1],
+            ['rule' => 'matches', 'target' => 'name', 'field' => 'email', 'bogus' => 1],
         ];
         $res = TemplateValidator::preflight($tpl);
         $codes = array_column($res['errors'], 'code');


### PR DESCRIPTION
## Summary
- use `target` and `field` properties for cross-field rule schema
- update validators and documentation to match new schema
- adjust tests and regenerate template schema

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c78dcc2164832d9bc8e312a7fe0055