### PR TITLE
Update Phase 8 email roadmap deliverables

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -239,6 +239,8 @@
 - SMTP/PHPMailer integration; DKIM optional; strict header sanitation; plain text default; HTML allowed via config.
 - Attachments policy; enforce size/count caps before send.
 - Email template selection pipeline matches [`email_template`] JSON keys to `/templates/email/{name}.txt.php` and `{name}.html.php`, enforces the token set/slot handling defined in [Email Templates (Registry) (§24)](#sec-email-templates), and constrains template inputs to the canonical fields/meta/uploads summary.
+- `Reply-To` header sourced from the validated field configured via `email.reply_to_field` per [Email Delivery (§14)](#sec-email).
+- `email.policy` modes (`strict`, `autocorrect`) implemented per [Email Delivery (§14)](#sec-email), including autocorrect's display-only normalization (no persisted mutations).
 - Staging safety (`email.disable_send`, `email.staging_redirect_to`, `X-EForms-Env: staging`, `[STAGING]` subject).
 - **Failure semantics (normative):**
 	- If `send()` returns false/throws: abort success PRG, surface `_global` error **“We couldn't send your message. Please try again later.”**, respond **HTTP 500**, log at `error`, **do not** mutate cookie/hidden records, **skip positive Set-Cookie**, continue emitting NCID/challenge deletion headers when matrices require them, keep original identifier for rerender, **rollback ledger reservation** so user can retry.
@@ -250,6 +252,7 @@
 - Transport failure tests: retries/backoff (per config), error surfaced, 500 status, ledger unreserved, no cookie changes.
 - No positive Set-Cookie emitted on email-failure rerender; NCID/challenge deletion headers still fire when required by matrices.
 - Fixtures/tests cover supported template inputs (fields/meta/uploads summary), token expansion for `{{field.key}}`/`{{submitted_at}}`/`{{ip}}`/`{{form_id}}`/`{{submission_id}}`/`{{slot}}`, and escape rules for text (CR/LF normalization) and HTML contexts per [Email Templates (Registry) (§24)](#sec-email-templates).
+- Acceptance tests cover both `email.policy` modes (`strict`, `autocorrect`)—including autocorrect's display-only normalization—and verify `Reply-To` resolution via `email.reply_to_field`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add Phase 8 deliverables for Reply-To sourcing and email.policy strict/autocorrect modes
- extend acceptance criteria to require tests for policy modes and Reply-To resolution

## Testing
- not run (docs change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9f1612d5c832da30d55ff6aced23d