### PR TITLE
Document Phase 1 config filter enforcement

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,6 +7,7 @@
 **Delivers**
 
 - `Config::get()` (idempotent, per-request snapshot) + `bootstrap()` called exactly-once per request.
+- `Config::bootstrap()` runs the `eforms_config` filter once per request and enforces the clamp/enumeration/unknown-key rules mandated by [Configuration → Domains, Constraints, and Defaults (§17)](#sec-configuration).
 - Snapshot covers `security.*`, `spam.*`, `challenge.*`, `email.*`, `logging.*`, `privacy.*`, `throttle.*`, `validation.*`, `uploads.*`, `assets.*`, `install.*`, defaults (authoritative table in [Configuration: Domains, Constraints, and Defaults (§17)](#sec-configuration)).
 - Shared storage rules: `{h2}` sharding via `Helpers::h2()`, dirs `0700`, files `0600`, with a one-time fallback to `0750/0640` and a warning log when strict creation fails per [Implementation Notes → Helpers](electronic_forms_SPEC.md#sec-implementation-notes).
 - Defensive `Config::get()` calls inside helpers (normative lazy backstop).
@@ -19,6 +20,7 @@
 
 - Multiple `Config::get()` calls in a request are safe; first triggers bootstrap only.
 - Unit tests: snapshot immutability across components; default resolution; missing keys handled per spec.
+- Fixtures/tests prove the `eforms_config` filter executes exactly once per request, reject invalid keys, and clamp configuration values to the §17 ranges/enumerations defined in [Configuration → Domains, Constraints, and Defaults (§17)](#sec-configuration).
 - Uninstall integration tests assert the `defined('WP_UNINSTALL_PLUGIN')` guard, require the Config bootstrap, and respect purge-flag decisions per [Architecture → /electronic_forms/ layout (§3)](electronic_forms_SPEC.md#sec-architecture).
 - Packaging checks confirm `/templates/` ships the protective files and filename allow-list required by [Architecture → /electronic_forms/ layout (§3)](electronic_forms_SPEC.md#sec-architecture).
 - Storage acceptance includes a warning-path assertion so the `0750/0640` fallback continues to be exercised in tests.


### PR DESCRIPTION
## Summary
- clarify that `Config::bootstrap()` runs the `eforms_config` filter and enforces the §17 configuration constraints
- require acceptance coverage that exercises the filter execution, rejects invalid keys, and clamps values to the §17 ranges

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d9f4bf1d1c832da6fed1d247cc445c