### PR TITLE
Truncate class tokens before validation

### DIFF
--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -555,6 +555,9 @@ class TemplateValidator
         $keep = [];
         foreach ($tokens as $t) {
             if ($t === '') continue;
+            if (strlen($t) > 32) {
+                $t = substr($t, 0, 32);
+            }
             if (!preg_match('/^[A-Za-z0-9_-]{1,32}$/', $t)) continue;
             if (!in_array($t, $keep, true)) $keep[] = $t;
         }

--- a/tests/unit/TemplateValidatorTest.php
+++ b/tests/unit/TemplateValidatorTest.php
@@ -520,4 +520,18 @@ class TemplateValidatorTest extends BaseTestCase
         $this->assertSame('123', $res['context']['version']);
         unlink($tmp);
     }
+
+    public function testClassTokenTruncateAndDedup(): void
+    {
+        $tpl = $this->baseTpl();
+        $longA1 = str_repeat('a', 40);
+        $longA2 = str_repeat('a', 35);
+        $longB = str_repeat('b', 33);
+        $tpl['fields'][0]['class'] = $longA1 . ' ' . $longA2 . ' ' . $longB;
+        $res = TemplateValidator::preflight($tpl);
+        $this->assertTrue($res['ok']);
+        $field = $res['context']['fields'][0] ?? [];
+        $expected = str_repeat('a', 32) . ' ' . str_repeat('b', 32);
+        $this->assertSame($expected, $field['class']);
+    }
 }


### PR DESCRIPTION
## Summary
- truncate CSS class tokens to 32 chars before validation
- ensure deduplication happens after truncation
- add regression test for class token truncation

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68c82092ede0832da7dae7a8541c2984