### PR TITLE
Move cookie matrices to security section

### DIFF
--- a/docs/SPEC_CONTRACTS.md
+++ b/docs/SPEC_CONTRACTS.md
@@ -18,10 +18,10 @@
 ## 3) CI/Verifier Rules (summary)
 - Every “MUST/SHOULD/MAY” sentence **SHOULD** include a condition (`when|if|unless`) unless it’s a global invariant.
 - Every helper contract in §7.1.x contains **Inputs / Side-effects / Returns** blocks.
-- Changes in **Appendix 26** require a corresponding change in at least one anchored narrative/helper section (and vice-versa).
+- Changes in the **Security §7.1 matrices** (and the Appendix 26 pointer stubs) require a corresponding change in at least one anchored narrative/helper section (and vice-versa).
 
 ## 4) Anchors used by the Verifier
-- Matrices: `#sec-app-cookie-policy`, `#sec-app-cookie-lifecycle`, `#sec-app-cookie-ncid`
+- Matrices: `#sec-cookie-policy-matrix`, `#sec-cookie-lifecycle-matrix`, `#sec-cookie-ncid-summary`
 - Helper sections: `#sec-hidden-mode`, `#sec-cookie-mode`, `#sec-ncid`
 - Narrative hub: `#sec-submission-protection`
 


### PR DESCRIPTION
## Summary
- move the cookie policy, lifecycle, and NCID matrices into Security §7.1
- leave Appendix 26.5–26.7 as legacy anchors with pointers back to §7.1
- update SPEC_CONTRACTS guidance to reflect the new canonical matrix anchors

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d606913cc4832d9550251f1c50ae1a