### PR TITLE
Track submission identifiers across success flow and logging

### DIFF
--- a/src/Email/Emailer.php
+++ b/src/Email/Emailer.php
@@ -200,7 +200,7 @@ class Emailer
         if (!is_file($file)) {
             throw new \RuntimeException('Email template not found');
         }
-        $allowedMeta = ['submitted_at','ip','form_id','instance_id'];
+        $allowedMeta = ['submitted_at','ip','form_id','instance_id','submission_id','slot'];
         $include_fields = $tpl['email']['include_fields'] ?? [];
         $include_fields = array_values(array_filter($include_fields, function ($k) use ($canonical, $meta, $allowedMeta) {
             if (isset($canonical[$k]) || isset($canonical['_uploads'][$k])) {
@@ -216,7 +216,7 @@ class Emailer
 
     private static function sanitizeMeta(array $meta): array
     {
-        $allowed = ['submitted_at','ip','form_id','instance_id'];
+        $allowed = ['submitted_at','ip','form_id','instance_id','submission_id','slot'];
         return array_intersect_key($meta, array_flip($allowed));
     }
 
@@ -228,7 +228,7 @@ class Emailer
 
     private static function expandTokens(string $str, array $canonical, array $meta): string
     {
-        return preg_replace_callback('/\{\{\s*(field\.[a-z0-9_-]+|submitted_at|ip|form_id)\s*\}\}/i', function ($m) use ($canonical, $meta) {
+        return preg_replace_callback('/\{\{\s*(field\.[a-z0-9_-]+|submitted_at|ip|form_id|submission_id|slot)\s*\}\}/i', function ($m) use ($canonical, $meta) {
             $token = strtolower($m[1]);
             if (str_starts_with($token, 'field.')) {
                 $key = substr($token, 6);

--- a/src/Logging.php
+++ b/src/Logging.php
@@ -108,15 +108,20 @@ class Logging
         }
         $ip = $ctx['ip'] ?? Helpers::client_ip();
         $ipDisp = Helpers::ip_display((string) $ip);
+        $slot = array_key_exists('slot', $ctx) ? (int) $ctx['slot'] : null;
         $data = [
             'ts' => gmdate('c'),
             'severity' => $severity,
             'code' => $code,
             'form_id' => $ctx['form_id'] ?? '',
             'instance_id' => $ctx['instance_id'] ?? '',
+            'submission_id' => $ctx['submission_id'] ?? '',
             'uri' => Helpers::request_uri(),
             'ip' => $ipDisp,
         ];
+        if ($slot !== null) {
+            $data['slot'] = $slot;
+        }
         if (!empty($ctx['msg'])) {
             $data['msg'] = $ctx['msg'];
         }
@@ -135,7 +140,7 @@ class Logging
             }
         }
         $meta = $ctx;
-        unset($meta['form_id'], $meta['instance_id'], $meta['msg'], $meta['ip'], $meta['spam']);
+        unset($meta['form_id'], $meta['instance_id'], $meta['submission_id'], $meta['slot'], $meta['msg'], $meta['ip'], $meta['spam']);
         if (array_key_exists('token_mode', $ctx)) {
             $meta['token_mode'] = $ctx['token_mode'];
         }
@@ -178,8 +183,14 @@ class Logging
             if ($data['form_id'] !== '') {
                 $parts[] = 'form=' . $data['form_id'];
             }
+            if ($data['submission_id'] !== '') {
+                $parts[] = 'subm=' . $data['submission_id'];
+            }
             if ($data['instance_id'] !== '') {
                 $parts[] = 'inst=' . $data['instance_id'];
+            }
+            if ($slot !== null) {
+                $parts[] = 'slot=' . $slot;
             }
             if ($data['ip'] !== '') {
                 $parts[] = 'ip=' . $data['ip'];

--- a/src/Rendering/Renderer.php
+++ b/src/Rendering/Renderer.php
@@ -85,6 +85,18 @@ class Renderer
             $cookieName = 'eforms_s_' . $formId;
             $cookieVal = $_COOKIE[$cookieName] ?? '';
             if ($cookieVal && str_starts_with($cookieVal, $formId . ':')) {
+                $sub = substr($cookieVal, strlen($formId) + 1);
+                if ($sub === '') {
+                    \setcookie($cookieName, '', [
+                        'expires' => time() - 3600,
+                        'path' => '/',
+                        'secure' => \is_ssl(),
+                        'httponly' => true,
+                        'samesite' => 'Lax',
+                    ]);
+                    unset($_COOKIE[$cookieName]);
+                    return '';
+                }
                 $msg = $tpl['success']['message'] ?? 'Success';
                 $successHtml = '<div class="eforms-success">' . \esc_html($msg) . '</div>';
                 \setcookie($cookieName, '', [

--- a/src/TemplateSpec.php
+++ b/src/TemplateSpec.php
@@ -41,7 +41,7 @@ class TemplateSpec
 
     private const FIELDS = [
         'reserved_keys' => [
-            'form_id','instance_id','eforms_token','eforms_hp','timestamp','js_ok','ip','submitted_at'
+            'form_id','instance_id','submission_id','eforms_token','eforms_hp','timestamp','js_ok','ip','submitted_at'
         ],
         'allowed_types' => [
             'name','first_name','last_name','text','email','textarea','textarea_html','url','tel','tel_us','number',
@@ -60,7 +60,7 @@ class TemplateSpec
             'max_file_bytes','max_files','step'
         ],
         'size_allowed_types' => ['text','tel','tel_us','url','email'],
-        'allowed_meta' => ['ip','submitted_at','form_id','instance_id'],
+        'allowed_meta' => ['ip','submitted_at','form_id','instance_id','submission_id','slot'],
     ];
 
     private const RULES = [

--- a/templates/email/default.html.php
+++ b/templates/email/default.html.php
@@ -5,7 +5,8 @@ defined('ABSPATH') || exit;
 ?>
 <p>
 Form: <?= htmlspecialchars($meta['form_id'] ?? '', ENT_QUOTES) ?><br>
-Instance: <?= htmlspecialchars($meta['instance_id'] ?? '', ENT_QUOTES) ?><br>
+Submission: <?= htmlspecialchars($meta['submission_id'] ?? '', ENT_QUOTES) ?><br>
+<?php if (!empty($meta['slot'] ?? null)): ?>Slot: <?= htmlspecialchars((string) ($meta['slot'] ?? ''), ENT_QUOTES) ?><br><?php endif; ?>
 Submitted: <?= htmlspecialchars($meta['submitted_at'] ?? '', ENT_QUOTES) ?>
 </p>
 <table>

--- a/templates/email/default.txt.php
+++ b/templates/email/default.txt.php
@@ -4,7 +4,10 @@ defined('ABSPATH') || exit;
 
 // Rendered when email.email_template="default".
 echo 'Form: ' . ($meta['form_id'] ?? '') . "\n";
-echo 'Instance: ' . ($meta['instance_id'] ?? '') . "\n";
+echo 'Submission: ' . ($meta['submission_id'] ?? '') . "\n";
+if (!empty($meta['slot'] ?? null)) {
+    echo 'Slot: ' . ($meta['slot'] ?? '') . "\n";
+}
 echo 'Submitted: ' . ($meta['submitted_at'] ?? '') . "\n\n";
 foreach ($include_fields as $key) {
     if (isset($canonical['_uploads'][$key])) {

--- a/tests/integration/test_success_inline.php
+++ b/tests/integration/test_success_inline.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 $getSnapshot = $_GET;
 $cookieSnapshot = $_COOKIE;
 $_GET['eforms_success'] = 'contact_us';
-$_COOKIE['eforms_s_contact_us'] = 'contact_us:instOK';
+$_COOKIE['eforms_s_contact_us'] = 'contact_us:submOK';
 
 require __DIR__ . '/../bootstrap.php';
 

--- a/tests/unit/EmailAttachmentNameTest.php
+++ b/tests/unit/EmailAttachmentNameTest.php
@@ -38,7 +38,7 @@ final class EmailAttachmentNameTest extends BaseTestCase
                 ],
             ],
         ];
-        $meta = ['form_id' => 't1', 'instance_id' => 'i1'];
+        $meta = ['form_id' => 't1', 'submission_id' => 'sub1'];
         Emailer::send($tpl, $canonical, $meta);
         global $TEST_ARTIFACTS;
         $mail = json_decode((string)file_get_contents($TEST_ARTIFACTS['mail_file']), true);
@@ -69,7 +69,7 @@ final class EmailAttachmentNameTest extends BaseTestCase
                 ],
             ],
         ];
-        $meta = ['form_id' => 't1', 'instance_id' => 'i1'];
+        $meta = ['form_id' => 't1', 'submission_id' => 'sub1'];
         Emailer::send($tpl, $canonical, $meta);
         global $TEST_ARTIFACTS;
         $mail = json_decode((string)file_get_contents($TEST_ARTIFACTS['mail_file']), true);

--- a/tests/unit/EmailAttachmentOverflowTest.php
+++ b/tests/unit/EmailAttachmentOverflowTest.php
@@ -40,7 +40,7 @@ final class EmailAttachmentOverflowTest extends BaseTestCase
                 ],
             ],
         ];
-        $meta = ['form_id' => 't1', 'instance_id' => 'i1'];
+        $meta = ['form_id' => 't1', 'submission_id' => 'sub1'];
         Emailer::send($tpl, $canonical, $meta);
         global $TEST_ARTIFACTS;
         $mail = json_decode((string) file_get_contents($TEST_ARTIFACTS['mail_file']), true);

--- a/tests/unit/EmailBodySanitizeTest.php
+++ b/tests/unit/EmailBodySanitizeTest.php
@@ -39,7 +39,7 @@ final class EmailBodySanitizeTest extends BaseTestCase
         ];
         $rawBody = "Hello\rWorld\nAgain\x00\x1F";
         $canonical = ['body' => $rawBody];
-        $meta = ['form_id' => 't1', 'instance_id' => 'i1'];
+        $meta = ['form_id' => 't1', 'submission_id' => 'sub1'];
         Emailer::send($tpl, $canonical, $meta);
         remove_action('phpmailer_init', $prep);
         global $TEST_ARTIFACTS;

--- a/tests/unit/EmailTelFormattingTest.php
+++ b/tests/unit/EmailTelFormattingTest.php
@@ -39,7 +39,7 @@ final class EmailTelFormattingTest extends BaseTestCase
             'rules' => [],
         ];
         $canonical = ['phone' => '1234567890'];
-        $meta = ['form_id' => 't1', 'instance_id' => 'i1'];
+        $meta = ['form_id' => 't1', 'submission_id' => 'sub1'];
         Emailer::send($tpl, $canonical, $meta);
         global $TEST_ARTIFACTS;
         $mail = json_decode((string) file_get_contents($TEST_ARTIFACTS['mail_file']), true);

--- a/tests/unit/EmailTokenExpansionTest.php
+++ b/tests/unit/EmailTokenExpansionTest.php
@@ -48,12 +48,14 @@ final class EmailTokenExpansionTest extends BaseTestCase
             'submitted_at' => '2024-01-01T00:00:00Z',
             'ip' => '1.2.3.4',
             'form_id' => 't1',
+            'submission_id' => 'sub-123',
+            'slot' => 3,
         ];
 
-        $input = 'F={{field.foo}} U={{field.up}} S={{submitted_at}} I={{ip}} ID={{form_id}} X={{unknown}}';
+        $input = 'F={{field.foo}} U={{field.up}} S={{submitted_at}} I={{ip}} ID={{form_id}} SUB={{submission_id}} SL={{slot}} X={{unknown}}';
         $out = $this->expand($input, $canonical, $meta);
         $this->assertSame(
-            'F=bar U=a.pdf, b.pdf S=2024-01-01T00:00:00Z I=1.2.3.4 ID=t1 X={{unknown}}',
+            'F=bar U=a.pdf, b.pdf S=2024-01-01T00:00:00Z I=1.2.3.4 ID=t1 SUB=sub-123 SL=3 X={{unknown}}',
             $out
         );
     }

--- a/tests/unit/SuccessAntiSpoofTest.php
+++ b/tests/unit/SuccessAntiSpoofTest.php
@@ -33,7 +33,7 @@ final class SuccessAntiSpoofTest extends BaseTestCase
         $getSnapshot = $_GET;
         try {
             $_GET = [];
-            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
+            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:subm'];
             $fm = new \EForms\Rendering\FormRenderer();
             $html = $fm->render('contact_us');
             $this->assertStringNotContainsString('Thanks! We got your message.', $html);
@@ -48,7 +48,7 @@ final class SuccessAntiSpoofTest extends BaseTestCase
         $getSnapshot = $_GET;
         try {
             $_GET = ['eforms_success' => 'contact_us'];
-            $_COOKIE = ['eforms_s_contact_us' => 'other:inst'];
+            $_COOKIE = ['eforms_s_contact_us' => 'other:subm'];
             $fm = new \EForms\Rendering\FormRenderer();
             $html = $fm->render('contact_us');
             $this->assertSame('', $html);
@@ -63,7 +63,7 @@ final class SuccessAntiSpoofTest extends BaseTestCase
         $getSnapshot = $_GET;
         try {
             $_GET = ['eforms_success' => 'contact_us'];
-            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
+            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:subm'];
             $fm = new \EForms\Rendering\FormRenderer();
             $html = $fm->render('contact_us');
             $this->assertStringContainsString('Thanks! We got your message.', $html);
@@ -78,7 +78,7 @@ final class SuccessAntiSpoofTest extends BaseTestCase
         $getSnapshot = $_GET;
         try {
             $_GET = ['eforms_success' => 'contact_us'];
-            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:inst'];
+            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:subm'];
             $fm = new \EForms\Rendering\FormRenderer();
             $html1 = $fm->render('contact_us');
             $this->assertStringContainsString('Thanks! We got your message.', $html1);


### PR DESCRIPTION
## Summary
- derive a canonical submission_id in SubmitHandler and propagate it through logging, honeypot checks, ledger reservations, and success cookie issuance
- extend logging and renderer success handling to use the new identifiers and capture cookie-mode slot metadata
- expose submission identifiers in email meta/templates and template specs, updating automated tests to reflect the new identifiers

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_68caeec838f0832d9093258476a594d7