### PR TITLE
Refactor NCID rerender guidance into generated include

### DIFF
--- a/docs/generated/security/ncid_rerender.md
+++ b/docs/generated/security/ncid_rerender.md
@@ -1,0 +1,7 @@
+**Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
+<!-- BEGIN GENERATED: ncid-rerender-steps -->
+- **Expire the minted cookie** — MUST delete `eforms_eid_{form_id}` via a `Set-Cookie` header whose Name/Path/SameSite/Secure/HttpOnly attributes match the minted cookie and whose `Max-Age=0` (or `Expires` is in the past) whenever NCID fallback or challenge rerenders fire, including the PRG redirect on challenge success.
+- **Re-prime via `/eforms/prime`** — MUST embed `/eforms/prime?f={form_id}[&s={slot}]` on those rerenders so the persisted record is reissued before the next POST; the rerender itself MUST NOT emit a positive `Set-Cookie`.
+- **Keep the NCID-pinned `submission_id`** — MUST continue using the existing NCID as `submission_id`; rerenders, verification templates, and challenge success responses MUST NOT mint or substitute another identifier mid-flow. This delete + re-prime cycle is an allowed carve-out and does not violate the “no rotation before success” rule.
+- **Challenge verification handoff** — Challenge verification success MUST emit only the deletion header and rely on the PRG follow-up GET (the redirect target) to embed `/eforms/prime` and restore cookie presence before the next POST; verifiers MUST NOT mint or refresh the cookie directly.
+<!-- END GENERATED: ncid-rerender-steps -->

--- a/scripts/spec_lint.py
+++ b/scripts/spec_lint.py
@@ -118,6 +118,7 @@ def check_ncid_rerender_include(path: Path, lines: Sequence[str]) -> List[str]:
     section_has_reference = False
     section_has_include = False
     in_generated_block = False
+    in_code_block = False
 
     def flush_section() -> None:
         nonlocal section_has_reference, section_has_include, section_start_line
@@ -130,10 +131,16 @@ def check_ncid_rerender_include(path: Path, lines: Sequence[str]) -> List[str]:
 
     for idx, line in enumerate(lines):
         stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+
         if stripped.startswith("<!-- BEGIN GENERATED:"):
             in_generated_block = True
         elif stripped.startswith("<!-- END GENERATED:"):
             in_generated_block = False
+            continue
+
+        if in_code_block:
             continue
 
         if stripped.startswith("#") or stripped.startswith("<a id="):

--- a/tools/check_cookie_tables.py
+++ b/tools/check_cookie_tables.py
@@ -44,6 +44,12 @@ EXPECTED_ROW_IDS = {
         "ncid-summary-challenge-success",
         "ncid-summary-success-handoff",
     },
+    "ncid_rerender_steps": {
+        "ncid-rerender-delete-cookie",
+        "ncid-rerender-reprime",
+        "ncid-rerender-pinned-submission",
+        "ncid-rerender-challenge-verify",
+    },
 }
 TABLE_HEADERS = {
     "sec-cookie-policy-matrix": "| Policy path | Handling when cookie missing/invalid or record expired | `token_ok` | Soft labels | `require_challenge` | Identifier returned | `cookie_present?` |",

--- a/tools/spec_sources/security_data.yaml
+++ b/tools/spec_sources/security_data.yaml
@@ -233,3 +233,17 @@ ncid_summary_rows:
     canonical_section:
       anchor: sec-success-ncid
       label: Success → NCID-only handoff (§13.1)
+
+ncid_rerender_steps:
+  - id: ncid-rerender-delete-cookie
+    title: Expire the minted cookie
+    action: "MUST delete `eforms_eid_{form_id}` via a `Set-Cookie` header whose Name/Path/SameSite/Secure/HttpOnly attributes match the minted cookie and whose `Max-Age=0` (or `Expires` is in the past) whenever NCID fallback or challenge rerenders fire, including the PRG redirect on challenge success."
+  - id: ncid-rerender-reprime
+    title: Re-prime via `/eforms/prime`
+    action: "MUST embed `/eforms/prime?f={form_id}[&s={slot}]` on those rerenders so the persisted record is reissued before the next POST; the rerender itself MUST NOT emit a positive `Set-Cookie`."
+  - id: ncid-rerender-pinned-submission
+    title: Keep the NCID-pinned `submission_id`
+    action: "MUST continue using the existing NCID as `submission_id`; rerenders, verification templates, and challenge success responses MUST NOT mint or substitute another identifier mid-flow. This delete + re-prime cycle is an allowed carve-out and does not violate the “no rotation before success” rule."
+  - id: ncid-rerender-challenge-verify
+    title: Challenge verification handoff
+    action: "Challenge verification success MUST emit only the deletion header and rely on the PRG follow-up GET (the redirect target) to embed `/eforms/prime` and restore cookie presence before the next POST; verifiers MUST NOT mint or refresh the cookie directly."


### PR DESCRIPTION
## Summary
- add structured `ncid_rerender_steps` data and emit a generated include for the NCID rerender lifecycle
- replace repeated rerender guidance in the security spec with the generated snippet
- extend spec tooling to validate the new data block and require the include when referencing the NCID rerender section

## Testing
- python3 tools/generate_spec_sections.py --check
- python3 tools/check_cookie_tables.py
- python3 scripts/spec_lint.py

------
https://chatgpt.com/codex/tasks/task_e_68d85e76c52c832d99ce867a959db2f2