### PR TITLE
Document success verifier invalidation

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -467,7 +467,7 @@ electronic_forms - Spec
   - Anti-spoofing (inline mode only):
     1. On successful POST, create a one-time success ticket `${uploads.dir}/eforms-private/success/{form_id}/{h2}/{submission_id}.json` (short TTL, e.g., 5 minutes) containing `{ form_id, submission_id, issued_at }`. Set `eforms_s_{form_id}={submission_id}` (`SameSite=Lax`, HttpOnly=false, `Secure` on HTTPS, `Path`=current request path, `Max-Age≈300`).
     2. Redirect with `?eforms_success={form_id}`.
-    3. Cached page loads a lightweight verifier that calls `/eforms/success-verify?f={form_id}&s={submission_id}` (`Cache-Control: no-store`). Render the success banner only when both the query flag and verifier response succeed. Then clear the cookie and strip the query parameter.
+    3. Cached page loads a lightweight verifier that calls `/eforms/success-verify?f={form_id}&s={submission_id}` (`Cache-Control: no-store`). Render the success banner only when both the query flag and verifier response succeed. A successful verifier response MUST immediately invalidate the ticket so any subsequent verify call for the same `{form_id, submission_id}` pair returns false. Then clear the cookie and strip the query parameter. This prevents replaying old cookie/query combinations on cached pages.
   - Inline success MUST NOT rely solely on a bare `eforms_s_{form_id}=1` cookie; always pair it with the ticket verifier to prevent spoofing.
 
 14. EMAIL DELIVERY


### PR DESCRIPTION
## Summary
- clarify that a successful /eforms/success-verify request must invalidate its ticket immediately
- note that invalidation prevents replayed cookie and query parameter combinations on cached pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68caf8178ec4832d8278052c6d792582