### PR TITLE
Clarify config lazy-load responsibilities

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -12,7 +12,7 @@ electronic_forms - Spec
 - Out of scope for this project: any multi-step or multi-page questionnaires/wizards, or flows that depend on persistent user identity beyond a single submission.
 - No admin UI.
 - Focus on simplicity and efficiency; avoid overengineering. Easy to maintain and performant for intended use.
-- Lazy by design: the configuration snapshot is bootstrapped lazily on first access (Renderer/SubmitHandler/Emailer/Security) rather than at plugin load; modules initialize only when their triggers occur (see [Central Registries → Lazy-load Matrix (§6)](#sec-lazy-load-matrix) and [Configuration: Domains, Constraints, and Defaults (§17)](#sec-configuration).)
+- Lazy by design: the configuration snapshot is bootstrapped lazily on first access. Entry points (Renderer/SubmitHandler/Emailer/`/eforms/prime`) call `Config::get()` before delegating, and Security helpers re-call it as a backstop, so modules initialize only when their triggers occur (see [Central Registries → Lazy-load Matrix (§6)](#sec-lazy-load-matrix) and [Configuration: Domains, Constraints, and Defaults (§17)](#sec-configuration).)
 - No database writes; file-backed one-time token ledger for duplicate-submit prevention (no Redis/queues).
 - Clear boundaries: render vs. validate vs. send vs. log vs. upload.
 - Deterministic pipeline and schema parity: big win for testability.


### PR DESCRIPTION
## Summary
- clarify the Objective section so it explicitly states that entry points call `Config::get()` before delegating while Security helpers re-call it as a backstop, aligning the narrative with the lazy-load matrix

## Testing
- python3 scripts/spec_lint.py

------
https://chatgpt.com/codex/tasks/task_e_68d989d6afc8832d8e158acb9a2c77b0