### PR TITLE
Clarify challenge success re-prime flow

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -647,8 +647,8 @@ Definition — PRG re-prime = the success redirect carries the deletion header a
 - Render only on POST re-render when required (including `challenge.mode="always"`) or during verification; never on the initial GET.
 		- In cookie mode:
 			- **Before verification** (when `require_challenge=true`), the challenge rerender MUST clear `eforms_eid_{form_id}` and embed the `/eforms/prime?f={form_id}[&s={slot}]` pixel so it reissues the persisted cookie before the next POST (see [Security → Cookie-mode contract (§7.1.3)](#sec-cookie-mode)).
-			- **After successful verification** for `cookie_missing_policy="challenge"`, do **not** mint a new EID on that success response; still send the NCID rerender deletion header plus embedded `/eforms/prime` per [NCID rerender lifecycle (§7.1.4.2)](#sec-ncid-rerender) so the existing record is reissued before PRG.
-			- Definition — Challenge success reuse = deletion header + embedded `/eforms/prime` that reissues the persisted record without reminting.
+			- **After successful verification** for `cookie_missing_policy="challenge"`, do **not** mint a new EID on that success response; send the NCID rerender deletion header and rely on the follow-up GET to embed `/eforms/prime` per [NCID rerender lifecycle (§7.1.4.2)](#sec-ncid-rerender) so the existing record is reissued before PRG.
+			- Definition — Challenge success reuse = deletion header on the redirect + the follow-up `/eforms/prime` reissuing the persisted record without reminting.
 	- Turnstile → cf-turnstile-response; hCaptcha → h-captcha-response; reCAPTCHA v2 → g-recaptcha-response.
 
 <a id="sec-validation-pipeline"></a>


### PR DESCRIPTION
## Summary
- clarify that challenge success redirects rely on the follow-up GET to embed `/eforms/prime`
- align the adaptive challenge section with the NCID rerender lifecycle wording

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d73c31afa4832d999c9b8029378aea