### PR TITLE
Fix identifier kind for slotless cookie lifecycle row

### DIFF
--- a/tools/spec_sources/security_data.yaml
+++ b/tools/spec_sources/security_data.yaml
@@ -63,7 +63,7 @@ cookie_lifecycle_rows:
     flow_trigger: GET render (slots disabled)
     server_must: "MUST omit `eforms_slot`; embed `/eforms/prime?f={form_id}` pixel; reuse markup verbatim on rerender."
     identifier:
-      kind: eid
+      kind: submission_id
       text: "`submission_id` rendered without slot suffix."
     notes: "Slotless deployments omit the `s` query parameter entirely."
     references:


### PR DESCRIPTION
## Summary
- correct the identifier type for the slotless GET render cookie lifecycle row to `submission_id`

## Testing
- python scripts/spec_lint.py

------
https://chatgpt.com/codex/tasks/task_e_68d6feef5cdc832d99268e5a938f4ae4