### PR TITLE
Implement success ticket verification and filesystem-safe tokens

### DIFF
--- a/assets/forms.js
+++ b/assets/forms.js
@@ -5,6 +5,64 @@
  */
 (function () {
   function onReady(fn){ if (document.readyState === 'loading') { document.addEventListener('DOMContentLoaded', fn); } else { fn(); } }
+  function expireCookie(name, path) {
+    if (!name) { return; }
+    var parts = [name + '='];
+    parts.push('expires=Thu, 01 Jan 1970 00:00:00 GMT');
+    parts.push('path=' + (path || '/'));
+    parts.push('SameSite=Lax');
+    if (window.location && window.location.protocol === 'https:') {
+      parts.push('Secure');
+    }
+    document.cookie = parts.join('; ');
+  }
+  function clearSuccessQuery(formId) {
+    if (!formId || typeof URL !== 'function' || !window.history || typeof window.history.replaceState !== 'function') {
+      return;
+    }
+    try {
+      var url = new URL(window.location.href);
+      if (url.searchParams.get('eforms_success') === formId) {
+        url.searchParams.delete('eforms_success');
+        window.history.replaceState(null, document.title, url.toString());
+      }
+    } catch (e) {
+      /* noop */
+    }
+  }
+  function handleSuccessPlaceholders() {
+    var nodes = document.querySelectorAll('.eforms-success-pending');
+    if (!nodes.length) { return; }
+    nodes.forEach(function (node) {
+      var formId = node.getAttribute('data-form-id');
+      var submissionId = node.getAttribute('data-submission-id');
+      var verifyUrl = node.getAttribute('data-verify-url');
+      var message = node.getAttribute('data-message') || 'Success';
+      var cookieName = node.getAttribute('data-cookie-name');
+      var cookiePath = node.getAttribute('data-cookie-path') || '/';
+      if (!formId || !submissionId || !verifyUrl) {
+        node.parentNode && node.parentNode.removeChild(node);
+        return;
+      }
+      var url = verifyUrl + '?f=' + encodeURIComponent(formId) + '&s=' + encodeURIComponent(submissionId);
+      fetch(url, { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
+        .then(function (resp) { if (!resp.ok) { return { ok: false }; } return resp.json().catch(function () { return { ok: false }; }); })
+        .then(function (body) {
+          if (body && body.ok) {
+            node.classList.remove('eforms-success-pending');
+            node.classList.add('eforms-success');
+            node.textContent = message;
+            expireCookie(cookieName, cookiePath);
+            clearSuccessQuery(formId);
+          } else {
+            node.parentNode && node.parentNode.removeChild(node);
+          }
+        })
+        .catch(function () {
+          node.parentNode && node.parentNode.removeChild(node);
+        });
+    });
+  }
   onReady(function () {
     document.querySelectorAll('input[name="js_ok"]').forEach(function (el) {
       try { el.value = '1'; } catch(_){}
@@ -31,5 +89,6 @@
         }
       });
     });
+    handleSuccessPlaceholders();
   });
 })();

--- a/src/Config.php
+++ b/src/Config.php
@@ -56,6 +56,7 @@ class Config
         $sec['honeypot_response'] = in_array($sec['honeypot_response'], ['stealth_success','hard_fail'], true) ? $sec['honeypot_response'] : $defaults['security']['honeypot_response'];
         $sec['cookie_missing_policy'] = in_array($sec['cookie_missing_policy'], ['off','soft','hard','challenge'], true) ? $sec['cookie_missing_policy'] : $defaults['security']['cookie_missing_policy'];
         $sec['cookie_mode_slots_enabled'] = (bool)($sec['cookie_mode_slots_enabled'] ?? false);
