### PR TITLE
Add error code for unsupported field types

### DIFF
--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -26,6 +26,7 @@ class TemplateValidator
     public const EFORMS_ERR_FRAGMENT_UNBALANCED  = 'EFORMS_ERR_FRAGMENT_UNBALANCED';
     public const EFORMS_ERR_FRAGMENT_ROW_TAG     = 'EFORMS_ERR_FRAGMENT_ROW_TAG';
     public const EFORMS_ERR_FRAGMENT_STYLE_ATTR  = 'EFORMS_ERR_FRAGMENT_STYLE_ATTR';
+    public const EFORMS_ERR_TYPE                 = 'EFORMS_ERR_TYPE';
 
 
     /**
@@ -130,7 +131,7 @@ class TemplateValidator
             }
             $type = $f['type'] ?? null;
             if (!in_array($type, $allowedTypes, true)) {
-                $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_ENUM,'path'=>$path.'type'];
+                $errors[] = ['code'=>self::EFORMS_ERR_TYPE,'path'=>$path.'type'];
                 continue;
             }
             if ($type === 'row_group') {

--- a/tests/unit/TemplateValidatorTest.php
+++ b/tests/unit/TemplateValidatorTest.php
@@ -56,6 +56,15 @@ class TemplateValidatorTest extends BaseTestCase
         $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_UNKNOWN_KEY, $codes);
     }
 
+    public function testUnsupportedFieldType(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['type'] = 'bogus';
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_TYPE, $codes);
+    }
+
     public function testDuplicateFieldKey(): void
     {
         $tpl = $this->baseTpl();


### PR DESCRIPTION
## Summary
- add `EFORMS_ERR_TYPE` constant for invalid field types
- use `EFORMS_ERR_TYPE` in `TemplateValidator::preflight` when encountering unsupported field `type`
- test that unknown field types trigger the new error code

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c81f370fd8832db8b8093f4f3f4704