### PR TITLE
Handle optional hidden submission tokens softly

### DIFF
--- a/tests/integration/test_hidden_optional_token.php
+++ b/tests/integration/test_hidden_optional_token.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+
+set_config([
+    'security' => [
+        'submission_token' => ['required' => false],
+        'spam' => ['soft_fail_threshold' => 5],
+        'min_fill_seconds' => 0,
+    ],
+    'email' => [
+        'disable_send' => false,
+    ],
+    'logging' => [
+        'level' => 2,
+    ],
+]);
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_REFERER'] = 'http://hub.local/form-test/';
+$_SERVER['HTTP_ORIGIN'] = 'http://hub.local';
+$_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+$_SERVER['HTTP_USER_AGENT'] = 'phpunit-hidden-optional';
+
+unset($_COOKIE['eforms_eid_contact_us']);
+
+$_POST = [
+    'form_id' => 'contact_us',
+    'eforms_mode' => 'hidden',
+    'instance_id' => 'instOPTH1',
+    'timestamp' => time() - 30,
+    'eforms_hp' => '',
+    'contact_us' => [
+        'name' => 'Zed',
+        'email' => 'zed@example.com',
+        'message' => 'Ping',
+    ],
+    'js_ok' => '1',
+];
+
+$handler = new \EForms\Submission\SubmitHandler();
+$handler->handleSubmit();


### PR DESCRIPTION
## Summary
- allow hidden-mode submissions to proceed when the submission token requirement is disabled while still logging missing tokens
- make hidden token validation honor the submission token requirement flag and fall back to soft signals when disabled
- add unit and integration coverage for optional hidden token flows and ensure the handler records suspect signals instead of hard failure

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68caf80998f8832dbe85eaafed9ce657