### PR TITLE
Clarify lazy-load responsibilities for security helpers

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -258,7 +258,7 @@ electronic_forms - Spec
 		| TemplateValidator / Validator | Lazy | Rendering (GET) preflight; POST validate | Builds resolved descriptors on first call; memoizes per request (no global scans). |
 		| Static registries (`HANDLERS` maps) | Lazy | First call to `resolve()` / class autoload | Autoloading counts as lazy; classes hold only const maps; derived caches compute on demand. |
 		| Renderer / FormRenderer | Lazy | Shortcode or template tag executes | Enqueues assets only when form present. |
-		| Security (token/origin) | Lazy | **Hidden-token mint during GET render**, any token/origin check during POST, or `/eforms/prime` cookie mint | `FormRenderer` **delegates** all minting to Security helpers (no local UUID/TTL logic). Minting helpers do not load challenge/throttle; they read the config snapshot for TTL **and slot policy** before returning canonical metadata. |
+               | Security (token/origin) | Lazy | **Hidden-token mint during GET render**, any token/origin check during POST, or `/eforms/prime` cookie mint | `FormRenderer` **delegates** all minting to Security helpers (no local UUID/TTL logic). Minting helpers skip challenge/throttle/origin reads and use the snapshot only for TTL **and slot policy**; validation helpers (`Security::token_validate()` / origin checks) load challenge, throttle, and origin policy after the entry point primes the snapshot. |
 		| Uploads | Lazy | Template declares file(s) or POST carries files | Initializes finfo and policy only when needed. |
 		| Emailer | Lazy | After validation succeeds (just before send) | SMTP/DKIM init only on send; skipped on failures. |
 		| Logging | Lazy | First log write when `logging.mode != "off"` | Opens/rotates file on demand. |


### PR DESCRIPTION
## Summary
- clarify the security lazy-load matrix so minting helpers skip challenge/throttle/origin checks while validation helpers load those policies after the snapshot is primed

## Testing
- not run (spec change only)


------
https://chatgpt.com/codex/tasks/task_e_68d8941c53b8832d8a6b390b32e41658