### PR TITLE
Guard spec generator on PyYAML availability

### DIFF
--- a/tools/generate_spec_sections.py
+++ b/tools/generate_spec_sections.py
@@ -2,10 +2,16 @@
 """Generate security spec tables from YAML data."""
 
 import argparse
+import importlib.util
 import re
 import sys
 from pathlib import Path
 from typing import Any, Iterable
+
+if importlib.util.find_spec("yaml") is None:
+    raise SystemExit(
+        "PyYAML is required to generate spec tables. Install it via 'pip install PyYAML' and rerun."
+    )
 
 import yaml
 


### PR DESCRIPTION
## Summary
- fail fast with a helpful message when PyYAML is missing before generating spec tables

## Testing
- python3 tools/generate_spec_sections.py --check
- python3 tools/check_cookie_tables.py

------
https://chatgpt.com/codex/tasks/task_e_68d70d23edc4832da337987601a63794