### PR TITLE
Reuse minted cookie records during prime and add coverage

### DIFF
--- a/tests/integration/test_prime_cookie_remint.php
+++ b/tests/integration/test_prime_cookie_remint.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../bootstrap.php';
+
+global $TEST_QUERY_VARS, $TEST_ARTIFACTS;
+
+$TEST_QUERY_VARS['eforms_prime'] = 1;
+$cookieName = 'eforms_eid_contact_us';
+$headersPath = $TEST_ARTIFACTS['headers_file'];
+$uploadsBase = dirname(__DIR__) . '/tmp/uploads/eforms-private';
+$ttl = (int) \EForms\Config::get('security.token_ttl_seconds', 600);
+$issuedAt = time() - 5;
+$eid = 'i-00000000-0000-4000-8000-0000000cafe0';
+set_eid_cookie('contact_us', $eid, $issuedAt, $ttl);
+$hash = hash('sha256', $eid);
+$mintPath = $uploadsBase . '/eid_minted/contact_us/' . substr($hash, 0, 2) . '/' . $eid . '.json';
+$mintBefore = [];
+if (is_file($mintPath)) {
+    $raw = file_get_contents($mintPath);
+    if ($raw !== false) {
+        $decoded = json_decode($raw, true);
+        if (is_array($decoded)) {
+            $mintBefore = $decoded;
+        }
+    }
+}
+
+register_shutdown_function(function () use ($mintBefore, $mintPath, $headersPath, $cookieName, $TEST_ARTIFACTS): void {
+    $mintAfter = [];
+    if (is_file($mintPath)) {
+        $raw = file_get_contents($mintPath);
+        if ($raw !== false) {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded)) {
+                $mintAfter = $decoded;
+            }
+        }
+    }
+    $issuedBefore = isset($mintBefore['issued_at']) ? (int) $mintBefore['issued_at'] : 0;
+    $issuedAfter = isset($mintAfter['issued_at']) ? (int) $mintAfter['issued_at'] : 0;
+    $expiresBefore = isset($mintBefore['expires']) ? (int) $mintBefore['expires'] : 0;
+    $expiresAfter = isset($mintAfter['expires']) ? (int) $mintAfter['expires'] : 0;
+    $hasMintedTimestamps = isset($mintBefore['issued_at'], $mintBefore['expires'], $mintAfter['issued_at'], $mintAfter['expires']);
+    $timestampsEqual = ($hasMintedTimestamps && $issuedBefore === $issuedAfter && $expiresBefore === $expiresAfter) ? '1' : '0';
+    $headersAfter = (string) file_get_contents($headersPath);
+    $secondSetCookie = str_contains($headersAfter, 'Set-Cookie') ? '1' : '0';
+    $resultLines = [
+        'timestamps_equal=' . $timestampsEqual,
+        'second_set_cookie=' . $secondSetCookie,
+        'eid=' . ($mintAfter['eid'] ?? ''),
+        'issued_at_before=' . $issuedBefore,
+        'issued_at_after=' . $issuedAfter,
+        'expires_before=' . $expiresBefore,
+        'expires_after=' . $expiresAfter,
+    ];
+    file_put_contents($TEST_ARTIFACTS['dir'] . '/prime_remint.txt', implode("\n", $resultLines) . "\n");
+    unset($_COOKIE[$cookieName]);
+});
+
+$getSnapshot = $_GET;
+$_GET['f'] = 'contact_us';
+
+do_action('template_redirect');
+
+$_GET = $getSnapshot;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -100,6 +100,13 @@ assert_grep tmp/headers.txt 'Set-Cookie: eforms_eid_contact_us=' || ok=1
 assert_grep tmp/headers.txt 'Max-Age=' || ok=1
 record_result "prime sets max-age" $ok
 
+# Prime reuse within TTL keeps timestamps
+run_test test_prime_cookie_remint
+ok=0
+assert_grep tmp/prime_remint.txt '^timestamps_equal=1$' || ok=1
+assert_grep tmp/prime_remint.txt '^second_set_cookie=0$' || ok=1
+record_result "prime reuse keeps ttl" $ok
+
 # 1) Submit route: 405
 run_test test_submit_405
 ok=0


### PR DESCRIPTION
## Summary
- update the /eforms/prime handler to reuse existing minted cookie records, keep timestamps stable, and atomically merge slot data
- extend the test helpers to emit slot metadata in minted cookie fixtures
- add an integration test that confirms re-priming within the TTL preserves the minted record and avoids a new Set-Cookie header

## Testing
- tests/run.sh

------
https://chatgpt.com/codex/tasks/task_e_68d09476ba34832d8bf6223eab4dc147