### PR TITLE
Reference canonical hierarchy in electronic forms spec

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -2,6 +2,7 @@ electronic_forms - Spec
 ================================================================
 
 --8<-- "SPEC_CONTRACTS.md:sec-normative-note"
+--8<-- "SPEC_CONTRACTS.md:sec-canonicality"
 
 <a id="sec-objective"></a>
 1. OBJECTIVE
@@ -267,10 +268,10 @@ electronic_forms - Spec
  	
 <a id="sec-security"></a>
 7. SECURITY
-Cookie and NCID matrices in this section are normative; per [Canonicality & Precedence (§1)](SPEC_CONTRACTS.md#sec-canonicality) §7 remains the authoritative location for these policies.
+Per [Canonicality & Precedence (§1)](SPEC_CONTRACTS.md#sec-canonicality), defer to the canonical cookie/NCID matrices in §7.
 <a id="sec-submission-protection"></a>1. Submission Protection for Public Forms (hidden vs cookie)
 - See [Lifecycle quickstart (§7.1.0)](#sec-lifecycle-quickstart) for the canonical render → persist → POST → rerender/success contract that governs both modes.
-- Detailed matrices live in [Cookie policy outcomes (§7.1.3.2)](#sec-cookie-policy-matrix), [Cookie-mode lifecycle (§7.1.3.3)](#sec-cookie-lifecycle-matrix), and [Cookie/NCID reference (§7.1.4.3)](#sec-cookie-ncid-summary); this section keeps the authoritative mode invariants and shared storage rules while pointing back to [Canonicality & Precedence (§1)](SPEC_CONTRACTS.md#sec-canonicality).
+- Detailed matrices live in [Cookie policy outcomes (§7.1.3.2)](#sec-cookie-policy-matrix), [Cookie-mode lifecycle (§7.1.3.3)](#sec-cookie-lifecycle-matrix), and [Cookie/NCID reference (§7.1.4.3)](#sec-cookie-ncid-summary) per [Canonicality & Precedence (§1)](SPEC_CONTRACTS.md#sec-canonicality).
 <a id="sec-lifecycle-quickstart"></a>7.1.0 Lifecycle quickstart (normative)
 <!-- BEGIN BLOCK: lifecycle-pipeline-quickstart -->
 **Pipeline-first outline (render → persist → POST → challenge → normalization → ledger → success)**


### PR DESCRIPTION
## Summary
- include the normative/informative primer and canonicality table at the top of the electronic forms spec
- replace the security section's local cookie/NCID precedence restatement with a pointer to the canonical hierarchy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e171c5d0832dbf01e429d58833b5