### PR TITLE
Align config spec with code defaults and add parity test

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -5,6 +5,162 @@ namespace EForms;
 
 class Config
 {
+    public const DEFAULTS = [
+        'security' => [
+            'token_ledger' => ['enable' => true],
+            'token_ttl_seconds' => 600,
+            'submission_token' => ['required' => true],
+            'success_ticket_ttl_seconds' => 300,
+            'origin_mode' => 'soft',
+            'origin_missing_soft' => false,
+            'origin_missing_hard' => false,
+            'min_fill_seconds' => 4,
+            'max_form_age_seconds' => 600,
+            'js_hard_mode' => false,
+            'max_post_bytes' => 25000000,
+            'ua_maxlen' => 256,
+            'honeypot_response' => 'stealth_success',
+            'cookie_missing_policy' => 'soft',
+            'cookie_mode_slots_enabled' => false,
+            'cookie_mode_slots_allowed' => [],
+        ],
+        'spam' => [
+            'soft_fail_threshold' => 2,
+        ],
+        'throttle' => [
+            'enable' => false,
+            'per_ip' => [
+                'max_per_minute' => 5,
+                'cooldown_seconds' => 60,
+                'hard_multiplier' => 3.0,
+            ],
+        ],
+        'challenge' => [
+            'mode' => 'off',
+            'provider' => 'turnstile',
+            'turnstile' => ['site_key' => null, 'secret_key' => null],
+            'hcaptcha' => ['site_key' => null, 'secret_key' => null],
+            'recaptcha' => ['site_key' => null, 'secret_key' => null],
+            'http_timeout_seconds' => 2,
+        ],
+        'html5' => [
+            'client_validation' => false,
+        ],
+        'email' => [
+            'policy' => 'strict',
+            'smtp' => [
+                'timeout_seconds' => 10,
+                'max_retries' => 2,
+                'retry_backoff_seconds' => 2,
+            ],
+            'html' => false,
+            'from_address' => '',
+            'from_name' => '',
+            'reply_to_field' => '',
+            'envelope_sender' => '',
+            'dkim' => [
+                'domain' => '',
+                'selector' => '',
+                'private_key_path' => '',
+                'pass_phrase' => '',
+            ],
+            'disable_send' => false,
+            'staging_redirect_to' => null,
+            'suspect_subject_tag' => '[SUSPECT]',
+            'upload_max_attachments' => 5,
+            'debug' => [
+                'enable' => false,
+                'max_bytes' => 8192,
+            ],
+        ],
+        'logging' => [
+            'mode' => 'minimal',
+            'level' => 0,
+            'headers' => false,
+            'pii' => false,
+            'on_failure_canonical' => false,
+            'file_max_size' => 5000000,
+            'retention_days' => 30,
+            'fail2ban' => [
+                'enable' => false,
+                'target' => 'error_log',
+                'file' => null,
+                'file_max_size' => 5000000,
+                'retention_days' => 30,
+            ],
+        ],
+        'privacy' => [
+            'ip_mode' => 'masked',
+            'ip_salt' => '',
+            'client_ip_header' => '',
+            'trusted_proxies' => [],
+        ],
+        'assets' => [
+            'css_disable' => false,
+        ],
+        'install' => [
+            'min_php' => '8.0',
+            'min_wp' => '5.8',
+            'uninstall' => [
+                'purge_uploads' => false,
+                'purge_logs' => false,
+            ],
+        ],
+        'validation' => [
+            'max_fields_per_form' => 150,
+            'max_options_per_group' => 100,
+            'max_items_per_multivalue' => 50,
+            'textarea_html_max_bytes' => 32768,
+        ],
+        'uploads' => [
+            'enable' => true,
+            'dir' => null,
+            'allowed_tokens' => ['image', 'pdf'],
+            'allowed_mime' => [],
+            'allowed_ext' => [],
+            'max_file_bytes' => 5000000,
+            'max_files' => 10,
+            'total_field_bytes' => 10000000,
+            'total_request_bytes' => 20000000,
+            'max_email_bytes' => 10000000,
+            'delete_after_send' => true,
+            'retention_seconds' => 86400,
+            'max_image_px' => 50000000,
+            'original_maxlen' => 100,
+            'transliterate' => true,
+            'max_relative_path_chars' => 180,
+        ],
+    ];
+
+    public const RANGE_CLAMPS = [
+        'security.min_fill_seconds' => ['type' => 'int', 'min' => 0, 'max' => 60],
+        'security.token_ttl_seconds' => ['type' => 'int', 'min' => 1, 'max' => 86400],
+        'security.max_form_age_seconds' => ['type' => 'int', 'min' => 1, 'max' => 86400],
+        'security.success_ticket_ttl_seconds' => ['type' => 'int', 'min' => 30, 'max' => 3600],
+        'challenge.http_timeout_seconds' => ['type' => 'int', 'min' => 1, 'max' => 5],
+        'throttle.per_ip.max_per_minute' => ['type' => 'int', 'min' => 1, 'max' => 120],
+        'throttle.per_ip.cooldown_seconds' => ['type' => 'int', 'min' => 10, 'max' => 600],
+        'throttle.per_ip.hard_multiplier' => ['type' => 'float', 'min' => 1.5, 'max' => 10.0],
+        'logging.level' => ['type' => 'int', 'min' => 0, 'max' => 2],
+        'logging.retention_days' => ['type' => 'int', 'min' => 1, 'max' => 365],
+        'logging.fail2ban.retention_days' => ['type' => 'int', 'min' => 1, 'max' => 365],
+        'validation.max_fields_per_form' => ['type' => 'int', 'min' => 1, 'max' => 1000],
+        'validation.max_options_per_group' => ['type' => 'int', 'min' => 1, 'max' => 1000],
+        'validation.max_items_per_multivalue' => ['type' => 'int', 'min' => 1, 'max' => 1000],
+        'validation.textarea_html_max_bytes' => ['type' => 'int', 'min' => 1, 'max' => 1000000],
+    ];
+
+    public const ENUMS = [
+        'security.origin_mode' => ['off', 'soft', 'hard'],
+        'security.honeypot_response' => ['stealth_success', 'hard_fail'],
+        'security.cookie_missing_policy' => ['off', 'soft', 'hard', 'challenge'],
+        'challenge.mode' => ['off', 'auto', 'always'],
+        'challenge.provider' => ['turnstile', 'hcaptcha', 'recaptcha'],
+        'logging.mode' => ['off', 'minimal', 'jsonl'],
+        'logging.fail2ban.target' => ['error_log', 'syslog', 'file'],
+        'privacy.ip_mode' => ['none', 'masked', 'hash', 'full'],
+    ];
+
     private static array $data = [];
     private static bool $bootstrapped = false;
 
@@ -44,19 +200,40 @@ class Config
 
         // security
         $sec =& $cfg['security'];
-        $sec['origin_mode'] = in_array($sec['origin_mode'], ['off','soft','hard'], true) ? $sec['origin_mode'] : $defaults['security']['origin_mode'];
+        $sec['origin_mode'] = self::sanitizeEnum(
+            'security.origin_mode',
+            $sec['origin_mode'],
+            self::ENUMS['security.origin_mode'],
+            $defaults['security']['origin_mode']
+        );
         $sec['origin_missing_soft'] = (bool)$sec['origin_missing_soft'];
         $sec['origin_missing_hard'] = (bool)$sec['origin_missing_hard'];
-        $sec['min_fill_seconds'] = self::clampInt($sec['min_fill_seconds'], 0, 60);
-        $sec['token_ttl_seconds'] = self::clampInt($sec['token_ttl_seconds'], 1, 86400);
-        $sec['max_form_age_seconds'] = self::clampInt($sec['max_form_age_seconds'] ?? $sec['token_ttl_seconds'], 1, 86400);
+        $sec['min_fill_seconds'] = self::clampRangeValue('security.min_fill_seconds', $sec['min_fill_seconds']);
+        $sec['token_ttl_seconds'] = self::clampRangeValue('security.token_ttl_seconds', $sec['token_ttl_seconds']);
+        $sec['max_form_age_seconds'] = self::clampRangeValue(
+            'security.max_form_age_seconds',
+            $sec['max_form_age_seconds'] ?? $sec['token_ttl_seconds']
+        );
         $sec['js_hard_mode'] = (bool)$sec['js_hard_mode'];
         $sec['max_post_bytes'] = self::clampInt($sec['max_post_bytes'], 0, PHP_INT_MAX);
         $sec['ua_maxlen'] = self::clampInt($sec['ua_maxlen'], 0, 10000);
-        $sec['honeypot_response'] = in_array($sec['honeypot_response'], ['stealth_success','hard_fail'], true) ? $sec['honeypot_response'] : $defaults['security']['honeypot_response'];
-        $sec['cookie_missing_policy'] = in_array($sec['cookie_missing_policy'], ['off','soft','hard','challenge'], true) ? $sec['cookie_missing_policy'] : $defaults['security']['cookie_missing_policy'];
+        $sec['honeypot_response'] = self::sanitizeEnum(
+            'security.honeypot_response',
+            $sec['honeypot_response'],
+            self::ENUMS['security.honeypot_response'],
+            $defaults['security']['honeypot_response']
+        );
+        $sec['cookie_missing_policy'] = self::sanitizeEnum(
+            'security.cookie_missing_policy',
+            $sec['cookie_missing_policy'],
+            self::ENUMS['security.cookie_missing_policy'],
+            $defaults['security']['cookie_missing_policy']
+        );
         $sec['cookie_mode_slots_enabled'] = (bool)($sec['cookie_mode_slots_enabled'] ?? false);
-        $sec['success_ticket_ttl_seconds'] = self::clampInt($sec['success_ticket_ttl_seconds'] ?? $defaults['security']['success_ticket_ttl_seconds'], 30, 3600);
+        $sec['success_ticket_ttl_seconds'] = self::clampRangeValue(
+            'security.success_ticket_ttl_seconds',
+            $sec['success_ticket_ttl_seconds'] ?? $defaults['security']['success_ticket_ttl_seconds']
+        );
         $slotsAllowed = $sec['cookie_mode_slots_allowed'] ?? [];
         if (!is_array($slotsAllowed)) {
             $slotsAllowed = [];
@@ -77,9 +254,19 @@ class Config
 
         // challenge
         $ch =& $cfg['challenge'];
-        $ch['mode'] = in_array($ch['mode'], ['off','auto','always'], true) ? $ch['mode'] : $defaults['challenge']['mode'];
-        $ch['provider'] = in_array($ch['provider'], ['turnstile','hcaptcha','recaptcha'], true) ? $ch['provider'] : $defaults['challenge']['provider'];
-        $ch['http_timeout_seconds'] = self::clampInt($ch['http_timeout_seconds'], 1, 5);
+        $ch['mode'] = self::sanitizeEnum(
+            'challenge.mode',
+            $ch['mode'],
+            self::ENUMS['challenge.mode'],
+            $defaults['challenge']['mode']
+        );
+        $ch['provider'] = self::sanitizeEnum(
+            'challenge.provider',
+            $ch['provider'],
+            self::ENUMS['challenge.provider'],
+            $defaults['challenge']['provider']
+        );
+        $ch['http_timeout_seconds'] = self::clampRangeValue('challenge.http_timeout_seconds', $ch['http_timeout_seconds']);
 
         // email
         $em =& $cfg['email'];
@@ -87,47 +274,88 @@ class Config
 
         // privacy
         $prv =& $cfg['privacy'];
-        $prv['ip_mode'] = in_array($prv['ip_mode'], ['none','masked','hash','full'], true) ? $prv['ip_mode'] : $defaults['privacy']['ip_mode'];
+        $prv['ip_mode'] = self::sanitizeEnum(
+            'privacy.ip_mode',
+            $prv['ip_mode'],
+            self::ENUMS['privacy.ip_mode'],
+            $defaults['privacy']['ip_mode']
+        );
 
         // logging
-        $cfg['logging']['mode'] = in_array($cfg['logging']['mode'], ['off','minimal','jsonl'], true) ? $cfg['logging']['mode'] : $defaults['logging']['mode'];
-        $cfg['logging']['level'] = self::clampInt($cfg['logging']['level'], 0, 2);
+        $cfg['logging']['mode'] = self::sanitizeEnum(
+            'logging.mode',
+            $cfg['logging']['mode'],
+            self::ENUMS['logging.mode'],
+            $defaults['logging']['mode']
+        );
+        $cfg['logging']['level'] = self::clampRangeValue('logging.level', $cfg['logging']['level']);
         $cfg['logging']['headers'] = (bool)$cfg['logging']['headers'];
         $cfg['logging']['pii'] = (bool)$cfg['logging']['pii'];
         $cfg['logging']['on_failure_canonical'] = (bool)$cfg['logging']['on_failure_canonical'];
         $cfg['logging']['file_max_size'] = self::clampInt($cfg['logging']['file_max_size'], 0, PHP_INT_MAX);
-        $cfg['logging']['retention_days'] = self::clampInt($cfg['logging']['retention_days'], 1, 365);
+        $cfg['logging']['retention_days'] = self::clampRangeValue('logging.retention_days', $cfg['logging']['retention_days']);
         $f2b =& $cfg['logging']['fail2ban'];
         $f2b['enable'] = (bool)($f2b['enable'] ?? false);
-        $f2b['target'] = in_array($f2b['target'], ['error_log','syslog','file'], true) ? $f2b['target'] : 'error_log';
+        $f2b['target'] = self::sanitizeEnum(
+            'logging.fail2ban.target',
+            $f2b['target'],
+            self::ENUMS['logging.fail2ban.target'],
+            $defaults['logging']['fail2ban']['target']
+        );
         $f2b['file'] = is_string($f2b['file']) ? $f2b['file'] : null;
         $f2b['file_max_size'] = self::clampInt(
             $f2b['file_max_size'] ?? $cfg['logging']['file_max_size'],
             0,
             PHP_INT_MAX
         );
-        $f2b['retention_days'] = self::clampInt(
-            $f2b['retention_days'] ?? $cfg['logging']['retention_days'],
-            1,
-            365
+        $f2b['retention_days'] = self::clampRangeValue(
+            'logging.fail2ban.retention_days',
+            $f2b['retention_days'] ?? $cfg['logging']['retention_days']
         );
 
         // throttle
         $cfg['throttle']['enable'] = (bool)($cfg['throttle']['enable'] ?? false);
         $thr =& $cfg['throttle']['per_ip'];
-        $thr['max_per_minute'] = self::clampInt($thr['max_per_minute'] ?? 5, 1, 120);
-        $thr['cooldown_seconds'] = self::clampInt($thr['cooldown_seconds'] ?? 60, 10, 600);
-        $thr['hard_multiplier'] = (float)($thr['hard_multiplier'] ?? 3.0);
-        if ($thr['hard_multiplier'] < 1.5) $thr['hard_multiplier'] = 1.5;
-        if ($thr['hard_multiplier'] > 10.0) $thr['hard_multiplier'] = 10.0;
+        $thr['max_per_minute'] = self::clampRangeValue(
+            'throttle.per_ip.max_per_minute',
+            $thr['max_per_minute'] ?? self::DEFAULTS['throttle']['per_ip']['max_per_minute']
+        );
+        $thr['cooldown_seconds'] = self::clampRangeValue(
+            'throttle.per_ip.cooldown_seconds',
+            $thr['cooldown_seconds'] ?? self::DEFAULTS['throttle']['per_ip']['cooldown_seconds']
+        );
+        $thr['hard_multiplier'] = self::clampRangeValue(
+            'throttle.per_ip.hard_multiplier',
+            $thr['hard_multiplier'] ?? self::DEFAULTS['throttle']['per_ip']['hard_multiplier']
+        );
 
         // validation
-        $cfg['validation']['max_fields_per_form'] = self::clampInt($cfg['validation']['max_fields_per_form'], 1, 1000);
-        $cfg['validation']['max_options_per_group'] = self::clampInt($cfg['validation']['max_options_per_group'], 1, 1000);
-        $cfg['validation']['max_items_per_multivalue'] = self::clampInt($cfg['validation']['max_items_per_multivalue'], 1, 1000);
-        $cfg['validation']['textarea_html_max_bytes'] = self::clampInt($cfg['validation']['textarea_html_max_bytes'], 1, 1000000);
+        $cfg['validation']['max_fields_per_form'] = self::clampRangeValue('validation.max_fields_per_form', $cfg['validation']['max_fields_per_form']);
+        $cfg['validation']['max_options_per_group'] = self::clampRangeValue('validation.max_options_per_group', $cfg['validation']['max_options_per_group']);
+        $cfg['validation']['max_items_per_multivalue'] = self::clampRangeValue('validation.max_items_per_multivalue', $cfg['validation']['max_items_per_multivalue']);
+        $cfg['validation']['textarea_html_max_bytes'] = self::clampRangeValue('validation.textarea_html_max_bytes', $cfg['validation']['textarea_html_max_bytes']);
 
         return $cfg;
+    }
+
+    private static function sanitizeEnum(string $path, $value, array $allowed, $default)
+    {
+        return in_array($value, $allowed, true) ? $value : $default;
+    }
+
+    private static function clampRangeValue(string $path, $value)
+    {
+        if (!isset(self::RANGE_CLAMPS[$path])) {
+            throw new \InvalidArgumentException('Unknown clamp path: ' . $path);
+        }
+        $meta = self::RANGE_CLAMPS[$path];
+        if ($meta['type'] === 'int') {
+            return self::clampInt($value, $meta['min'], $meta['max']);
+        }
+        if ($meta['type'] === 'float') {
+            return self::clampFloat($value, $meta['min'], $meta['max']);
+        }
+        throw new \InvalidArgumentException('Unsupported clamp type for: ' . $path);
     }
 
     private static function clampInt($v, int $min, int $max): int
@@ -138,134 +366,24 @@ class Config
         return $n;
     }
 
+    private static function clampFloat($v, float $min, float $max): float
+    {
+        $n = (float)$v;
+        if ($n < $min) $n = $min;
+        if ($n > $max) $n = $max;
+        return $n;
+    }
+
     private static function defaults(): array
     {
-        return [
-            'security' => [
-                'token_ledger' => ['enable' => true],
-                'token_ttl_seconds' => 600,
-                'submission_token' => ['required' => true],
-                'success_ticket_ttl_seconds' => 300,
-                'origin_mode' => 'soft',
-                'origin_missing_soft' => false,
-                'origin_missing_hard' => false,
-                'min_fill_seconds' => 4,
-                'max_form_age_seconds' => 600,
-                'js_hard_mode' => false,
-                'max_post_bytes' => 25000000,
-                'ua_maxlen' => 256,
-                'honeypot_response' => 'stealth_success',
-                'cookie_missing_policy' => 'soft',
-                'cookie_mode_slots_enabled' => false,
-                'cookie_mode_slots_allowed' => [],
-            ],
-            'spam' => [
-                'soft_fail_threshold' => 2,
-            ],
-            'throttle' => [
-                'enable' => false,
-                'per_ip' => [
-                    'max_per_minute' => 5,
-                    'cooldown_seconds' => 60,
-                    'hard_multiplier' => 3.0,
+        return array_replace_recursive(
+            self::DEFAULTS,
+            [
+                'uploads' => [
+                    'dir' => self::defaultUploadsDir(),
                 ],
-            ],
-            'challenge' => [
-                'mode' => 'off',
-                'provider' => 'turnstile',
-                'turnstile' => ['site_key' => null, 'secret_key' => null],
-                'hcaptcha' => ['site_key' => null, 'secret_key' => null],
-                'recaptcha' => ['site_key' => null, 'secret_key' => null],
-                'http_timeout_seconds' => 2,
-            ],
-            'html5' => [
-                'client_validation' => false,
-            ],
-            'email' => [
-                'policy' => 'strict',
-                'smtp' => [
-                    'timeout_seconds' => 10,
-                    'max_retries' => 2,
-                    'retry_backoff_seconds' => 2,
-                ],
-                'html' => false,
-                'from_address' => '',
-                'from_name' => '',
-                'reply_to_field' => '',
-                'envelope_sender' => '',
-                'dkim' => [
-                    'domain' => '',
-                    'selector' => '',
-                    'private_key_path' => '',
-                    'pass_phrase' => '',
-                ],
-                'disable_send' => false,
-                'staging_redirect_to' => null,
-                'suspect_subject_tag' => '[SUSPECT]',
-                'upload_max_attachments' => 5,
-                'debug' => [
-                    'enable' => false,
-                    'max_bytes' => 8192,
-                ],
-            ],
-            'logging' => [
-                'mode' => 'minimal',
-                'level' => 0,
-                'headers' => false,
-                'pii' => false,
-                'on_failure_canonical' => false,
-                'file_max_size' => 5000000,
-                'retention_days' => 30,
-                'fail2ban' => [
-                    'enable' => false,
-                    'target' => 'error_log',
-                    'file' => null,
-                    'file_max_size' => 5000000,
-                    'retention_days' => 30,
-                ],
-            ],
-            'privacy' => [
-                'ip_mode' => 'masked',
-                'ip_salt' => '',
-                'client_ip_header' => '',
-                'trusted_proxies' => [],
-            ],
-            'assets' => [
-                'css_disable' => false,
-            ],
-            'install' => [
-                'min_php' => '8.0',
-                'min_wp' => '5.8',
-                'uninstall' => [
-                    'purge_uploads' => false,
-                    'purge_logs' => false,
-                ],
-            ],
-            'validation' => [
-                'max_fields_per_form' => 150,
-                'max_options_per_group' => 100,
-                'max_items_per_multivalue' => 50,
-                'textarea_html_max_bytes' => 32768,
-            ],
-            'uploads' => [
-                'enable' => true,
-                'dir' => self::defaultUploadsDir(),
-                'allowed_tokens' => ['image', 'pdf'],
-                'allowed_mime' => [],
-                'allowed_ext' => [],
-                'max_file_bytes' => 5000000,
-                'max_files' => 10,
-                'total_field_bytes' => 10000000,
-                'total_request_bytes' => 20000000,
-                'max_email_bytes' => 10000000,
-                'delete_after_send' => true,
-                'retention_seconds' => 86400,
-                'max_image_px' => 50000000,
-                'original_maxlen' => 100,
-                'transliterate' => true,
-                'max_relative_path_chars' => 180,
-            ],
-        ];
+            ]
+        );
     }
 
     private static function defaultUploadsDir(): string

--- a/tests/unit/SpecConfigParityTest.php
+++ b/tests/unit/SpecConfigParityTest.php
@@ -1,0 +1,176 @@
+<?php
+declare(strict_types=1);
+
+use EForms\Config;
+
+final class SpecConfigParityTest extends BaseTestCase
+{
+    public function testSpecKeysAreSubsetOfDefaultsAndConstraintsMatch(): void
+    {
+        $specPath = dirname(__DIR__) . '/../docs/electronic_forms_SPEC.md';
+        $this->assertFileExists($specPath, 'Spec file not found');
+        $spec = file_get_contents($specPath);
+        $this->assertNotFalse($spec, 'Unable to read spec file');
+
+        $tableMeta = $this->parseNormativeConstraintsTable($spec);
+        $this->assertNotEmpty($tableMeta, 'Failed to parse normative constraints table');
+
+        $defaults = Config::DEFAULTS;
+
+        foreach ($tableMeta as $key => $meta) {
+            $this->assertTrue(
+                $this->arrayPathExists($defaults, $key),
+                sprintf('Spec documents key "%s" but it does not exist in Config::DEFAULTS', $key)
+            );
+        }
+
+        foreach (Config::RANGE_CLAMPS as $key => $range) {
+            $this->assertArrayHasKey(
+                $key,
+                $tableMeta,
+                sprintf('Range clamp for "%s" missing from spec table', $key)
+            );
+            $specRange = $tableMeta[$key]['range'] ?? null;
+            $this->assertNotNull($specRange, sprintf('Spec does not list a range for "%s"', $key));
+            $expectedMin = $range['type'] === 'float' ? (float) $range['min'] : (int) $range['min'];
+            $expectedMax = $range['type'] === 'float' ? (float) $range['max'] : (int) $range['max'];
+            $specMin = $range['type'] === 'float' ? (float) $specRange['min'] : (int) $specRange['min'];
+            $specMax = $range['type'] === 'float' ? (float) $specRange['max'] : (int) $specRange['max'];
+            $this->assertSame(
+                $expectedMin,
+                $specMin,
+                sprintf('Spec min clamp for "%s" does not match code (%s vs %s)', $key, $expectedMin, $specMin)
+            );
+            $this->assertSame(
+                $expectedMax,
+                $specMax,
+                sprintf('Spec max clamp for "%s" does not match code (%s vs %s)', $key, $expectedMax, $specMax)
+            );
+        }
+
+        foreach (Config::ENUMS as $key => $allowedValues) {
+            $this->assertArrayHasKey(
+                $key,
+                $tableMeta,
+                sprintf('Enum for "%s" missing from spec table', $key)
+            );
+            $specEnum = $tableMeta[$key]['enum'] ?? null;
+            $this->assertIsArray($specEnum, sprintf('Spec does not list enum values for "%s"', $key));
+            $expected = $allowedValues;
+            $actual = $specEnum;
+            sort($expected);
+            sort($actual);
+            $this->assertSame(
+                $expected,
+                $actual,
+                sprintf('Spec enum for "%s" differs from code', $key)
+            );
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $array
+     */
+    private function arrayPathExists(array $array, string $path): bool
+    {
+        $segments = explode('.', $path);
+        $cursor = $array;
+        foreach ($segments as $segment) {
+            if (!is_array($cursor) || !array_key_exists($segment, $cursor)) {
+                return false;
+            }
+            $cursor = $cursor[$segment];
+        }
+        return true;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function parseNormativeConstraintsTable(string $spec): array
+    {
+        $lines = explode("\n", $spec);
+        $inTable = false;
+        $tableLines = [];
+        foreach ($lines as $line) {
+            if (str_contains($line, '#### 17.2')) {
+                $inTable = true;
+                continue;
+            }
+            if ($inTable && str_contains($line, '#### 17.3')) {
+                break;
+            }
+            if ($inTable && str_starts_with(trim($line), '|')) {
+                $tableLines[] = $line;
+            }
+        }
+
+        $meta = [];
+        foreach ($tableLines as $line) {
+            $cells = array_map('trim', explode('|', trim($line)));
+            if (count($cells) < 5) {
+                continue;
+            }
+            if ($this->isSeparatorRow($cells)) {
+                continue;
+            }
+            if (!preg_match('/`([^`]+)`/', $cells[2], $match)) {
+                continue;
+            }
+            $key = $match[1];
+            $constraints = $cells[4];
+            $entry = [
+                'domain' => $cells[1],
+                'type' => $cells[3],
+                'constraints' => $constraints,
+            ];
+            if (preg_match('/clamp\s+([0-9_\.]+)[\x{2013}-]([0-9_\.]+)/u', $constraints, $rangeMatch)) {
+                $entry['range'] = [
+                    'min' => $this->normalizeNumber($rangeMatch[1]),
+                    'max' => $this->normalizeNumber($rangeMatch[2]),
+                ];
+            }
+            if (preg_match('/\{([^}]+)\}/', $constraints, $enumMatch)) {
+                $entry['enum'] = $this->parseEnumList($enumMatch[1]);
+            }
+            $meta[$key] = $entry;
+        }
+
+        return $meta;
+    }
+
+    /**
+     * @param array<int,string> $cells
+     */
+    private function isSeparatorRow(array $cells): bool
+    {
+        foreach ($cells as $cell) {
+            $clean = str_replace(['-', ':'], '', $cell);
+            if ($clean !== '') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private function parseEnumList(string $inner): array
+    {
+        if (preg_match_all('/`([^`]+)`/', $inner, $matches)) {
+            return $matches[1];
+        }
+        $parts = preg_split('/[,|]/', $inner) ?: [];
+        return array_values(array_filter(array_map('trim', $parts), 'strlen'));
+    }
+
+    /**
+     * @return int|float
+     */
+    private function normalizeNumber(string $raw)
+    {
+        $normalized = str_replace('_', '', $raw);
+        return str_contains($normalized, '.') ? (float) $normalized : (int) $normalized;
+    }
+}


### PR DESCRIPTION
## Summary
- rewrite §17 of the spec to group configuration domains, reference Config::DEFAULTS as the authority, and summarize normative constraints without duplicating literal defaults
- expose Config::DEFAULTS along with range and enum metadata in code, refactoring clamp logic to share those values
- add a SpecConfigParityTest that parses the spec and ensures documented keys, ranges, and enums stay in sync with the implementation

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d2d13e38e4832d9e0e8e63cf82a175