### PR TITLE
Implement minted EID workflow and align tests

### DIFF
--- a/templates/forms/rules-demo.json
+++ b/templates/forms/rules-demo.json
@@ -7,7 +7,7 @@
   "email": { "to": "test@example.com", "subject": "Rules Demo" },
   "fields": [
     { "key": "user_email", "type": "email", "label": "Your Email" },
-    { "key": "confirm_email_checkbox", "type": "checkbox", "label": "Confirm Email", "choices": [{ "text": "Yes", "value": "yes" }] }
+    { "key": "confirm_email_checkbox", "type": "checkbox", "label": "Confirm Email", "options": [{ "key": "yes", "label": "Yes" }] }
   ],
   "rules": [
     { "rule": "required_if", "target": "confirm_email_checkbox", "field": "user_email", "equals": "yes" }

--- a/tests/integration/test_cookie_rotation.php
+++ b/tests/integration/test_cookie_rotation.php
@@ -4,7 +4,7 @@ require __DIR__ . '/../bootstrap.php';
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = 'oldCookie';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-0000000c0fee');
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => 'instROT',
@@ -18,7 +18,7 @@ $_POST = [
 ];
 
 register_shutdown_function(function () {
-    file_put_contents(__DIR__ . '/../tmp/cookie.txt', $_COOKIE['eforms_t_contact_us'] ?? '');
+    file_put_contents(__DIR__ . '/../tmp/cookie.txt', $_COOKIE['eforms_eid_contact_us'] ?? '');
 });
 
 $sh = new \EForms\Submission\SubmitHandler();

--- a/tests/integration/test_dir_protect.php
+++ b/tests/integration/test_dir_protect.php
@@ -4,7 +4,7 @@ require __DIR__ . '/../bootstrap.php';
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000099';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000099');
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => 'instPROTECT',

--- a/tests/integration/test_email_attachment.php
+++ b/tests/integration/test_email_attachment.php
@@ -4,7 +4,7 @@ require __DIR__ . '/../bootstrap.php';
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_upload_test'] = '00000000-0000-4000-8000-000000000007';
+set_eid_cookie('upload_test', 'i-00000000-0000-4000-8000-000000000007');
 $tmp = __DIR__ . '/../tmp/upload.pdf';
 file_put_contents($tmp, "%PDF-1.4\n");
 $_FILES = [

--- a/tests/integration/test_honeypot.php
+++ b/tests/integration/test_honeypot.php
@@ -6,7 +6,7 @@ set_config(['logging' => ['level' => 1]]);
 // Honeypot: non-empty should result in PRG 303 and no email
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000012';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000012');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_honeypot_capture.php
+++ b/tests/integration/test_honeypot_capture.php
@@ -5,7 +5,7 @@ set_config(['logging' => ['level' => 1]]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000013';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000013');
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => 'instHP',

