### PR TITLE
Document HANDLERS registry deliverables in Phase 9B

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -300,6 +300,7 @@
 **Delivers**
 
 - Full validation pipeline: normalize → validate → coerce with stable error codes, redirect safety (§9), suspect handling (§10), throttling (§11), and rerender metadata per [Error handling (§20)](#sec-error-handling).
+- Private `HANDLERS` registries (validators, normalizers/coercers, renderers, uploads) with spec-aligned `resolve()` helpers so runtime lookups stay centralized and pluggable without bypassing the authoritative tables.
 - RuntimeCap enforcement that clamps POST bodies using `security.max_post_bytes`, PHP INI (`post_max_size`, `upload_max_filesize`), and `uploads.*` overrides while guarding `CONTENT_LENGTH` and coordinating with upload slot validation (see [POST Size Cap (§6)](#sec-post-size-cap)).
 - Assets and accessibility: enqueue scripts/styles only during rendering, deliver JS usability helpers, and implement accessibility focus/error summary guidance per [Accessibility (§12)](#sec-accessibility) and [Assets (§22)](#sec-assets), including label/control associations, fieldset/legend grouping, role/ARIA obligations for the error summary, and focus-management rules when native validation remains enabled (`html5.client_validation=true`): skip pre-submit summary focus to avoid double focus, yet still move focus to the first invalid control after server rerenders.
 - Sanitize `textarea_html` via `wp_kses_post` and enforce the post-sanitize size bound per [Special Case: HTML-Bearing Fields](docs/electronic_forms_SPEC.md#sec-html-fields).
@@ -310,6 +311,7 @@
 - Oversized and boundary payload fixtures covering RuntimeCap clamps, validation errors, and `CONTENT_LENGTH` guards.
 - Accessibility tests cover focus management alongside markup requirements: labels tied to controls, grouped inputs wrapped in fieldset/legend, and role="alert" summary behavior.
 - Tests cover each bounded cross-field rule type defined in [Validation → Cross-field rules (§10)](#sec-cross-field-rules).
+- Registry fixtures assert lazy initialization and lookup failure paths for each `HANDLERS` table so the registries remain the single source of truth for validator, normalizer/coercer, renderer, and upload resolution.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a Phase 9B deliverable committing to implement the private HANDLERS registries and resolve() helpers for validators, normalizers/coercers, renderers, and uploads
- extend Phase 9B acceptance criteria to cover lazy initialization and lookup failure tests so the registries remain the single source of truth

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dab2585490832d89b744b19d6934f9