### PR TITLE
Consolidate normative hierarchy guidance in SPEC_CONTRACTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Narrative must not contradict either.
 - If they conflict, the PR MUST fix both and state which source is canonical in the PR description.
 - Verifier checks that **narrative + matrices + helper contracts** are aligned (see `scripts/spec_lint.py`).
+- Normative vs. informative hierarchy lives in [`docs/SPEC_CONTRACTS.md#sec-normative-note`](docs/SPEC_CONTRACTS.md#sec-normative-note); other specs must include or link to that section instead of duplicating it.
 
 ## Roles
 - Spec Agent: finds contradictions; proposes minimal normative edits.
@@ -81,3 +82,4 @@
 - [ ] Lists use tabs for indentation; no mixed tab/space.
 - [ ] No accidental reflow/whitespace-only churn.
 - [ ] If editing Security §7, QA matrix links updated as needed.
+- [ ] If adjusting the normative/informative hierarchy, edits land in `docs/SPEC_CONTRACTS.md#sec-normative-note` (other files should reference/include it).

--- a/docs/SPEC_CONTRACTS.md
+++ b/docs/SPEC_CONTRACTS.md
@@ -3,12 +3,27 @@
 > Single place for canonicality, ownership, and the helper-contract template.
 > This file is **normative** unless a paragraph is explicitly marked “non-normative”.
 
+<!--8<-- [start:sec-normative-note] -->
+<a id="sec-normative-note"></a>Normative vs. Non-normative
+This front matter summarizes the single canonical hierarchy defined in [Spec Contracts → Canonicality & Precedence (§1)](#sec-canonicality). Update that section first, then link to it from any new mandates instead of restating hierarchy in full.
+
+| Scope | Authoritative source | Notes |
+|-------|----------------------|-------|
+| Runtime behavior (code paths, fixtures) | PHP implementation, helper fixtures, and verifier scripts | Runtime sources remain the ground truth for execution details; this spec references them without overriding behavior. |
+| Spec constraints (matrices, helper contracts, narrative) | `docs/SPEC_CONTRACTS.md#sec-canonicality`, Security §7 matrices, anchored helper contracts | These define normative outcomes, inputs/outputs, ranges, and precedence rules. Narrative changes must stay aligned with the matrices and helper contracts they summarize. |
+| Informative material | Appendices, diagrams, explanatory callouts | Marked non-normative; they illustrate behavior but do not change requirements. |
+
+- Narrative text, tables, and matrices are normative unless explicitly marked otherwise.
+- Diagrams and callouts are non-normative references only; they illustrate the normative rules above.
+- **Conflict resolution (normative):** Follow the hierarchy above when sources disagree, and keep [Spec Contracts → Canonicality & Precedence (§1)](#sec-canonicality) and this hub in sync so verifiers have a single entry point.
+<!--8<-- [end:sec-normative-note] -->
+
 ## 1) Canonicality & Precedence {#sec-canonicality}
 - **Matrices are authoritative for _outcomes_** (e.g., `token_ok`, `require_challenge`, `submission_id`, `cookie_present?`).
 - **Helper contracts are authoritative for _behavior/returns_** (inputs, side-effects, idempotency, hit/miss/expired).
 - **Narrative text must not contradict** matrices or helper contracts.
 - If two sources conflict, the PR **must** update both and declare which is canonical in the PR description.
-- The narrative preamble at [Normative vs. Non-normative](electronic_forms_SPEC.md#sec-normative-note) defers to this section; update the hierarchy here and reference it elsewhere to avoid drift.
+- The narrative preamble at [Normative vs. Non-normative](#sec-normative-note) defers to this section; update the hierarchy here and reference it elsewhere to avoid drift.
 
 ## 2) State Model (cookie/hidden/NCID)
 - **Identifiers**: `token` (hidden), `eid[_ _slot{n}]` (cookie), `nc-…` (NCID).

--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -1,18 +1,7 @@
 electronic_forms - Spec
 ================================================================
 
-<a id="sec-normative-note"></a>Normative vs. Non-normative
-This front matter summarizes the single canonical hierarchy defined in [Spec Contracts → Canonicality & Precedence (§1)](SPEC_CONTRACTS.md#sec-canonicality). Update that section first, then link to it from any new mandates instead of restating hierarchy in full.
-
-| Scope | Authoritative source | Notes |
-|-------|----------------------|-------|
-| Runtime behavior (code paths, fixtures) | PHP implementation, helper fixtures, and verifier scripts | Runtime sources remain the ground truth for execution details; this spec references them without overriding behavior. |
-| Spec constraints (matrices, helper contracts, narrative) | `docs/SPEC_CONTRACTS.md#sec-canonicality`, Security §7 matrices, anchored helper contracts | These define normative outcomes, inputs/outputs, ranges, and precedence rules. Narrative changes must stay aligned with the matrices and helper contracts they summarize. |
-| Informative material | Appendices, diagrams, explanatory callouts | Marked non-normative; they illustrate behavior but do not change requirements. |
-
-- Narrative text, tables, and matrices are normative unless explicitly marked otherwise.
-- Diagrams and callouts are non-normative references only; they illustrate the normative rules above.
-- **Conflict resolution (normative):** Follow the hierarchy above when sources disagree, and keep [Spec Contracts → Canonicality & Precedence (§1)](SPEC_CONTRACTS.md#sec-canonicality) and this hub in sync so verifiers have a single entry point.
+--8<-- "SPEC_CONTRACTS.md:sec-normative-note"
 
 <a id="sec-objective"></a>
 1. OBJECTIVE


### PR DESCRIPTION
## Summary
- move the normative vs. informative hierarchy table into `docs/SPEC_CONTRACTS.md` and wrap it in a reusable snippet
- reference the shared snippet from `docs/electronic_forms_SPEC.md` so front matter stays in sync at build time
- document the new canonical location for hierarchy edits in `AGENTS.md`, including the contributor checklist

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d6c081661c832d813e6b92f9e6eb1c