### PR TITLE
Document submission and slot tokens

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -485,7 +485,7 @@ electronic_forms - Spec
   - Reject arrays where a scalar is expected in headers/subject fields.
   - Reply-To from a validated email field (email.reply_to_field).
   - deliverability: recommend SMTP with SPF/DKIM/DMARC
-  - template tokens: {{field.key}}, {{submitted_at}}, {{ip}}, {{form_id}}
+  - template tokens: {{field.key}}, {{submitted_at}}, {{ip}}, {{form_id}}, {{submission_id}}, {{slot}} (emitted only for cookie-mode submissions where slots are configured and successfully bound)
   - If an upload field key appears in include_fields, render value as comma-separated list of original_name_safe in the email body (attachments separate).
   - attachments: only for fields with email_attach=true; enforce uploads.max_email_bytes and email.upload_max_attachments; summarize overflow in body before send.
   - Enforce size/count before PHPMailer->send() to avoid SMTP 552.


### PR DESCRIPTION
## Summary
- note that email templates can now use submission and slot tokens alongside existing values

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68cece44fe10832d81dfeb4a2182f9e2