### PR TITLE
Clarify token validation metadata flow

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -237,9 +237,12 @@ electronic_forms - Spec
         - soft mode: cross/unknown → +1 soft; missing → +1 soft only when security.origin_missing_soft=true.
       - Method/Type: Require POST. Accept only application/x-www-form-urlencoded (charset allowed) or multipart/form-data (boundary required). Else 405/415. Enforce POST size cap per §7.5.
       - Token validation (Security::token_validate(declared_mode, post_token, cookie_token)):
-        - Inputs include the declared mode from the renderer metadata. The validator never deduces the mode from the presence or absence of `eforms_token` or cookies.
+        - Inputs include the declared token mode from the renderer metadata (`RenderContext.token_mode`). The validator never deduces the mode from the presence or absence of `eforms_token` or cookies.
+        - Mode authority is resolved deterministically:
+          - If a token is present, load the token record and use its stored mode; no per-instance metadata lookup is required.
+          - If a token is missing, consult the saved form metadata (e.g., cacheable flag) to determine which missing-token policy to apply.
         - For any presented token (hidden field or cookie), compute sha256(token) and load the persisted record. Missing records, tokens whose prefix does not match the persisted mode (`h-` for hidden, `c-` for cookie), or mode mismatches immediately HARD FAIL (EFORMS_ERR_TOKEN). The persisted record never changes modes; form_id must also match.
-        - When no token value is presented, skip the lookup and apply the declared mode’s missing-token policy: hidden → security.submission_token.required; cookie → security.cookie_missing_policy.
+        - When no token value is presented, skip the lookup and apply the missing-token policy chosen from the saved metadata: hidden → security.submission_token.required; cookie → security.cookie_missing_policy.
         - Hidden-mode (declared/persisted instance): expect the posted `eforms_token` to match the minted token (prefix `h-`). Missing/invalid tokens are governed solely by security.submission_token.required:
           - true → HARD FAIL (EFORMS_ERR_TOKEN)
           - false → token_soft=1, continue §7.6


### PR DESCRIPTION
## Summary
- document that token validation consumes RenderContext.token_mode metadata and deterministically resolves the authoritative mode
- clarify the handling for present tokens versus missing tokens and reference the saved metadata for the missing-token policy

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c973908348832da9076da68ce401e3