--- a/tests/integration/test_honeypot_hard.php
+++ b/tests/integration/test_honeypot_hard.php
@@ -8,7 +8,7 @@ set_config([
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000011';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000011');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_honeypot_throttle_first.php
+++ b/tests/integration/test_honeypot_throttle_first.php
@@ -12,7 +12,7 @@ set_config([
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000014';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000014');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_honeypot_throttle_second.php
+++ b/tests/integration/test_honeypot_throttle_second.php
@@ -12,7 +12,7 @@ set_config([
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000015';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000015');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_js_hard.php
+++ b/tests/integration/test_js_hard.php
@@ -8,7 +8,7 @@ set_config([
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000004';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000004');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_js_soft.php
+++ b/tests/integration/test_js_soft.php
@@ -8,7 +8,7 @@ set_config([
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000003';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000003');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_ledger_dup_first.php
+++ b/tests/integration/test_ledger_dup_first.php
@@ -14,7 +14,7 @@ if (is_dir($ledgerBase)) {
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-00000000000b';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-00000000000b');
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => 'instDup1',

--- a/tests/integration/test_ledger_dup_second.php
+++ b/tests/integration/test_ledger_dup_second.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../bootstrap.php';
 // Second submit with same token should be rejected
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-00000000000b';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-00000000000b');
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => 'instDup2',

--- a/tests/integration/test_ledger_duplicate.php
+++ b/tests/integration/test_ledger_duplicate.php
@@ -15,7 +15,7 @@ if (is_dir($ledgerBase)) {
 // First submit (should succeed -> redirect 303)
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = 'dupTok';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-00000000d000');
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => 'instDup1',
@@ -36,7 +36,7 @@ ob_end_clean();
 require __DIR__ . '/../bootstrap.php'; // rebootstrap fresh hooks and artifacts
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = 'dupTok';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-00000000d000');
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => 'instDup2',

--- a/tests/integration/test_logging.php
+++ b/tests/integration/test_logging.php
@@ -7,7 +7,7 @@ putenv('EFORMS_FORCE_MAIL_FAIL=1');
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000005';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000005');
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => 'instLOG1',

--- a/tests/integration/test_logging_minimal.php
+++ b/tests/integration/test_logging_minimal.php
@@ -10,7 +10,7 @@ putenv('EFORMS_FORCE_MAIL_FAIL=1');
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000005';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000005');
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => 'instLOG1',

--- a/tests/integration/test_minimal_email.php
+++ b/tests/integration/test_minimal_email.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../bootstrap.php';
 // Valid submit should send mail with template body
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000006';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000006');
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => 'instMAIL1',

--- a/tests/integration/test_operational_rerender.php
+++ b/tests/integration/test_operational_rerender.php
@@ -9,6 +9,7 @@ $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $origInstance = 'instOP1';
 $origToken = '00000000-0000-4000-8000-00000000abcd';
+mint_hidden_token_record('contact_us', $origToken, time() - 60);
 $_POST = [
     'form_id' => 'contact_us',
     'instance_id' => $origInstance,

--- a/tests/integration/test_origin_hard.php
+++ b/tests/integration/test_origin_hard.php
@@ -7,7 +7,7 @@ set_config(['security' => ['origin_mode' => 'hard']]);
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_ORIGIN'] = 'http://evil.example.com';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000014';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000014');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_origin_soft.php
+++ b/tests/integration/test_origin_soft.php
@@ -9,7 +9,7 @@ $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_ORIGIN'] = 'http://evil.example.com';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000001';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000001');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_throttle_hard_first.php
+++ b/tests/integration/test_throttle_hard_first.php
@@ -12,7 +12,7 @@ set_config([
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-00000000000f';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-00000000000f');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_throttle_hard_second.php
+++ b/tests/integration/test_throttle_hard_second.php
@@ -12,7 +12,7 @@ set_config([
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000010';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000010');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_throttle_soft_first.php
+++ b/tests/integration/test_throttle_soft_first.php
@@ -12,7 +12,7 @@ set_config([
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-00000000000d';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-00000000000d');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_throttle_soft_second.php
+++ b/tests/integration/test_throttle_soft_second.php
@@ -12,7 +12,7 @@ set_config([
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
 $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-00000000000e';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-00000000000e');
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_timing_expired.php
+++ b/tests/integration/test_timing_expired.php
@@ -5,6 +5,7 @@ set_config(['logging' => ['level' => 1]]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+mint_hidden_token_record('contact_us', '00000000-0000-4000-8000-000000000000', time() - 1000, 3600);
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_timing_min_fill.php
+++ b/tests/integration/test_timing_min_fill.php
@@ -5,7 +5,7 @@ set_config(['logging' => ['level' => 1]]);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000002';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000002', time());
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/test_upload_reject.php
+++ b/tests/integration/test_upload_reject.php
@@ -7,7 +7,7 @@ set_config([
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_upload_test'] = '00000000-0000-4000-8000-000000000008';
+set_eid_cookie('upload_test', 'i-00000000-0000-4000-8000-000000000008');
 $tmp = __DIR__ . '/../tmp/upload_big.pdf';
 file_put_contents($tmp, "%PDF-1.4\n%\xE2\xE3\xCF\xD3\n" . str_repeat('B', 200));
 $_FILES = [
@@ -31,7 +31,7 @@ $_POST = [
 ];
 register_shutdown_function(function () {
     $files = array_filter(glob(__DIR__ . '/../tmp/uploads/eforms-private/*/*') ?: [], function ($f) {
-        return !str_contains($f, '/ledger/') && !str_contains($f, '/throttle/');
+        return !str_contains($f, '/ledger/') && !str_contains($f, '/throttle/') && !str_contains($f, '/eid_minted/');
     });
     file_put_contents(__DIR__ . '/../tmp/uploaded.txt', $files ? implode("\n", $files) : '');
 });

--- a/tests/integration/test_upload_valid.php
+++ b/tests/integration/test_upload_valid.php
@@ -4,7 +4,7 @@ require __DIR__ . '/../bootstrap.php';
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_upload_test'] = '00000000-0000-4000-8000-00000000000c';
+set_eid_cookie('upload_test', 'i-00000000-0000-4000-8000-00000000000c');
 $tmp = __DIR__ . '/../tmp/upload.pdf';
 file_put_contents($tmp, "%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
 $_FILES = [
@@ -27,7 +27,7 @@ $_POST = [
 ];
 register_shutdown_function(function () {
     $files = array_filter(glob(__DIR__ . '/../tmp/uploads/eforms-private/*/*') ?: [], function ($f) {
-        return !str_contains($f, '/ledger/') && !str_contains($f, '/throttle/');
+        return !str_contains($f, '/ledger/') && !str_contains($f, '/throttle/') && !str_contains($f, '/eid_minted/');
     });
     file_put_contents(__DIR__ . '/../tmp/uploaded.txt', $files[0] ?? '');
 });

--- a/tests/integration/test_validation_formats.php
+++ b/tests/integration/test_validation_formats.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../bootstrap.php';
 // Invalid email/zip/tel should produce format errors
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_quote_request'] = '00000000-0000-4000-8000-00000000000a';
+set_eid_cookie('quote_request', 'i-00000000-0000-4000-8000-00000000000a');
 
 $_POST = [
     'form_id' => 'quote_request',

--- a/tests/integration/test_validation_required.php
+++ b/tests/integration/test_validation_required.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../bootstrap.php';
 // Missing required fields should produce per-field errors
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_contact_us'] = '00000000-0000-4000-8000-000000000009';
+set_eid_cookie('contact_us', 'i-00000000-0000-4000-8000-000000000009', 1234567890);
 
 $_POST = [
     'form_id' => 'contact_us',

--- a/tests/integration/upload_fail_cleanup_runner.php
+++ b/tests/integration/upload_fail_cleanup_runner.php
@@ -12,7 +12,7 @@ $prop->setValue(null, $data);
 
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
-$_COOKIE['eforms_t_upload_test'] = '00000000-0000-4000-8000-000000000008';
+set_eid_cookie('upload_test', 'i-00000000-0000-4000-8000-000000000008');
 
 $tmp = __DIR__ . '/../tmp/fail_upload.pdf';
 file_put_contents($tmp, "%PDF-1.4\n");
@@ -38,7 +38,7 @@ $_POST = [
 
 register_shutdown_function(function () use ($tmp): void {
     $files = array_filter(glob(__DIR__ . '/../tmp/uploads/eforms-private/*/*') ?: [], function ($f) {
-        return !str_contains($f, '/ledger/') && !str_contains($f, '/throttle/');
+        return !str_contains($f, '/ledger/') && !str_contains($f, '/throttle/') && !str_contains($f, '/eid_minted/');
     });
     file_put_contents(__DIR__ . '/../tmp/upload_fail_cleanup.txt', $files ? implode("\n", $files) : '');
     @unlink($tmp);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -96,7 +96,7 @@ record_result "spec schema parity" $ok
 # Prime endpoint cookie attributes
 run_test test_prime_cookie
 ok=0
-assert_grep tmp/headers.txt 'Set-Cookie: eforms_t_contact_us=' || ok=1
+assert_grep tmp/headers.txt 'Set-Cookie: eforms_eid_contact_us=' || ok=1
 assert_grep tmp/headers.txt 'Max-Age=' || ok=1
 record_result "prime sets max-age" $ok
 

--- a/tests/unit/ChallengeInitTest.php
+++ b/tests/unit/ChallengeInitTest.php
@@ -58,7 +58,7 @@ final class ChallengeInitTest extends BaseTestCase
     public function testPolicyChallengeEnqueuesScriptWhenCookieMissing(): void
     {
         $this->setConfig('security.cookie_missing_policy', 'challenge');
-        unset($_COOKIE['eforms_t_contact_us']);
+        unset($_COOKIE['eforms_eid_contact_us']);
         $fm = new FormRenderer();
         $GLOBALS['wp_enqueued_scripts'] = [];
         $html = $fm->render('contact_us');

--- a/tests/unit/HoneypotBehaviorTest.php
+++ b/tests/unit/HoneypotBehaviorTest.php
@@ -27,7 +27,7 @@ class HoneypotBehaviorTest extends BaseTestCase
         $this->assertStringContainsString('EFORMS_ERR_HONEYPOT', $log);
         $this->assertStringContainsString('"stealth":true', $log);
 
-        $hash = sha1('contact_us:00000000-0000-4000-8000-000000000013');
+        $hash = sha1('contact_us:i-00000000-0000-4000-8000-000000000013');
         $ledgerFile = $tmpDir . '/uploads/eforms-private/ledger/' . substr($hash,0,2) . '/' . $hash . '.used';
         $this->assertFileExists($ledgerFile);
     }

--- a/tests/unit/UploadFailCleanupTest.php
+++ b/tests/unit/UploadFailCleanupTest.php
@@ -15,7 +15,12 @@ final class UploadFailCleanupTest extends BaseTestCase
         @unlink(__DIR__ . '/../tmp/upload_fail_cleanup.txt');
         foreach (glob(__DIR__ . '/../tmp/uploads/eforms-private/*/*') ?: [] as $f) {
             if (!str_contains($f, '/ledger/') && !str_contains($f, '/throttle/')) {
-                @unlink($f);
+                if (is_dir($f)) {
+                    @array_map('unlink', glob($f . '/*') ?: []);
+                    @rmdir($f);
+                } else {
+                    @unlink($f);
+                }
             }
         }
         $ledgerDir = __DIR__ . '/../tmp/uploads/eforms-private/ledger';


### PR DESCRIPTION
## Summary
- mint cookie-mode identifiers as eforms_eid_* cookies and persist a matching record under uploads/eid_minted
- load minted EID metadata in Security::token_validate so SubmitHandler can reuse the same submission identifier, issued timestamp and apply cookie-missing policy consistently
- adjust SubmitHandler, helpers and tests to work with minted identifiers, add hidden token minting helpers, and refresh template fixtures to satisfy schema checks

## Testing
- ./tests/run.sh

------
https://chatgpt.com/codex/tasks/task_e_68cae439f2d8832d857c6ea3df77bb08