### PR TITLE
Document TemplateContext outputs in Phase 3 roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,6 +67,7 @@
 
 - `TemplateValidator` preflight covering field definitions, row-group constraints, and envelope rules.
 - Manifest/schema source of truth for template metadata referenced by Renderer, SubmitHandler, and challenge flows; runtime uses the preflighted manifest only.
+- TemplateContext outputs enumerated and persisted per [Template Model → Row groups (§5.2)](#sec-template-row-groups) and [Template Model → Template JSON (§5.3)](#sec-template-json), covering descriptors, `max_input_vars_estimate`, sanitized `before_html`/`after_html` fragments, `display_format_tel` tokens, and other canonical fragments consumed by runtime components.
 - CLI/CI wiring that fails builds when templates drift from the canonical schema or omit required rows/fields.
 - Ship default template assets in `/templates/forms/` and `/templates/email/` so deployments have ready-to-use form and email examples.
 - Developer ergonomics: actionable diagnostics, anchor links back to spec sections, fixtures for regression tests.
@@ -76,6 +77,7 @@
 - Golden fixtures for representative templates (hidden, cookie, NCID, uploads) pass preflight.
 - Schema drift or missing sections produce stable error codes/messages.
 - Renderer/SubmitHandler rely exclusively on the validated manifest (no ad-hoc template parsing at runtime).
+- TemplateValidator sanitizes `before_html`/`after_html` via `wp_kses_post`, persists the canonical markup, and exposes TemplateContext fields (descriptors, `max_input_vars_estimate`, sanitized fragments, telephone formatting tokens) required by [Template Model → Template JSON (§5.3)](#sec-template-json) and [Template Model → display_format_tel tokens (§5.4)](#sec-display-format-tel).
 
 ---
 


### PR DESCRIPTION
## Summary
- list TemplateContext deliverables for Phase 3 with links to template model anchors
- add acceptance criteria for sanitizing before_html/after_html and exposing TemplateContext fields

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d9d2f63a94832dad658a36f438bed1