### PR TITLE
Generate slot handling and cookie invariants from spec data

### DIFF
--- a/tools/spec_sources/security_data.yaml
+++ b/tools/spec_sources/security_data.yaml
@@ -151,6 +151,33 @@ cookie_lifecycle_rows:
       - sec-ncid-rerender
       - sec-cookie-lifecycle-matrix
 
+slot_handling_summary_rows:
+  - id: slot-helper-no-union
+    text: "`Security::mint_cookie_record()` never unions slots."
+  - id: prime-unions-slots
+    text: "`/eforms/prime` performs `slots_allowed ∪ {s}` (when allowed), derives `slot` when `|slots_allowed| == 1`, and persists only those fields; it MUST NOT rewrite `issued_at`/`expires`."
+
+prime_set_cookie_guidance_rows:
+  - id: prime-set-cookie-attributes
+    text: "Set-Cookie attributes (normative): When `/eforms/prime` sends `Set-Cookie`, it MUST set `eforms_eid_{form_id}` with:"
+    children:
+      - text: "`Path=/`"
+      - text: "`Secure` when the request is HTTPS; omit otherwise"
+      - text: "`HttpOnly=true`"
+      - text: "`SameSite=Lax`"
+      - text: "`Max-Age =`"
+        children:
+          - text: "`security.token_ttl_seconds` when minting a new record, or"
+          - text: "`record.expires - now` when reissuing an existing record so the client countdown never exceeds the server record."
+  - id: prime-remaining-lifetime
+    text: "Definition — Remaining lifetime = `max(0, record.expires - now)` (seconds)."
+  - id: prime-sends-set-cookie-definition
+    text: "Definition: “sends `Set-Cookie`” refers to the positive header emitted under the carve-out below; deletion headers on rerender are governed by [NCID rerender lifecycle (§7.1.4.2)](#sec-ncid-rerender)."
+  - id: prime-unexpired-match
+    text: "Definition — **unexpired match**: the request presents `eforms_eid_{form_id}` matching the EID regex and a server record exists for that EID with `now < record.expires`. HTTP requests do not echo Path/SameSite/Secure, so equality is inferred from minting with the configured attributes."
+  - id: prime-set-cookie-carve-out
+    text: "Carve-out (normative): `/eforms/prime` MUST send `Set-Cookie` when minting a new record or when the request lacks an unexpired match. It MUST NOT emit a positive `Set-Cookie` when an unexpired match is present; the endpoint MUST skip the header whenever an identical, unexpired cookie (same Name, Value, Path, SameSite, Secure) was presented. No alternate positive header is permitted while that match exists."
+
 lifecycle_quickstart_rows:
   - id: quickstart-render
     stage: "Render (GET)"


### PR DESCRIPTION
## Summary
- store the slot-handling summary and `/eforms/prime` Set-Cookie requirements in `security_data.yaml`
- extend the section generator to render bullet lists alongside existing tables with proper indentation
- regenerate the security spec so the slot and Set-Cookie guidance is produced from the shared data

## Testing
- python tools/generate_spec_sections.py

------
https://chatgpt.com/codex/tasks/task_e_68d95bbc6828832dacd293fb79b5aa6d