### PR TITLE
Clarify default references in configuration spec

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -412,7 +412,7 @@ Appendix 26 matrices are normative; see [Appendix 26](#sec-appendices).
 		- Logging: emit no success log.
 
 <a id="sec-timing-checks"></a>3. Timing Checks
-- min_fill_time (soft; configurable). Hidden-mode measures from the original hidden timestamp (reused on re-render). Cookie-mode measures from the minted record’s `issued_at` (prime pixel time) and ignores client timestamps entirely. *(Informative: Deployments that ship with the baseline profile inherit the duration from `Config::DEFAULTS`; if code changes the literal, the new default prevails.)*
+- min_fill_time (soft; configurable). Hidden-mode measures from the original hidden timestamp (reused on re-render). Cookie-mode measures from the minted record’s `issued_at` (prime pixel time) and ignores client timestamps entirely. Default: see §17 Defaults note.
 	- Max form age:
 		- - Cookie mode: enforce via minted record `expires`. Expired → treat as missing cookie and apply `security.cookie_missing_policy`. Because `/eforms/prime` never refreshes `issued_at`/`expires` for a still-valid record, the server-side countdown stays monotonic when an unexpired cookie is presented: QA fixtures and POST handlers can assert that a re-primed request with that cookie continues to age out on the original schedule, while an expired record prompts a full remint (new timestamps + Set-Cookie). When the browser omitted the cookie, the required `Set-Cookie` reissues the same identifier without altering the stored expiry.
 		- Hidden-mode: posted timestamp is best-effort; over `security.max_form_age_seconds` → +1 soft (never hard on age alone).
@@ -671,9 +671,9 @@ Appendix 26 matrices are normative; see [Appendix 26](#sec-appendices).
 	- minimal — compact line per event via error_log(); rotation governed by server.
 	- off — no logging (except optional Fail2ban emission).
 	- Severity mapping: error (fatal pipeline failures), warning (rejections, validation, challenge timeouts), info (successful sends, token rotations, throttling state changes).
-- `logging.level`: 0 errors; 1 +warnings; 2 +info. *(Informative: The shipping profile inherits its literal from `Config::DEFAULTS`; code remains authoritative for the actual default.)*
-- `logging.headers` (bool) — if true, log normalized UA/Origin (scheme+host only). *(Informative: The opt-in state shown in examples reflects `Config::DEFAULTS`; see [Configuration: Domains, Constraints, and Defaults (§17)](#sec-configuration) before assuming the literal.)*
-- `logging.pii` (bool) — allows full emails/IPs in JSONL only; minimal mode still masks unless explicitly overridden. *(Informative: Baseline enablement defers to `Config::DEFAULTS`; code-defined defaults prevail if they change.)*
+- `logging.level`: 0 errors; 1 +warnings; 2 +info. Default: see §17 Defaults note.
+- `logging.headers` (bool) — if true, log normalized UA/Origin (scheme+host only). Default: see §17 Defaults note.
+- `logging.pii` (bool) — allows full emails/IPs in JSONL only; minimal mode still masks unless explicitly overridden. Default: see §17 Defaults note.
 	- Rotation/retention for JSONL: dirs 0700, files 0600, rotate when file_max_size exceeded, prune > retention_days. flock() used; note NFS caveats.
 	- What to log (all modes, subject to pii/headers):
 	- Timestamp (UTC ISO-8601), severity, code, form_id, submission_id, slot? (when provided), request URI (path + only `eforms_*` query), privacy-processed IP, spam signals summary (honeypot, origin_state, soft_reasons, throttle_state), SMTP failure reason when applicable.
@@ -693,7 +693,7 @@ Appendix 26 matrices are normative; see [Appendix 26](#sec-appendices).
 
 <a id="sec-privacy"></a>
 16. PRIVACY AND IP HANDLING
-- `privacy.ip_mode` ∈ {`none`,`masked`,`hash`,`full`}. *(Informative: The baseline selection comes from `Config::DEFAULTS`; if the code-defined literal changes, the new value governs.)*
+- `privacy.ip_mode` ∈ {`none`,`masked`,`hash`,`full`}. Default: see §17 Defaults note.
 	- masked: IPv4 last octet(s) redacted; IPv6 last 80 bits zeroed (compressed)
 	- hash: sha256(ip + optional salt); store hash only
 	- full: store/display IP as-is
@@ -710,7 +710,9 @@ Appendix 26 matrices are normative; see [Appendix 26](#sec-appendices).
 
 <a id="sec-configuration"></a>
 17. CONFIGURATION: DOMAINS, CONSTRAINTS, AND DEFAULTS
-	- Authority: Default *values* live in code as `Config::DEFAULTS` (see `src/Config.php`). This spec no longer duplicates every literal; the code array is the single source of truth for defaults.
+- Authority: Default *values* live in code as `Config::DEFAULTS` (see `src/Config.php`). This spec no longer duplicates every literal; the code array is the single source of truth for defaults.
+
+Defaults note: When this spec refers to a ‘Default’, the authoritative literal is `Config::DEFAULTS` in code; the spec does not restate those literals.
 	- Normative constraints (this spec): types, enums, required/forbidden combinations, range clamps, migration/fallback behavior, and precedence rules remain authoritative here. Implementations MUST enforce these even when defaults evolve.
 	- Lazy bootstrap: The first call to `Config::get()` (including the invocations performed by `FormRenderer::render()`, `SubmitHandler::handle()`, `Security::token_validate()`, `Emailer::send()`, or the prime/success endpoints) invokes `Config::bootstrap()`; within a request it runs at most once, applies the `eforms_config` filter, clamps values, then freezes the snapshot. `uninstall.php` calls it eagerly to honor purge flags; standalone tooling MAY force bootstrap.
 	- Bootstrap ownership (normative):


### PR DESCRIPTION
## Summary
- update timing, logging, and privacy bullets to reference the §17 Defaults note instead of informative parentheticals
- add a Defaults note in §17 clarifying that literal values come from `Config::DEFAULTS`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5cd4c1444832d9a0d6a8d9aaa4293