### PR TITLE
Clarify unexpired match definition

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -424,7 +424,8 @@ Definition — Rotation trigger = minted record replacement caused by expiry or 
   - `status:"hit"` means storage already holds an unexpired record for this form; it **does not** imply the request presented that cookie. Callers MUST still apply the **unexpired-match** test before deciding to skip the positive header.
 
 **Definitions (normative):**
-- **Unexpired match** = request presents `eforms_eid_{form_id}` matching the EID regex **and** storage has a record with `now < record.expires`.
+- **Unexpired match** = request presents `eforms_eid_{form_id}` matching the EID regex **and** storage has a record for that EID with `now < record.expires`.
+- Definition — Matching record = lookup is keyed by the presented cookie value; other EIDs for the form do not satisfy the match.
 - Definition — Presented cookie = the request supplies `eforms_eid_{form_id}` matching the EID regex.
 - **Header boundary (normative)** — [Cookie header actions matrix (§7.1.3.3)](#sec-cookie-header-actions) is authoritative for which flow emits which header. `/eforms/prime` remains the sole source of a positive `Set-Cookie` for `eforms_eid_{form_id}`.
 - <a id="sec-cookie-header-actions"></a>Cookie header actions (normative):


### PR DESCRIPTION
## Summary
- align the cookie-mode helper definition of "unexpired match" with the header actions matrix by requiring the record to match the presented EID
- document that the lookup is keyed to the cookie value so stray records for the form cannot satisfy the match

## Testing
- not run (docs change)


------
https://chatgpt.com/codex/tasks/task_e_68d8941c53b8832d8a6b390b32e41658