### PR TITLE
docs: clarify cookie-mode success guidance

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -430,7 +430,8 @@ electronic_forms - Spec
 
 13. SUCCESS BEHAVIOR (PRG)
   - inline: PRG (303) to same URL with `eforms_success={form_id}`. Renderer shows success only in the first instance in source order when multiple same-ID instances exist; suppress in subsequent instances.
-  - redirect: `wp_safe_redirect(redirect_url, 303)`; no flag on destination.
+  - redirect: `wp_safe_redirect(redirect_url, 303)`; no flag on destination. Cookie-mode deployments SHOULD prefer `success.mode="redirect"` pointing at a non-cached endpoint per v4.4 guidance.
+  - Fallback UX: when a redirect target is impossible (e.g., static cached page without a non-cached handoff), continue to use inline success on cached pages as the graceful fallback.
   - PRG status: fixed at 303.
   - Caching: do not disable page caching globally. Only vary/bypass for (a) the short-lived success cookie `eforms_s_{form_id}` and (b) requests containing `eforms_*` query args.
   - Success responses MUST send: `Cache-Control: private, no-store, max-age=0` and SHOULD include `Vary: Cookie` scoped to `eforms_s_{form_id}`.


### PR DESCRIPTION
## Summary
- document v4.4 guidance for cookie-mode deployments to prefer redirect-based success handling against non-cached endpoints
- note that inline success on cached pages remains the fallback when a redirect experience cannot be provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caf5bd83cc832d8b4055291b89a3c4