### PR TITLE
Document cacheable shortcode rendering modes

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -179,6 +179,7 @@
 	- Hidden-mode: embed payload from `mint_hidden_record()` including the normative `token`, `instance_id`, and `timestamp` hidden fields.
 	- Cookie-mode: deterministic markup plus prime pixel `/eforms/prime?f={form_id}[&s={slot}]`; **renderer never emits Set-Cookie**.
 	- Prime pixel only (no synchronous `/eforms/prime`); follow-up navigation performs the mint.
+- Shortcode `[eform id="…"]` `cacheable=true|false` switch controls hidden-mode vs. cookie-mode rendering per [Request Lifecycle → GET (§19)](electronic_forms_SPEC.md#sec-request-lifecycle-get).
 - WordPress shortcode and template tag entry points bootstrap through the frozen configuration snapshot and document caching guidance, including `Vary: Cookie` scoped to `eforms_s_{form_id}`.
 - **SubmitHandler (POST)**
 	- Orchestrates Security → Normalize → Validate → Coerce → Ledger before any side effects.
@@ -191,6 +192,7 @@
 **Acceptance**
 
 - Matrix-driven GET, POST, and rerender rows for renderer and SubmitHandler flows.
+- Acceptance tests cover both `[eform id="…"]` hidden mode (`cacheable=false`) and cookie mode (`cacheable=true`) rendering flows.
 - Success placeholder path covered by integration tests (banner/no-op) while PRG is deferred.
 - Spam and anti-abuse helpers exercised via golden tests.
 


### PR DESCRIPTION
## Summary
- note that the `[eform id="…"]` shortcode's `cacheable=true|false` switch governs hidden- versus cookie-mode rendering per the GET lifecycle spec
- require acceptance coverage for both `cacheable=false` (hidden mode) and `cacheable=true` (cookie mode) flows in Phase 7A

## Testing
- not run (doc-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9e8811da0832d91c11887bae27910