### PR TITLE
Clarify returned record scope for mint_cookie_record

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -423,6 +423,7 @@ This table routes each lifecycle stage to the normative matrices that govern its
 		- `miss` = no prior record
 		- `expired` = prior record exists and `now >= prior.expires`  
 		- `hit` = prior record exists and `now < prior.expires`  
+	- Definition — Returned record scope = On `status ∈ {miss, expired}`, the helper returns `record.slots_allowed=[]` and `record.slot=null`; `/eforms/prime` MUST apply the slot union after this helper returns per [Cookie-mode lifecycle](#sec-cookie-lifecycle-matrix).
 	- After any remint (miss/expired), `record.expires` reflects the newly persisted value.
 - Failure modes:
         - Invalid/disabled `slot?` (not allowed or outside 1–255) is normalized to `null`; on miss/expired writes the helper ignores `slot?` and persists `{ slots_allowed:[], slot:null }`, leaving `/eforms/prime` to union slots after it returns; `status:"hit"` leaves the existing `slots_allowed`/`slot` fields untouched.


### PR DESCRIPTION
## Summary
- clarify that mint_cookie_record returns slot metadata prior to /eforms/prime slot union so implementers follow the matrix contract

## Testing
- python3 scripts/spec_lint.py docs/electronic_forms_SPEC.md

------
https://chatgpt.com/codex/tasks/task_e_68db0060bc18832dba4c6947299e1f88