### PR TITLE
Document POST mode persistence

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -655,6 +655,7 @@ uploads.*
 
   2. POST
     - SubmitHandler orchestrates Security gate -> Normalize -> Validate -> Coerce
+    - The hidden-token vs cookie mode chosen during the initial GET render is fixed for that instance; POST re-renders reuse the same mode and never switch mid-flow.
     - Early enforce RuntimeCap using CONTENT_LENGTH when present; else rely on PHP INI limits and post-facto caps.
     - On errors:
       - Before token reservation → re-render reusing instance_id, timestamp, and (if hidden) same eforms_token.


### PR DESCRIPTION
## Summary
- clarify that POST submissions reuse the mode chosen during the initial GET render and cannot switch between hidden-token and cookie modes mid-flow

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68c8a5bcc9b0832d9282a71702d75e80