### PR TITLE
chore: regenerate spec tables

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -279,6 +279,7 @@ This table routes each lifecycle stage to the normative matrices that govern its
 **Pipeline-first outline (render → persist → POST → challenge → normalization → ledger → success)**
 
 **Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
+
 <!-- BEGIN GENERATED: lifecycle-quickstart -->
 | Stage | Overview |
 |-------|----------|
@@ -444,6 +445,7 @@ This table routes each lifecycle stage to the normative matrices that govern its
 **Slot handling:**
 
 **Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
+
 <!-- BEGIN GENERATED: slot-handling-summary -->
 - `Security::mint_cookie_record()` never unions slots.
 - `/eforms/prime` performs `slots_allowed ∪ {s}` (when allowed), derives `slot` when `|slots_allowed| == 1`, and persists only those fields; it MUST NOT rewrite `issued_at`/`expires`.
@@ -481,6 +483,7 @@ This table routes each lifecycle stage to the normative matrices that govern its
                                         - Definition — Deletion header options = Match the minted cookie’s Name/Path/SameSite/Secure/HttpOnly attributes (and Domain when the mint included one) and clear it via `Max-Age=0` or an already-expired `Expires` value. Host-only mints omit Domain; the deletion header MUST do the same.
 
                                         **Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
+
                                         <!-- BEGIN GENERATED: cookie-lifecycle-matrix -->
                                         | Flow trigger | Server MUST | Identifier outcome | Notes |
                                         |--------------|-------------|--------------------|-------|
@@ -500,6 +503,7 @@ This table routes each lifecycle stage to the normative matrices that govern its
 
 --8<-- "generated/security/ncid_rerender.md"
                                         **Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
+
                                         <!-- BEGIN GENERATED: cookie-policy-matrix -->
                                         | Policy path | Handling when cookie missing/invalid or record expired | `token_ok` | Soft labels | `require_challenge` | Identifier returned | `cookie_present?` |
                                         |-------------|-----------------------------------------------------|-----------|-------------|--------------------|--------------------|-------------------|
@@ -517,6 +521,7 @@ This table routes each lifecycle stage to the normative matrices that govern its
 			- Prime endpoint semantics (`/eforms/prime`):
 
 				**Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
+
 				<!-- BEGIN GENERATED: prime-set-cookie-guidance -->
 				- Set-Cookie attributes (normative): When `/eforms/prime` sends `Set-Cookie`, it MUST set `eforms_eid_{form_id}` with:
 					- `Path=/`
@@ -572,6 +577,7 @@ This table routes each lifecycle stage to the normative matrices that govern its
 - <a id="sec-ncid-success-ref"></a>NCID success integration: Redirect-only success handling, redirect target selection, and verifier requirements are defined by [NCID success handoff (Cookie/NCID reference)](#sec-cookie-ncid-summary). [Success Behavior (PRG)](#sec-success) repeats the rules informatively.
 <a id="sec-cookie-ncid-summary"></a>Cookie/NCID reference (authoritative summary):
 **Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
+
 <!-- BEGIN GENERATED: cookie-ncid-summary -->
 | Scenario | Identifier outcome | Required action | Canonical section |
 |----------|--------------------|-----------------|-------------------|

--- a/docs/generated/security/cookie_headers.md
+++ b/docs/generated/security/cookie_headers.md
@@ -1,4 +1,5 @@
 **Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
+
 <!-- BEGIN GENERATED: cookie-header-actions -->
 | Flow trigger | Header action | Invariants |
 |--------------|---------------|------------|

--- a/docs/generated/security/ncid_rerender.md
+++ b/docs/generated/security/ncid_rerender.md
@@ -1,4 +1,5 @@
 **Generated from `tools/spec_sources/security_data.yaml` — do not edit manually.**
+
 <!-- BEGIN GENERATED: ncid-rerender-steps -->
 - **Expire the minted cookie** — MUST delete `eforms_eid_{form_id}` via a `Set-Cookie` header whose Name/Path/SameSite/Secure/HttpOnly attributes match the minted cookie and whose `Max-Age=0` (or `Expires` is in the past) whenever NCID fallback or challenge rerenders fire, including the challenge verification success response and the PRG redirect on challenge success.
 - **Re-prime via `/eforms/prime`** — MUST embed `/eforms/prime?f={form_id}[&s={slot}]` on those rerenders so the persisted record is reissued before the next POST; the rerender itself MUST NOT emit a positive `Set-Cookie`.

--- a/tools/generate_spec_sections.py
+++ b/tools/generate_spec_sections.py
@@ -406,6 +406,7 @@ def format_ncid_summary_rows(rows: list[dict]) -> list[dict[str, str]]:
 def render_ncid_rerender_steps(steps: list[dict]) -> str:
     lines = [
         POINTER_TEXT,
+        "",
         "<!-- BEGIN GENERATED: ncid-rerender-steps -->",
     ]
     for step in steps:
@@ -457,6 +458,7 @@ def render_bullet_block(
 ) -> list[str]:
     lines = [
         base_indent + POINTER_TEXT,
+        "",
         base_indent + f"<!-- BEGIN GENERATED: {name} -->",
     ]
     lines.extend(render_bullet_rows(rows, base_indent=base_indent, indent_unit=indent_unit))
@@ -707,7 +709,11 @@ def render_table(config: dict, rows: list[dict[str, str]]) -> list[str]:
         lines.append(line)
     indent = get_indent_string(config)
     prefixed = [indent + line if line else line for line in lines]
-    block = [indent + POINTER_TEXT, indent + f"<!-- BEGIN GENERATED: {config['name']} -->"]
+    block = [
+        indent + POINTER_TEXT,
+        "",
+        indent + f"<!-- BEGIN GENERATED: {config['name']} -->",
+    ]
     block.extend(prefixed)
     block.append(indent + f"<!-- END GENERATED: {config['name']} -->")
     return block
@@ -761,18 +767,24 @@ def integrate_generated_content(data: dict, *, check: bool) -> bool:
                 start_idx = None
                 end_idx = None
                 for idx, line in enumerate(updated):
-                    if idx + 1 >= len(updated):
+                    if line != pointer_line:
                         continue
-                    if line == pointer_line and updated[idx + 1] == begin_marker:
+                    next_idx = idx + 1
+                    while next_idx < len(updated) and updated[next_idx] == "":
+                        next_idx += 1
+                    if next_idx < len(updated) and updated[next_idx] == begin_marker:
                         start_idx = idx
                         break
                 if start_idx is None:
                     trimmed_pointer = POINTER_TEXT.strip()
                     trimmed_begin = begin_marker.strip()
                     for idx, line in enumerate(updated):
-                        if idx + 1 >= len(updated):
+                        if line.strip() != trimmed_pointer:
                             continue
-                        if line.strip() == trimmed_pointer and updated[idx + 1].strip() == trimmed_begin:
+                        next_idx = idx + 1
+                        while next_idx < len(updated) and updated[next_idx].strip() == "":
+                            next_idx += 1
+                        if next_idx < len(updated) and updated[next_idx].strip() == trimmed_begin:
                             start_idx = idx
                             break
                 if start_idx is None:


### PR DESCRIPTION
## Summary
- add a blank line between the pointer notice and generated markers when rendering spec tables for improved readability
- regenerate the security spec includes so the Markdown now matches the updated generator formatting

## Testing
- python tools/generate_spec_sections.py --check

------
https://chatgpt.com/codex/tasks/task_e_68dadec6b244832d84cb860b6b7a701b