### PR TITLE
Document CI scaffolding checks in roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -314,6 +314,11 @@
 - **Header boundary:** Only `/eforms/prime` emits positive `Set-Cookie`; deletion headers occur on rerender & PRG rows as specified; no positive header in PRG.
 - **No rotation before success:** Identifiers (hidden/cookie/NCID) remain pinned until the success path triggers documented rotations.
 - **Security invariants:** Regex guards before disk; tamper paths hard-fail; error rerenders reuse persisted records; NCID fallbacks preserve dedupe semantics; enforce origin-only CSRF boundary; audit cookie attributes (Path=/, SameSite=Lax, Secure on HTTPS, HttpOnly).
+- **CI scaffolding checks:**
+	- Descriptor resolution test proves every handler surfaced by `Spec::typeDescriptors()` is callable, preventing drift between matrices and helper implementations.【F:docs/electronic_forms_SPEC.md†L1116-L1117】
+	- Schema parity diff regenerates JSON Schema from `TEMPLATE_SPEC` (or vice versa) and fails when enums, required fields, or shapes diverge from the canonical manifest.【F:docs/electronic_forms_SPEC.md†L1117-L1118】
+	- Determinism validation replays a fixed template + inputs and asserts identical error ordering, canonical values, and rendered attribute sets for every run.【F:docs/electronic_forms_SPEC.md†L1117-L1118】
+	- TTL alignment asserts minted records respect `security.token_ttl_seconds` and success tickets honor `security.success_ticket_ttl_seconds`.【F:docs/electronic_forms_SPEC.md†L1118-L1119】
 - **WP-CLI smoke coverage:** Enumerate the commands required to exercise the Origin policy and RuntimeCap checks so CI can invoke them directly, matching the §23 CI scaffolding guidance for WP-CLI smoke tests.【F:docs/electronic_forms_SPEC.md†L1117-L1119】
 
 **Acceptance**


### PR DESCRIPTION
## Summary
- document the descriptor resolution, schema parity, determinism, and TTL CI scaffolding checks in the cross-phase guarantees section
- reference the spec’s CI scaffolding lines so the roadmap cites the canonical requirements

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d9c7d67874832d893a7f1f95195c77