### PR TITLE
Add ledger rollback carve-out for email failures

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -348,6 +348,7 @@ Definition — Rotation trigger = minted record replacement caused by expiry or 
 		- <a id="sec-ledger-contract"></a>Ledger reservation contract
 			- Duplicate suppression reserves `${uploads.dir}/eforms-private/ledger/{form_id}/{h2}/{submission_id}.used` via `fopen('xb')` (or equivalent) immediately before side effects.
 			- Treat `EEXIST` or any filesystem failure as a duplicate and log `EFORMS_LEDGER_IO` on unexpected IO errors.
+			- Normative carve-out: If [Request Lifecycle → POST (§19.2)](#sec-request-lifecycle-post) hits the email-failure clause after validation, SubmitHandler MAY roll back `${submission_id}.used`; no other path may undo the reservation.
 			- Honeypot short-circuits burn the same ledger entry, and submission IDs for all modes remain colon-free.
 
 		- <a id="sec-security-invariants"></a>Security invariants (apply to hidden/cookie/NCID):


### PR DESCRIPTION
## Summary
- document the sole ledger rollback exception when POST email sending fails after validation
- reference the POST lifecycle clause so the carve-out stays scoped to that path

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68d98be4c8dc832dac81228d9c3fec32