### PR TITLE
Clarify Phase 6 and Phase 10 slot unioning responsibilities

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -158,9 +158,10 @@
 
 - Calls `Config::get()` then `mint_cookie_record(form_id, slot?)`.
 - Load/update record; **Conditional header action** (the only flow allowed to emit the positive `Set-Cookie` for `eforms_eid_{form_id}` minted by `/eforms/prime`, leaving other cookies such as success tickets to their own flows):
-  - **Send** the conditional header action’s positive `Set-Cookie` when the request **lacks an unexpired match** (mint/remint; expired/missing record; cookie omitted/malformed/mismatched).
-  - **Skip** the conditional header action only when an identical, unexpired cookie is present (same Name/Value/Path/SameSite/Secure).
+	- **Send** the conditional header action’s positive `Set-Cookie` when the request **lacks an unexpired match** (mint/remint; expired/missing record; cookie omitted/malformed/mismatched).
+	- **Skip** the conditional header action only when an identical, unexpired cookie is present (same Name/Value/Path/SameSite/Secure).
 - Set-Cookie attrs (normative): `Path=/`, `Secure` (HTTPS only), `HttpOnly`, `SameSite=Lax`, `Max-Age` = TTL on mint, or remaining lifetime on reissue.
+- `/eforms/prime`: persist `slots_allowed ∪ {s}` (when allowed), derive `slot` when the union contains exactly one member, and update only those fields using the atomic write contract without rewriting `issued_at/expires`, per [Security → Cookie-mode contract → Prime endpoint semantics](electronic_forms_SPEC.md#sec-cookie-mode).
 - Response: `204` + `Cache-Control: no-store`.
 - No header emission elsewhere except deletion per matrices (rerender/PRG).
 
@@ -171,7 +172,8 @@
 - Identical, unexpired cookie ⇒ skip the conditional header action.
 - Reissue uses remaining-lifetime (`record.expires - now`) for `Max-Age`.
 - Renderer never emits Set-Cookie; `/eforms/prime` not called synchronously on GET.
-- Never rewrite `issued_at/expires` on hit; slot unioning is deferred to [Phase 10](#phase-10).
+- Never rewrite `issued_at/expires` on hit; slot unioning updates persist `slots_allowed`/`slot` atomically per [Security → Cookie-mode contract → Prime endpoint semantics](electronic_forms_SPEC.md#sec-cookie-mode).
+- Concurrency tests for `/eforms/prime` simulate slot unions and concurrent updates to ensure atomic persistence prevents truncated or reverted `slots_allowed` state.
 - Tests for attribute equality & remaining-lifetime logic.
 
 ---
@@ -331,13 +333,12 @@
 
 ## Phase 10: Slots (unioning & enforcement) {#phase-10}
 
-**Goal:** Add slot semantics **after** core cookie flow is stable; keep unioning isolated to `/eforms/prime` and validation to POST.
+**Goal:** Finalize slot semantics **after** core cookie flow is stable, building on the `/eforms/prime` unioning shipped in [Phase 6](#phase-6); keep unioning isolated to `/eforms/prime` and validation to POST.
 
 **Dependencies:** Extends the `/eforms/prime` storage writes from [Phase 6](#phase-6); do not start until that endpoint ships the unexpired-match contract.
 
 **Delivers**
 
-- `/eforms/prime`: `slots_allowed ∪ {s}` (when allowed), derive `slot` when union size is 1, and persist only those fields using the atomic write contract without rewriting `issued_at/expires`, per [Security → Cookie-mode contract → Prime endpoint semantics](electronic_forms_SPEC.md#sec-cookie-mode).
 - Renderer: deterministic slot selection per GET; surplus instances slotless.
 - POST enforcement: when slotted, require posted integer slot ∈ allowed set and consistent with record; otherwise hard fail; slotless deployments reject posted slot.
 - Submission ID shape in cookie mode when slotted: `eid__slot{n}`.
@@ -349,7 +350,6 @@
 - Rerender rows preserve deterministic slot & follow delete+re-prime contract.
 - Global slots disabled ⇒ posted `eforms_slot` hard-fails.
 - Posted slot must exist in config allow-list and the record's `slots_allowed`.
-- Concurrency tests for `/eforms/prime` simulate slot unions and concurrent updates to ensure atomic persistence prevents truncated or reverted `slots_allowed` state.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that Phase 6 now persists `slots_allowed`/`slot` updates during `/eforms/prime`
- adjust Phase 6 acceptance to cover atomic slot unioning and drop the Phase 10 deferral
- narrow Phase 10 scope to renderer and POST enforcement work that layers on Phase 6 unioning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daf03fea24832db486565387e385dd