### PR TITLE
Align unexpired match definition with prime guidance

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -431,7 +431,8 @@ This table routes each lifecycle stage to the normative matrices that govern its
 - Definition — Status lookup scope = helper loads the form's persisted active minted record; cookie headers participate only in the unexpired-match test.
 
 **Definitions (normative):**
-- **Unexpired match** = request presents `eforms_eid_{form_id}` matching the EID regex **and** storage has a record for that EID with `now < record.expires`; equality is evaluated against that record's `eid`.
+- **Unexpired match** = request presents `eforms_eid_{form_id}` matching the EID regex **and** storage has a record for that EID with `now < record.expires`; equality compares against the persisted `eid` minted under the configured attributes.
+- Definition — Attribute inference = HTTP requests never echo Path/SameSite/Secure, so treat the stored mint metadata as authoritative when evaluating matches.
 - Definition — Presented cookie = the request supplies `eforms_eid_{form_id}` matching the EID regex.
 - Definition — Hit without match = `status:"hit"` but no unexpired match; `/eforms/prime` MUST still send the positive header per [Cookie header actions](#sec-cookie-header-actions).
 - **Header boundary (normative)** — [Cookie header actions matrix](#sec-cookie-header-actions) is authoritative for which flow emits which header. `/eforms/prime` remains the sole source of a positive `Set-Cookie` for `eforms_eid_{form_id}`.


### PR DESCRIPTION
## Summary
- align the cookie-mode contract’s narrative definition of an unexpired match with the generated prime guidance
- add an explicit attribute-inference definition so implementers rely on the stored mint metadata when evaluating `/eforms/prime`

## Testing
- python3 scripts/spec_lint.py *(fails: existing include guard warnings about cookie header and NCID blocks)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f2c80878832dbe6e004d7b2246a4