### PR TITLE
Document email template pipeline requirements

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -198,16 +198,18 @@
 
 - SMTP/PHPMailer integration; DKIM optional; strict header sanitation; plain text default; HTML allowed via config.
 - Attachments policy; enforce size/count caps before send.
+- Email template selection pipeline matches [`email_template`] JSON keys to `/templates/email/{name}.txt.php` and `{name}.html.php`, enforces the token set/slot handling defined in [Email Templates (Registry) (§24)](#sec-email-templates), and constrains template inputs to the canonical fields/meta/uploads summary.
 - Staging safety (`email.disable_send`, `email.staging_redirect_to`, `X-EForms-Env: staging`, `[STAGING]` subject).
 - **Failure semantics (normative):**
-  - If `send()` returns false/throws: abort success PRG, surface `_global` error **“We couldn't send your message. Please try again later.”**, respond **HTTP 500**, log at `error`, **do not** mutate cookie/hidden records, **do not** emit any Set-Cookie, keep original identifier for rerender, **rollback ledger reservation** so user can retry.
-  - Error code: `EFORMS_ERR_EMAIL_SEND`.
+- If `send()` returns false/throws: abort success PRG, surface `_global` error **“We couldn't send your message. Please try again later.”**, respond **HTTP 500**, log at `error`, **do not** mutate cookie/hidden records, **do not** emit any Set-Cookie, keep original identifier for rerender, **rollback ledger reservation** so user can retry.
+- Error code: `EFORMS_ERR_EMAIL_SEND`.
 - Success logs at `info`.
 
 **Acceptance**
 
 - Transport failure tests: retries/backoff (per config), error surfaced, 500 status, ledger unreserved, no cookie changes.
 - No Set-Cookie (positive or deletion) emitted on email-failure rerender.
+- Fixtures/tests cover supported template inputs (fields/meta/uploads summary), token expansion for `{{field.key}}`/`{{submitted_at}}`/`{{ip}}`/`{{form_id}}`/`{{submission_id}}`/`{{slot}}`, and escape rules for text (CR/LF normalization) and HTML contexts per [Email Templates (Registry) (§24)](#sec-email-templates).
 
 ---
 


### PR DESCRIPTION
## Summary
- Note that the Phase 8 deliverables include the email template selection pipeline with the §24 token set, slot handling, and canonical inputs.
- Add an acceptance item requiring fixtures/tests for template inputs, token expansion, and escaping rules.

## Testing
- Not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d9ba3a7b2c832d94e8770e0865e0ba