### PR TITLE
Reject colon in template field keys

### DIFF
--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -185,7 +185,7 @@ class TemplateValidator
                 }
             }
             $key = $f['key'] ?? null;
-            if (!is_string($key) || !preg_match('/^[a-z0-9_:-]{1,64}$/', $key)) {
+            if (!is_string($key) || !preg_match('/^[a-z0-9_-]{1,64}$/', $key)) {
                 $errors[] = ['code'=>self::EFORMS_ERR_SCHEMA_TYPE,'path'=>$path.'key'];
                 continue;
             }

--- a/tests/unit/TemplateValidatorTest.php
+++ b/tests/unit/TemplateValidatorTest.php
@@ -65,6 +65,15 @@ class TemplateValidatorTest extends BaseTestCase
         $this->assertContains(TemplateValidator::EFORMS_ERR_TYPE, $codes);
     }
 
+    public function testFieldKeyRejectsColon(): void
+    {
+        $tpl = $this->baseTpl();
+        $tpl['fields'][0]['key'] = 'name:extra';
+        $res = TemplateValidator::preflight($tpl);
+        $codes = array_column($res['errors'], 'code');
+        $this->assertContains(TemplateValidator::EFORMS_ERR_SCHEMA_TYPE, $codes);
+    }
+
     public function testDuplicateFieldKey(): void
     {
         $tpl = $this->baseTpl();


### PR DESCRIPTION
## Summary
- tighten the template field key validation regex to disallow colons in accordance with the latest spec
- add a regression test that asserts colonized keys return EFORMS_ERR_SCHEMA_TYPE

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cf30a6e148832d9393643139dfe210