### PR TITLE
Clarify Phase 8 emailer roadmap requirements

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -246,7 +246,7 @@
 
 **Delivers**
 
-- SMTP/PHPMailer integration; DKIM optional; strict header sanitation; plain text default; HTML allowed via config.
+- SMTP/PHPMailer integration; DKIM optional; plain text default; HTML allowed via config; enforce the DMARC-aligned `From:` fallback (`no-reply@{site_domain}`), same-domain `From` requirement, optional `email.envelope_sender`, and Subject/header sanitization rules from [Email Delivery (§14)](#sec-email).
 - Attachments policy; enforce size/count caps before send.
 - Register `wp_mail_failed` handler to log send failures and surface diagnostics per [Email Delivery (§14)](#sec-email).
 - Register `phpmailer_init` handler to apply DKIM and debug configuration before dispatch per [Email Delivery (§14)](#sec-email).


### PR DESCRIPTION
## Summary
- align the Phase 8 Emailer deliverable with §14 by spelling out the DMARC-aligned From fallback, same-domain requirement, optional `email.envelope_sender`, and header sanitization expectations, and linking back to the normative mail section

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dac8c806ac832d87df19d3650a91fb