+        $sec['success_ticket_ttl_seconds'] = self::clampInt($sec['success_ticket_ttl_seconds'] ?? $defaults['security']['success_ticket_ttl_seconds'], 30, 3600);
         $slotsAllowed = $sec['cookie_mode_slots_allowed'] ?? [];
         if (!is_array($slotsAllowed)) {
             $slotsAllowed = [];
@@ -144,6 +145,7 @@ class Config
                 'token_ledger' => ['enable' => true],
                 'token_ttl_seconds' => 600,
                 'submission_token' => ['required' => true],
+                'success_ticket_ttl_seconds' => 300,
                 'origin_mode' => 'soft',
                 'origin_missing_soft' => false,
                 'origin_missing_hard' => false,

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -80,6 +80,9 @@ class BaseTestCase extends TestCase
         global $TEST_FILTERS;
         $TEST_FILTERS = $this->filtersSnapshot;
         register_test_env_filter();
+        if (class_exists('EForms\\Rendering\\Renderer')) {
+            \EForms\Rendering\Renderer::resetSuccessState();
+        }
         Config::resetForTests();
         Logging::resetForTests();
         parent::tearDown();

--- a/tests/integration/upload_fail_cleanup_runner.php
+++ b/tests/integration/upload_fail_cleanup_runner.php
@@ -39,7 +39,7 @@ $_POST = [
 
 register_shutdown_function(function () use ($tmp): void {
     $files = array_filter(glob(__DIR__ . '/../tmp/uploads/eforms-private/*/*') ?: [], function ($f) {
-        return !str_contains($f, '/ledger/') && !str_contains($f, '/throttle/') && !str_contains($f, '/eid_minted/');
+        return !str_contains($f, '/ledger/') && !str_contains($f, '/throttle/') && !str_contains($f, '/eid_minted/') && !str_contains($f, '/success/');
     });
     file_put_contents(__DIR__ . '/../tmp/upload_fail_cleanup.txt', $files ? implode("\n", $files) : '');
     @unlink($tmp);

--- a/tests/unit/SecurityChecksTest.php
+++ b/tests/unit/SecurityChecksTest.php
@@ -61,5 +61,24 @@ final class SecurityChecksTest extends BaseTestCase
         $log = (string) file_get_contents($this->logFile);
         $this->assertStringContainsString('EFORMS_ERR_FORM_AGE', $log);
     }
+
+    public function testSuccessTicketRoundTrip(): void
+    {
+        set_config([]);
+        $formId = 'contact_us';
+        $submissionId = 'i-123e4567-e89b-12d3-a456-426614174000:s2';
+        $stored = Security::successTicketStore($formId, $submissionId);
+        $this->assertTrue($stored);
+        $base = __DIR__ . '/../tmp/uploads/eforms-private/success/' . $formId;
+        $hash = hash('sha256', $submissionId);
+        $expectedDir = $base . '/' . substr($hash, 0, 2) . '/i-123e4567-e89b-12d3-a456-426614174000';
+        $expectedFile = $expectedDir . '/s2.json';
+        $this->assertFileExists($expectedFile);
+        $result = Security::successTicketConsume($formId, $submissionId);
+        $this->assertTrue($result['ok']);
+        $this->assertFileDoesNotExist($expectedFile);
+        $result2 = Security::successTicketConsume($formId, $submissionId);
+        $this->assertFalse($result2['ok']);
+    }
 }
 

--- a/tests/unit/SuccessAntiSpoofTest.php
+++ b/tests/unit/SuccessAntiSpoofTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use EForms\Config;
+use EForms\Security\Security;
 
 final class SuccessAntiSpoofTest extends BaseTestCase
 {
@@ -33,10 +34,11 @@ final class SuccessAntiSpoofTest extends BaseTestCase
         $getSnapshot = $_GET;
         try {
             $_GET = [];
-            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:subm'];
+            $_COOKIE = ['eforms_s_contact_us' => 'subm'];
             $fm = new \EForms\Rendering\FormRenderer();
             $html = $fm->render('contact_us');
-            $this->assertStringNotContainsString('Thanks! We got your message.', $html);
+            $this->assertStringContainsString('<form', $html);
+            $this->assertStringNotContainsString('eforms-success-pending', $html);
         } finally {
             $_GET = $getSnapshot;
         }
@@ -48,7 +50,7 @@ final class SuccessAntiSpoofTest extends BaseTestCase
         $getSnapshot = $_GET;
         try {
             $_GET = ['eforms_success' => 'contact_us'];
-            $_COOKIE = ['eforms_s_contact_us' => 'other:subm'];
+            $_COOKIE = ['eforms_s_contact_us' => 'other-subm'];
             $fm = new \EForms\Rendering\FormRenderer();
             $html = $fm->render('contact_us');
             $this->assertSame('', $html);
@@ -62,11 +64,13 @@ final class SuccessAntiSpoofTest extends BaseTestCase
         header_remove();
         $getSnapshot = $_GET;
         try {
+            Security::successTicketStore('contact_us', 'subm');
             $_GET = ['eforms_success' => 'contact_us'];
-            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:subm'];
+            $_COOKIE = ['eforms_s_contact_us' => 'subm'];
             $fm = new \EForms\Rendering\FormRenderer();
             $html = $fm->render('contact_us');
-            $this->assertStringContainsString('Thanks! We got your message.', $html);
+            $this->assertStringContainsString('eforms-success-pending', $html);
+            $this->assertStringContainsString('data-submission-id="subm"', $html);
         } finally {
             $_GET = $getSnapshot;
         }
@@ -77,11 +81,12 @@ final class SuccessAntiSpoofTest extends BaseTestCase
         header_remove();
         $getSnapshot = $_GET;
         try {
+            Security::successTicketStore('contact_us', 'subm');
             $_GET = ['eforms_success' => 'contact_us'];
-            $_COOKIE = ['eforms_s_contact_us' => 'contact_us:subm'];
+            $_COOKIE = ['eforms_s_contact_us' => 'subm'];
             $fm = new \EForms\Rendering\FormRenderer();
             $html1 = $fm->render('contact_us');
-            $this->assertStringContainsString('Thanks! We got your message.', $html1);
+            $this->assertStringContainsString('eforms-success-pending', $html1);
             $fm2 = new \EForms\Rendering\FormRenderer();
             $html2 = $fm2->render('contact_us');
             $this->assertSame('', $html2);


### PR DESCRIPTION
## Summary
- add server-side success ticket storage helpers, filesystem-safe ledger paths, and a /eforms/success-verify endpoint
- update renderer and frontend script to verify inline success banners via success tickets and reset success state between renders
- expose a configurable success ticket TTL and extend tests/cleanup helpers to cover the new verification flow

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cb1cd099d0832d9ddef32f5d881ac1