### PR TITLE
Align canonicality guidance

### DIFF
--- a/docs/SPEC_CONTRACTS.md
+++ b/docs/SPEC_CONTRACTS.md
@@ -3,11 +3,12 @@
 > Single place for canonicality, ownership, and the helper-contract template.
 > This file is **normative** unless a paragraph is explicitly marked “non-normative”.
 
-## 1) Canonicality & Precedence
+## 1) Canonicality & Precedence {#sec-canonicality}
 - **Matrices are authoritative for _outcomes_** (e.g., `token_ok`, `require_challenge`, `submission_id`, `cookie_present?`).
 - **Helper contracts are authoritative for _behavior/returns_** (inputs, side-effects, idempotency, hit/miss/expired).
 - **Narrative text must not contradict** matrices or helper contracts.
 - If two sources conflict, the PR **must** update both and declare which is canonical in the PR description.
+- The narrative preamble at [Normative vs. Non-normative](electronic_forms_SPEC.md#sec-normative-note) defers to this section; update the hierarchy here and reference it elsewhere to avoid drift.
 
 ## 2) State Model (cookie/hidden/NCID)
 - **Identifiers**: `token` (hidden), `eid[_ _slot{n}]` (cookie), `nc-…` (NCID).

--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -2,9 +2,9 @@ electronic_forms - Spec
 ================================================================
 
 <a id="sec-normative-note"></a>Normative vs. Non-normative
-	- Narrative text, tables, and matrices are normative unless explicitly marked otherwise.
-	- Diagrams and callouts are non-normative references only; they illustrate the normative rules above.
-	- **Conflict resolution (normative):** When two normative sources disagree, apply this order of authority: 1) Appendix matrices; 2) Helper contracts; 3) Narrative. The higher item prevails without expanding scope. (Stubs that “retain the legacy anchor” are informative unless they restate matrix rows verbatim.)****
+        - Narrative text, tables, and matrices are normative unless explicitly marked otherwise.
+        - Diagrams and callouts are non-normative references only; they illustrate the normative rules above.
+        - **Conflict resolution (normative):** This narrative defers to [Spec Contracts → Canonicality & Precedence (§1)](SPEC_CONTRACTS.md#sec-canonicality) for the authoritative hierarchy across matrices, helper contracts, and narrative updates. (Stubs that “retain the legacy anchor” are informative unless they restate matrix rows verbatim.)****
 
 <a id="sec-objective"></a>
 1. OBJECTIVE


### PR DESCRIPTION
## Summary
- mark the Spec Contracts canonicality section with a stable anchor and note that the narrative defers to it
- update the narrative "Normative vs. Non-normative" preamble to reference the dedicated canonicality hierarchy instead of restating it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5abc1ade8832d95b979419928b274