### PR TITLE
Clarify Phase 9A proxy and IP acceptance tests

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -270,6 +270,8 @@
 - Redaction and rotation snapshots that verify PII handling across `jsonl`, `minimal`, and `off` configurations.
 - Error events assert presence of `request_id`.
 - Logging fixtures cover `logging.on_failure_canonical` by asserting canonical field outputs appear only on rejection when the toggle is enabled.
+- Proxy resolution fixtures exercise `privacy.client_ip_header` and `privacy.trusted_proxies` in CI, covering untrusted `X-Forwarded-For` spoofing, trusted proxy chains, and private-IP fallbacks per [Privacy and IP Handling (§16)](electronic_forms_SPEC.md#sec-privacy).
+- Masked/hash/full mode tests confirm the resolved client IP propagates to logs and emails with the expected redaction per [Privacy and IP Handling (§16)](electronic_forms_SPEC.md#sec-privacy).
 - Level 2 logging tests assert `desc_sha1` emission across sinks.
 
 ---


### PR DESCRIPTION
## Summary
- require Phase 9A acceptance coverage for proxy trust evaluation per Privacy and IP Handling
- document masked/hash/full IP presentation expectations in acceptance tests referencing the privacy spec

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ec31b1f8832d8541ac20b19c2f6d