### PR TITLE
Fix canonicality link for normative snippet include

### DIFF
--- a/docs/SPEC_CONTRACTS.md
+++ b/docs/SPEC_CONTRACTS.md
@@ -5,7 +5,7 @@
 
 <!--8<-- [start:sec-normative-note] -->
 <a id="sec-normative-note"></a>Normative vs. Non-normative
-This section summarizes the single canonical hierarchy defined in [Spec Contracts → Canonicality & Precedence (§1)](#sec-canonicality). Update that section first, then link to it from any new mandates instead of restating hierarchy in full.
+This section summarizes the single canonical hierarchy defined in [Spec Contracts → Canonicality & Precedence (§1)](docs/SPEC_CONTRACTS.md#sec-canonicality). Update that section first, then link to it from any new mandates instead of restating hierarchy in full.
 
 | Scope | Authoritative source | Notes |
 |-------|----------------------|-------|


### PR DESCRIPTION
## Summary
- update the normative-note snippet so its canonicality reference uses a fully qualified docs path

## Testing
- python3 tools/check_cookie_tables.py
- python3 - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_e_68d6ca3ccee0832da4678d3157c220b0