### PR TITLE
Add Helpers::nfc for validator normalization

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -30,6 +30,15 @@ class Helpers
         return \sanitize_key($v);
     }
 
+    public static function nfc(string $v): string
+    {
+        if (class_exists('\\Normalizer')) {
+            $n = \Normalizer::normalize($v, \Normalizer::FORM_C);
+            if ($n !== false) return $n;
+        }
+        return $v;
+    }
+
     public static function bytes_from_ini(?string $v): int
     {
         // "0"/null/"" -> PHP_INT_MAX (per spec)

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace EForms\Validation;
 
 use EForms\Config;
+use EForms\Helpers;
 use EForms\Logging;
 use EForms\Rendering\Renderer;
 
@@ -206,14 +207,6 @@ class Validator
         return false;
     }
 
-    private static function nfc(string $v): string
-    {
-        if (class_exists('\\Normalizer')) {
-            $n = \Normalizer::normalize($v, \Normalizer::FORM_C);
-            if ($n !== false) return $n;
-        }
-        return $v;
-    }
     public static function descriptors(array $tpl): array
     {
         if (isset($tpl['descriptors']) && is_array($tpl['descriptors'])) {
@@ -260,7 +253,7 @@ class Validator
                 foreach ($raw as $rv) {
                     if (is_scalar($rv)) {
                         $sv = function_exists('\\wp_unslash') ? \wp_unslash($rv) : stripslashes((string) $rv);
-                        $sv = self::nfc((string) $sv);
+                        $sv = Helpers::nfc((string) $sv);
                         $sv = trim($sv);
                         $vals[] = $norm($sv);
                     }
@@ -274,7 +267,7 @@ class Validator
                     continue;
                 }
                 $sv = function_exists('\\wp_unslash') ? \wp_unslash($v) : stripslashes((string) $v);
-                $sv = self::nfc((string) $sv);
+                $sv = Helpers::nfc((string) $sv);
                 $sv = trim($sv);
                 $values[$k] = $norm($sv);
             }


### PR DESCRIPTION
## Summary
- add Helpers::nfc to expose NFC normalization logic to the helpers utility
- update Validator normalization to use the helper and drop its private copy

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68c871862f14832dae6e2541d14f931d