### PR TITLE
Document bundled template directories

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -80,9 +80,9 @@ electronic_forms - Spec
 	- /schema/
 		- template.schema.json	// design-time only (editor/CI lint); kept in sync with PHP spec
 	- /templates/
-		- forms/
+		- forms/		// default JSON templates that ship with the plugin
 			- contact.json		// kebab-case filenames only
-	- email/
+		- email/		// default email bodies that ship with the plugin
 	- /assets/
 		- forms.css	 // namespaced styles
 		- forms.js		// JS marker (js_ok), error-summary/first-invalid focus, submit lock, spinner

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,6 +61,7 @@
 - `TemplateValidator` preflight covering field definitions, row-group constraints, and envelope rules.
 - Manifest/schema source of truth for template metadata referenced by Renderer, SubmitHandler, and challenge flows; runtime uses the preflighted manifest only.
 - CLI/CI wiring that fails builds when templates drift from the canonical schema or omit required rows/fields.
+- Ship default template assets in `/templates/forms/` and `/templates/email/` so deployments have ready-to-use form and email examples.
 - Developer ergonomics: actionable diagnostics, anchor links back to spec sections, fixtures for regression tests.
 
 **Acceptance**


### PR DESCRIPTION
## Summary
- describe in the spec that the bundled form and email templates live under `/templates/forms/` and `/templates/email/`
- note in the roadmap that Phase 3 ships the default template assets from those directories

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d9b784a694832d9680dc872a15f7fd