### PR TITLE
Log submission token mode for request diagnostics

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -475,6 +475,7 @@ electronic_forms - Spec
   - Rotation/retention for JSONL: dirs 0700, files 0600, rotate when file_max_size exceeded, prune > retention_days. flock() used; note NFS caveats.
   - What to log (all modes, subject to pii/headers):
     - Timestamp (UTC ISO-8601), severity, code, form_id, instance_id, request URI (path + only eforms_* query), privacy-processed IP, spam signals summary (honeypot, origin_state, soft_fail_count, throttle_state), SMTP failure reason when applicable.
+    - Token evaluation mode (meta.token_mode) when the submission token gate runs, to differentiate hidden-token vs cookie flows.
     - Optional on failure: canonical field names + values only for fields causing rejection when logging.on_failure_canonical=true.
     - Throttle & challenge outcomes at level >=1 (redact provider tokens).
     - At level=2, include a compact descriptor fingerprint for this request: desc_sha1 = sha1(json_encode(resolved descriptors)). Optionally include a compact spam bitset alongside the human list.

--- a/src/Logging.php
+++ b/src/Logging.php
@@ -136,6 +136,9 @@ class Logging
         }
         $meta = $ctx;
         unset($meta['form_id'], $meta['instance_id'], $meta['msg'], $meta['ip'], $meta['spam']);
+        if (array_key_exists('token_mode', $ctx)) {
+            $meta['token_mode'] = $ctx['token_mode'];
+        }
         if (isset($meta['email']) && is_array($meta['email'])) {
             unset($meta['email']);
         }

--- a/src/Submission/SubmitHandler.php
+++ b/src/Submission/SubmitHandler.php
@@ -72,6 +72,7 @@ class SubmitHandler
         $cookieName = 'eforms_t_' . $formId;
         $cookieToken = $_COOKIE[$cookieName] ?? '';
         $tokenInfo = Security::token_validate($formId, $hasHidden, $postedToken);
+        $logBase['token_mode'] = $tokenInfo['mode'] ?? '';
         if ($tokenInfo['mode'] === 'cookie') {
             $ttl = (int) Config::get('security.token_ttl_seconds', 600);
             $newToken = function_exists('\wp_generate_uuid4') ? \wp_generate_uuid4() : Helpers::random_id(16);


### PR DESCRIPTION
## Summary
- add the token mode to the logging context after validating submission tokens
- ensure the logger keeps any provided token_mode metadata
- document the new token_mode field in the logging specification

## Testing
- ./vendor/bin/phpunit


------
https://chatgpt.com/codex/tasks/task_e_68c87dad1e58832dafb548ff1a691ca2