### PR TITLE
Fix normative constraints table parser

### DIFF
--- a/tests/unit/SpecConfigParityTest.php
+++ b/tests/unit/SpecConfigParityTest.php
@@ -90,18 +90,36 @@ final class SpecConfigParityTest extends BaseTestCase
     private function parseNormativeConstraintsTable(string $spec): array
     {
         $lines = explode("\n", $spec);
-        $inTable = false;
         $tableLines = [];
+        $inConfigSection = false;
+        $inTable = false;
+
         foreach ($lines as $line) {
-            if (str_contains($line, '#### 17.2')) {
+            $trimmed = trim($line);
+
+            if (!$inConfigSection) {
+                if (str_contains($line, '<a id="sec-configuration"></a>')) {
+                    $inConfigSection = true;
+                }
+                continue;
+            }
+
+            if (str_contains($line, '<a id="sec-uploads"></a>')) {
+                break;
+            }
+
+            if (!$inTable && str_contains($line, '2. Normative constraints')) {
                 $inTable = true;
                 continue;
             }
-            if ($inTable && str_contains($line, '#### 17.3')) {
-                break;
-            }
-            if ($inTable && str_starts_with(trim($line), '|')) {
-                $tableLines[] = $line;
+
+            if ($inTable) {
+                if (str_contains($line, '3. Defaults') || str_contains($line, 'Additional notes')) {
+                    break;
+                }
+                if (str_starts_with($trimmed, '|')) {
+                    $tableLines[] = $line;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- update the spec parser in `SpecConfigParityTest` to locate the normative constraints table using the current anchors and section titles
- stop parsing when the configuration section ends to avoid unrelated tables

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist --order-by=random --fail-on-warning`


------
https://chatgpt.com/codex/tasks/task_e_68d401065468832d951a15e5fdc36c28