### PR TITLE
Run spec generator for cookie-mode tables

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -476,7 +476,7 @@ This table routes each lifecycle stage to the normative matrices that govern its
                                        `eforms_eid_{form_id}` with a matching Max-Age=0 Set-Cookie header and embed
                                        `/eforms/prime?f={form_id}[&s={slot}]` so the persisted record is reissued before the next
                                        POST without rotating identifiers.
-					**Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
+                                        **Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
                                         <!-- BEGIN GENERATED: cookie-lifecycle-matrix -->
                                         | Flow trigger | Server MUST | Identifier outcome | Notes |
                                         |--------------|-------------|--------------------|-------|
@@ -495,7 +495,7 @@ This table routes each lifecycle stage to the normative matrices that govern its
       Pick the configured policy, consume the row’s `{ token_ok, soft_reasons, require_challenge, identifier, cookie_present? }`, and defer NCID/challenge rerender + header handling to [Cookie header actions](#sec-cookie-header-actions) and [NCID rerender and challenge lifecycle](#sec-ncid-rerender).
 
 --8<-- "generated/security/ncid_rerender.md"
-					**Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
+                                        **Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
                                         <!-- BEGIN GENERATED: cookie-policy-matrix -->
                                         | Policy path | Handling when cookie missing/invalid or record expired | `token_ok` | Soft labels | `require_challenge` | Identifier returned | `cookie_present?` |
                                         |-------------|-----------------------------------------------------|-----------|-------------|--------------------|--------------------|-------------------|


### PR DESCRIPTION
## Summary
- regenerate the cookie lifecycle and policy matrices in `docs/electronic_forms_SPEC.md` using the spec generator script

## Testing
- python tools/generate_spec_sections.py

------
https://chatgpt.com/codex/tasks/task_e_68d9d737e7b4832d82e56a4f3fe53801