### PR TITLE
Update Phase 9B roadmap deliverables for textarea sanitization

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -282,6 +282,7 @@
 - Full validation pipeline: normalize → validate → coerce with stable error codes, redirect safety (§9), suspect handling (§10), throttling (§11), and rerender metadata per [Error handling (§20)](#sec-error-handling).
 - RuntimeCap enforcement that clamps POST bodies using `security.max_post_bytes`, PHP INI (`post_max_size`, `upload_max_filesize`), and `uploads.*` overrides while guarding `CONTENT_LENGTH` and coordinating with upload slot validation (see [POST Size Cap (§6)](#sec-post-size-cap)).
 - Assets and accessibility: enqueue scripts/styles only during rendering, deliver JS usability helpers, and implement accessibility focus/error summary guidance per [Assets (§22)](#sec-assets).
+- Sanitize `textarea_html` via `wp_kses_post` and enforce the post-sanitize size bound per [Special Case: HTML-Bearing Fields](docs/electronic_forms_SPEC.md#sec-html-fields).
 
 **Acceptance**
 


### PR DESCRIPTION
## Summary
- add a Phase 9B deliverable committing to sanitize `textarea_html` with `wp_kses_post` and enforce the post-sanitize size bound per the HTML-bearing fields spec

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68d9e895ec78832dae8837396311f356