### PR TITLE
Adjust token validation precedence

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -71,20 +71,17 @@ class Security
 
     public static function token_validate(string $formId, bool $hasHidden, ?string $postedToken): array
     {
-        $required = (bool) Config::get('security.submission_token.required', true);
         $cookie = $_COOKIE['eforms_t_' . $formId] ?? '';
         $cookieOk = self::isUuid($cookie);
-        if ($hasHidden) {
-            $tokenOk = self::isUuid((string) $postedToken);
-            if ($tokenOk) {
-                return ['mode' => 'hidden', 'token_ok' => true, 'hard_fail' => false, 'soft_signal' => 0, 'require_challenge' => false];
-            }
-            $hard = $required;
-            return ['mode' => 'hidden', 'token_ok' => false, 'hard_fail' => $hard, 'soft_signal' => $hard ? 0 : 1, 'require_challenge' => false];
+
+        if ($hasHidden && self::isUuid((string) $postedToken)) {
+            return ['mode' => 'hidden', 'token_ok' => true, 'hard_fail' => false, 'soft_signal' => 0, 'require_challenge' => false];
         }
+
         if ($cookieOk) {
             return ['mode' => 'cookie', 'token_ok' => true, 'hard_fail' => false, 'soft_signal' => 0, 'require_challenge' => false];
         }
+
         $policy = Config::get('security.cookie_missing_policy', 'soft');
         switch ($policy) {
             case 'hard':


### PR DESCRIPTION
## Summary
- allow token validation to fall back to cookie mode when the hidden token is invalid
- update unit coverage for hidden-token precedence and cookie-missing policy handling

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68c86aee17c8832d9e947dab8ca6398d