### PR TITLE
Clarify slot precedence in cookie-mode table

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -330,7 +330,7 @@ electronic_forms - Spec
 				- When the rendered instance was slotless (no `eforms_slot` field), POST **MUST NOT** include `eforms_slot`; `submission_id = eid` (valid regardless of the record’s `slot`).
 			- Rerender behavior: normal rerenders reuse the existing `{eid, slot}`; deterministic assignment minimizes collisions but does not override these rules.
                 - POST requirements (policy-gated presence; tampering always hard-fails):
-						- Scope: The first row applies to slotless renders. All subsequent rows assume the rendered instance included `eforms_slot`.
+                                                - Rendered-instance precedence. If the rendered instance was slotless, the POST MUST NOT include `eforms_slot` and MUST NOT apply any persisted-slot equality check; `submission_id = eid`.
 		| Scenario | Required fields / behavior | Rejection cases |
 		|----------|---------------------------|-----------------|
 		| Rendered instance slotless | Do not include eforms_slot; `submission_id = eid`. | Including eforms_slot → HARD FAIL (EFORMS_ERR_TOKEN). |
@@ -340,8 +340,8 @@ electronic_forms - Spec
 		| All policies | Always validate the minted record `{mode:"cookie", form_id, eid}` before trusting the POST body. | Mode/form_id mismatch, mixing hidden tokens into cookie submissions, forged/malformed EID, cross-mode payloads, or slot violations → **HARD FAIL**. |
 		| Slots disabled | Omit `eforms_slot`. | Any posted slot is tampering → `EFORMS_ERR_TOKEN`. |
 		| Slots enabled | Posted `eforms_slot` must be an integer 1–255 present in both `security.cookie_mode_slots_allowed` and the record’s `slots_allowed`; slotless records (`slot:null`, empty `slots_allowed`) reject posted slots. | Value outside either allow-list or a non-integer post → **HARD FAIL**. |
-		| Persisted slot non-null | Submitted `eforms_slot` MUST equal the persisted `slot`. | Missing/mismatched slot → **HARD FAIL**. |
-		| Persisted slot null with observed slots | Accept only posted slots enumerated in `slots_allowed`; omit `eforms_slot` only when the renderer emitted a slotless instance. | Unexpected or missing slot when `slots_allowed` is non-empty → **HARD FAIL**. |
+                | Persisted slot non-null (**slotted renders only**) | Submitted `eforms_slot` MUST equal the persisted `slot`. | Missing/mismatched slot → **HARD FAIL**. |
+                | Persisted slot null with observed slots (**slotted renders only**) | Accept only posted slots enumerated in `slots_allowed`; omit `eforms_slot` only when the renderer emitted a slotless instance. | Unexpected or missing slot when `slots_allowed` is non-empty → **HARD FAIL**. |
 		- All **HARD FAIL** cases above surface `EFORMS_ERR_TOKEN`; see [Security invariants (§7.1.2)](#sec-security-invariants).
 		- Rerender + rotation (supplements [Security invariants (§7.1.2)](#sec-security-invariants)):
 			- Normal rerenders reuse the existing `{eid, slot}` tuple. No mid-flow rotation occurs.


### PR DESCRIPTION
## Summary
- clarify that slotless renders bypass persisted-slot equality checks before the POST requirements table
- mark persisted-slot table rows as applying only to slotted renders to resolve the slotless contradiction

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d41b095a18832d94aa356e3148377f