### PR TITLE
Clarify NCID challenge success cookie handling

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -522,7 +522,7 @@ Definition — Rotation trigger = minted record replacement caused by expiry or 
 				- Error rerender after NCID fallback: delete `eforms_eid_{form_id}` (Set-Cookie: deleted) and embed `/eforms/prime` before rendering. The next GET reissues the persisted cookie record while the flow remains pinned to the NCID above.
 				- Definition — Reissue = send `Set-Cookie` for the existing record without changing `eid`, `issued_at`, or `expires`.
 				- Challenge rerender before verification: when `require_challenge=true`, delete `eforms_eid_{form_id}`, embed `/eforms/prime?f={form_id}[&s={slot}]`, and keep the NCID as the authoritative `submission_id` until verification succeeds.
-				- Challenge success response: reuse the just-verified cookie; do not remint inside the success response. Subsequent submissions receive fresh cookies via `/eforms/prime`.
+- Challenge success response: delete `eforms_eid_{form_id}` (Set-Cookie: deleted) and embed `/eforms/prime?f={form_id}[&s={slot}]` before delivering success so the just-verified record is reused. Do not remint inside the response; the embedded prime reissues the persisted cookie on the follow-up GET.
 - <a id="sec-ncid-success-ref"></a>NCID success integration: Redirect-only success handling, the `eforms_submission` query flag, and verifier requirements are defined in [Success Behavior (PRG) (§13)](#sec-success) (see [NCID-only handoff (§13.1)](#sec-success-ncid)).
 <a id="sec-cookie-ncid-summary"></a>Cookie/NCID reference (authoritative summary):
 **Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**


### PR DESCRIPTION
## Summary
- clarify the NCID challenge success narrative so it explicitly clears `eforms_eid_{form_id}` and embeds `/eforms/prime`
- align the descriptive text with the cookie lifecycle matrix directive for the challenge success response

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70bdf5630832dab1104c5e5700076