### PR TITLE
Enforce persisted token mode during validation

### DIFF
--- a/tests/unit/SecurityTokenModesTest.php
+++ b/tests/unit/SecurityTokenModesTest.php
@@ -5,19 +5,25 @@ use EForms\Config;
 class SecurityTokenModesTest extends BaseTestCase
 {
     private array $origConfig;
+    private string $tokenDir = '';
 
     protected function setUp(): void
     {
         parent::setUp();
 
+        Config::bootstrap();
         $ref = new \ReflectionClass(Config::class);
         $prop = $ref->getProperty('data');
         $prop->setAccessible(true);
         $this->origConfig = $prop->getValue();
+        $base = rtrim((string) Config::get('uploads.dir', ''), '/');
+        $this->tokenDir = $base === '' ? '' : $base . '/tokens';
+        $this->clearTokenDir();
     }
 
     protected function tearDown(): void
     {
+        $this->clearTokenDir();
         $ref = new \ReflectionClass(Config::class);
         $prop = $ref->getProperty('data');
         $prop->setAccessible(true);
@@ -46,7 +52,9 @@ class SecurityTokenModesTest extends BaseTestCase
 
     public function testHiddenTokenMode(): void
     {
-        $res = Security::token_validate('contact_us', true, '00000000-0000-4000-8000-000000000015');
+        $token = 'h-00000000-0000-4000-8000-000000000015';
+        $this->persistToken($token, 'contact_us', 'hidden');
+        $res = Security::token_validate('contact_us', true, $token);
         $this->assertSame('hidden', $res['mode']);
         $this->assertTrue($res['token_ok']);
         $this->assertFalse($res['hard_fail']);
@@ -96,28 +104,62 @@ class SecurityTokenModesTest extends BaseTestCase
         $this->assertFalse($res['require_challenge']);
     }
 
-    public function testHiddenInvalidFallsBackToCookie(): void
+    public function testHiddenInvalidDoesNotFallbackToCookie(): void
     {
-        $_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000016';
+        $cookieToken = 'c-00000000-0000-4000-8000-000000000016';
+        $_COOKIE['eforms_t_contact_us'] = $cookieToken;
+        $this->persistToken($cookieToken, 'contact_us', 'cookie');
         $res = Security::token_validate('contact_us', true, 'bad');
-        $this->assertSame('cookie', $res['mode']);
-        $this->assertTrue($res['token_ok']);
-        $this->assertFalse($res['hard_fail']);
+        $this->assertSame('hidden', $res['mode']);
+        $this->assertFalse($res['token_ok']);
+        $this->assertTrue($res['hard_fail']);
         $this->assertSame(0, $res['soft_signal']);
         $this->assertFalse($res['require_challenge']);
         unset($_COOKIE['eforms_t_contact_us']);
     }
 
-    public function testHiddenInvalidWithoutCookieUsesPolicy(): void
+    public function testHiddenInvalidHonorsSubmissionRequirement(): void
     {
-        $this->setConfig('security.cookie_missing_policy', 'challenge');
+        $this->setConfig('security.submission_token.required', false);
         unset($_COOKIE['eforms_t_contact_us']);
         $res = Security::token_validate('contact_us', true, 'bad');
-        $this->assertSame('cookie', $res['mode']);
+        $this->assertSame('hidden', $res['mode']);
         $this->assertFalse($res['token_ok']);
         $this->assertFalse($res['hard_fail']);
         $this->assertSame(1, $res['soft_signal']);
-        $this->assertTrue($res['require_challenge']);
+        $this->assertFalse($res['require_challenge']);
+    }
+
+    public function testHiddenTokenModeMismatchHardFails(): void
+    {
+        $token = 'h-00000000-0000-4000-8000-000000000017';
+        $this->persistToken($token, 'contact_us', 'cookie');
+        $res = Security::token_validate('contact_us', true, $token);
+        $this->assertSame('hidden', $res['mode']);
+        $this->assertFalse($res['token_ok']);
+        $this->assertTrue($res['hard_fail']);
+    }
+
+    public function testHiddenTokenPrefixMismatchHardFails(): void
+    {
+        $token = 'c-00000000-0000-4000-8000-000000000018';
+        $this->persistToken($token, 'contact_us', 'hidden');
+        $res = Security::token_validate('contact_us', true, $token);
+        $this->assertSame('hidden', $res['mode']);
+        $this->assertFalse($res['token_ok']);
+        $this->assertTrue($res['hard_fail']);
+    }
+
+    public function testCookieTokenPrefixMismatchHardFails(): void
+    {
+        $token = 'h-00000000-0000-4000-8000-000000000019';
+        $_COOKIE['eforms_t_contact_us'] = $token;
+        $this->persistToken($token, 'contact_us', 'cookie');
+        $res = Security::token_validate('contact_us', false, null);
+        $this->assertSame('cookie', $res['mode']);
+        $this->assertFalse($res['token_ok']);
+        $this->assertTrue($res['hard_fail']);
+        unset($_COOKIE['eforms_t_contact_us']);
     }
 
     public function testCookieRotation(): void
@@ -134,5 +176,43 @@ class SecurityTokenModesTest extends BaseTestCase
         $cookie = trim((string)file_get_contents($tmpDir . '/cookie.txt'));
         $this->assertNotSame('oldCookie', $cookie);
         $this->assertNotSame('', $cookie);
+    }
+
+    private function clearTokenDir(): void
+    {
+        if ($this->tokenDir === '' || !is_dir($this->tokenDir)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->tokenDir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $fs) {
+            $path = $fs->getPathname();
+            if ($fs->isDir()) {
+                @rmdir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($this->tokenDir);
+    }
+
+    private function persistToken(string $token, string $formId, string $mode): void
+    {
+        if ($this->tokenDir === '') {
+            return;
+        }
+        $hash = hash('sha256', $token);
+        $dir = $this->tokenDir . '/' . substr($hash, 0, 2);
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0777, true);
+        }
+        $data = [
+            'form_id' => $formId,
+            'mode' => $mode,
+            'expires' => time() + 600,
+        ];
+        @file_put_contents($dir . '/' . $hash . '.json', json_encode($data));
     }
 }


### PR DESCRIPTION
## Summary
- update token validation to consult persisted token records and reject mode or prefix mismatches instead of falling back to cookies
- add helpers in the security token tests to manage persisted records and cover hidden/cookie mismatch scenarios

## Testing
- vendor/bin/phpunit


------
https://chatgpt.com/codex/tasks/task_e_68c8b6b43bac832d959310adccac99f2