### PR TITLE
Clarify cookie helper slot handling and config requirements

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -412,8 +412,8 @@ Definition — Rotation trigger = minted record replacement caused by expiry or 
     - `hit` = prior record exists and `now < prior.expires`  
   - After any remint (miss/expired), `record.expires` reflects the newly persisted value.
 - Failure modes:
-  - Invalid/disabled `slot?` (not allowed or outside 1–255) is normalized to `null`; continue.  
-  - Filesystem errors propagate (hard fail).  
+  - Invalid/disabled `slot?` (not allowed or outside 1–255) is normalized to `null`; the helper otherwise ignores `slot?` and always persists `{ slots_allowed:[], slot:null }`, leaving `/eforms/prime` to union slots after it returns.
+  - Filesystem errors propagate (hard fail).
   - Status computation is independent of cookie header presence.
   - `status:"hit"` alone does not guarantee an unexpired match; a cookie-less hit still obligates `/eforms/prime` to send the positive header per the boundary below.
 
@@ -894,7 +894,7 @@ Defaults note: When this spec refers to a ‘Default’, the authoritative liter
 	- Lazy bootstrap: The first call to `Config::get()` (including the invocations performed by `FormRenderer::render()`, `SubmitHandler::handle()`, `Security::token_validate()`, `Emailer::send()`, or the prime/success endpoints) invokes `Config::bootstrap()`; within a request it runs at most once, applies the `eforms_config` filter, clamps values, then freezes the snapshot. `uninstall.php` calls it eagerly to honor purge flags; standalone tooling MAY force bootstrap.
 	- Bootstrap ownership (normative):
 		- Entry points MUST call `Config::get()` before invoking helpers (see [Lazy-load Matrix (§6)](#sec-lazy-load-matrix) for trigger ownership).
-		- Helpers MUST ALSO call `Config::get()` on first use as a safety net; the call is idempotent so callers that forget still behave correctly.
+- Helpers MUST ALSO call `Config::get()` on first use as a safety net; the call is idempotent so callers that forget still behave correctly, but skipping the caller-side invocation remains a contract violation for entry points.
 		- When adding a new public endpoint, that endpoint owns calling `Config::get()` up front; do not call `Config::bootstrap()` directly.
 		- Call order (illustrative): Endpoint → `Config::get()` → Helper (which internally no-ops `Config::get()` again) → …
 	- Migration behavior: unknown keys MUST be rejected; missing keys fall back to defaults before clamping; invalid enums/ranges/booleans MUST trigger validation errors rather than coercion; POST handlers MUST continue to enforce constraints after bootstrap.


### PR DESCRIPTION
## Summary
- clarify that Security::mint_cookie_record ignores the slot argument beyond validation and leaves unions to /eforms/prime
- restate that helper-side Config::get() calls are a safety net and do not waive the caller’s obligation

## Testing
- python scripts/spec_lint.py

------
https://chatgpt.com/codex/tasks/task_e_68d858a517d4832d8424e016119332d0