### PR TITLE
Clarify canonical TEMPLATE_SPEC source in DRY principles

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -101,7 +101,7 @@ electronic_forms - Spec
 	- Upload policy (accept tokens/mimes/exts; per-file/field/request caps)
 	- Row group stack handling (balanced start/end)
 	- Accept token -> MIME/extension registry (conservative mappings)
-	- Structural spec (PHP): TEMPLATE_SPEC array drives enums/required/unknown-key rules; JSON Schema is generated from or checked against it to avoid drift
+- Structural spec (PHP): The PHP `TEMPLATE_SPEC` array (defined in `src/Validation/TemplateValidator.php`) is the sole canonical definition for enums/required/unknown-key rules; `/schema/template.schema.json` must be auto-generated or mechanically derived from that array (no manual edits) to eliminate dual sources
 
 <a id="sec-template-model"></a>
 5. TEMPLATE MODEL


### PR DESCRIPTION
## Summary
- clarify that the TEMPLATE_SPEC array in TemplateValidator.php is the canonical definition
- document that template.schema.json must be generated from the PHP array to avoid dual sources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5e47e49e8832dbb015ac7e1888a5f