### PR TITLE
Document js_hard_mode enforcement in Phase 7A roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -198,7 +198,7 @@
 	- Enforces cookie handling and NCID transitions per matrices; **no mid-flow mode swaps**.
 	- Error rerenders reuse persisted records, emit `Cache-Control: private, no-store`, and honor the NCID rerender contract (delete + re-prime when specified).
 	- Wires spam headers (`X-EForms-Soft-Fails`, `X-EForms-Suspect`) and subject tagging while respecting `spam.soft_fail_threshold` outcomes.
-- Anti-abuse helpers: honeypot modes, minimum-fill timers, `js_ok`, and `max_form_age` soft enforcement with explicit helper contracts and fixtures, including `stealth_success` flows emitting `X-EForms-Stealth: 1` and logging `stealth:true` per [Security → Honeypot (§7.2)](electronic_forms_SPEC.md#sec-honeypot).
+- Anti-abuse helpers: honeypot modes, minimum-fill timers, `js_ok`, and `max_form_age` soft enforcement with explicit helper contracts and fixtures, including `stealth_success` flows emitting `X-EForms-Stealth: 1` and logging `stealth:true` per [Security → Honeypot (§7.2)](electronic_forms_SPEC.md#sec-honeypot). When `security.js_hard_mode=true`, non-JS submissions hard-fail as mandated by [Security → Timing Checks (§7.3)](electronic_forms_SPEC.md#sec-timing-checks) with defaults enumerated in [Configuration → Domains, Constraints, and Defaults (§17)](electronic_forms_SPEC.md#sec-configuration).
 - Success placeholder: temporary no-op banner that defers PRG semantics to [Phase 7B](#phase-7b).
 
 **Acceptance**
@@ -206,6 +206,7 @@
 - Matrix-driven GET, POST, and rerender rows for renderer and SubmitHandler flows.
 - Success placeholder path covered by integration tests (banner/no-op) while PRG is deferred.
 - Spam and anti-abuse helpers exercised via golden tests.
+- Golden tests cover `security.js_hard_mode`, proving `js_ok` hard-fails non-JS submissions when enabled while the default configuration retains soft behavior per [Security → Timing Checks (§7.3)](electronic_forms_SPEC.md#sec-timing-checks) and [Configuration → Domains, Constraints, and Defaults (§17)](electronic_forms_SPEC.md#sec-configuration).
 - Honeypot fixtures assert the `X-EForms-Stealth: 1` header and stealth logging output when `stealth_success` is configured, alongside existing coverage.
 - Integration or snapshot test asserts the `max_input_vars` advisory/comment appears when the heuristic triggers.
 


### PR DESCRIPTION
## Summary
- call out the `security.js_hard_mode` toggle in the Phase 7A anti-abuse helpers deliverables and reference the timing and configuration specs
- add an acceptance bullet requiring tests that prove `js_hard_mode` forces hard failures and that the default soft behavior remains in place

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dac34d17f8832dac372b48991ef0d6