### PR TITLE
Clarify novalidate handling for html5 client validation

### DIFF
--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -1045,7 +1045,7 @@ Defaults note: When this spec refers to a ‘Default’, the authoritative liter
 	- CDN/cache notes: bypass caching on non-cacheable token pages; /eforms/prime is no-store; do not strip Set-Cookie on 204.
 	- Initialize Logging only when logging.mode != "off".
 	- Initialize Uploads only when uploads.enable=true and template declares file/files (detected at preflight).
-- Renderer never adds `novalidate`; when `html5.client_validation=true`, retain HTML5 validation hints so browsers can run native checks, and when `false`, still omit `novalidate` and leave any suppression of native UI to custom templates. The server validator always runs on POST.
+- Renderer toggles the `novalidate` attribute based on `html5.client_validation`: omit it when the flag is `true` so browsers present native validation UI, and include it when the flag is `false` to suppress native validation in favor of server feedback. The server validator always runs on POST.
 	- Preflight resolves and freezes per-request resolved descriptors; reuse across Renderer and Validator (no re-merge on POST).
 
 	<a id="sec-request-lifecycle-post"></a>2. POST
@@ -1092,14 +1092,14 @@ Defaults note: When this spec refers to a ‘Default’, the authoritative liter
 	- assets.css_disable=true lets themes opt out
 	- On submit failure, focus the first control with an error
 	- Focus styling (a11y): do not remove outlines unless visible replacement is provided. For inside-the-box focus: outline: 1px solid #b8b8b8 !important; outline-offset: -1px;
-- Renderer never adds `novalidate`, so native validation UI remains active. When `html5.client_validation=true`, skip pre-submit summary focus to avoid double-focus yet still move focus to the first invalid control after server rerenders. When the flag is `false`, any suppression of native UI requires template overrides outside the renderer.
+- Renderer toggles the `novalidate` attribute based on `html5.client_validation`: when the flag is `true`, omit the attribute so native validation UI runs, and when `false`, include it to disable native validation in favor of server-rendered errors. With native UI active, skip pre-submit summary focus to avoid double-focus yet still move focus to the first invalid control after server rerenders.
 	- Only enqueue provider script when the challenge is rendered:
 	- Turnstile: https://challenges.cloudflare.com/turnstile/v0/api.js (defer, crossorigin=anonymous)
 	- hCaptcha: https://hcaptcha.com/1/api.js (defer)
 	- reCAPTCHA v2: https://www.google.com/recaptcha/api.js (defer)
 - Do not load challenge script on the initial GET. “Always” mode does not override this; challenges are rendered on POST rerender or during verification only.
 	- Secrets hygiene: Render only site_key to HTML. Never expose secret_key or verify tokens in markup/JS. Verify server-side; redact tokens in logs.
-	- Honor novalidate behavior: do not add `novalidate`; progressive enhancement depends on native validation.
+- Honor novalidate behavior: add `novalidate` only when `html5.client_validation=false`; omit it otherwise so progressive enhancement retains native validation.
 
 <a id="sec-implementation-notes"></a>
 23. NOTES FOR IMPLEMENTATION

--- a/docs/electronic_forms_SPEC.md
+++ b/docs/electronic_forms_SPEC.md
@@ -1045,7 +1045,7 @@ Defaults note: When this spec refers to a ‘Default’, the authoritative liter
 	- CDN/cache notes: bypass caching on non-cacheable token pages; /eforms/prime is no-store; do not strip Set-Cookie on 204.
 	- Initialize Logging only when logging.mode != "off".
 	- Initialize Uploads only when uploads.enable=true and template declares file/files (detected at preflight).
-	- html5.client_validation=true → omit novalidate; server validator still runs on POST.
+- Renderer never adds `novalidate`; when `html5.client_validation=true`, retain HTML5 validation hints so browsers can run native checks, and when `false`, still omit `novalidate` and leave any suppression of native UI to custom templates. The server validator always runs on POST.
 	- Preflight resolves and freezes per-request resolved descriptors; reuse across Renderer and Validator (no re-merge on POST).
 
 	<a id="sec-request-lifecycle-post"></a>2. POST
@@ -1092,7 +1092,7 @@ Defaults note: When this spec refers to a ‘Default’, the authoritative liter
 	- assets.css_disable=true lets themes opt out
 	- On submit failure, focus the first control with an error
 	- Focus styling (a11y): do not remove outlines unless visible replacement is provided. For inside-the-box focus: outline: 1px solid #b8b8b8 !important; outline-offset: -1px;
-	- html5.client_validation=true: do not suppress native validation UI; skip pre-submit summary focus to avoid double-focus; after server rerender with errors, still focus first invalid control.
+- Renderer never adds `novalidate`, so native validation UI remains active. When `html5.client_validation=true`, skip pre-submit summary focus to avoid double-focus yet still move focus to the first invalid control after server rerenders. When the flag is `false`, any suppression of native UI requires template overrides outside the renderer.
 	- Only enqueue provider script when the challenge is rendered:
 	- Turnstile: https://challenges.cloudflare.com/turnstile/v0/api.js (defer, crossorigin=anonymous)
 	- hCaptcha: https://hcaptcha.com/1/api.js (defer)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -193,7 +193,7 @@
 \t- Forms emit `<form method="post">` and add `enctype="multipart/form-data"` whenever upload fields are present (TemplateContext `has_uploads`), per [Request Lifecycle → GET (§19)](#sec-request-lifecycle-get).
 \t- Shortcode `[eform id="…"]` `cacheable=true|false` switch controls hidden-mode vs. cookie-mode rendering per [Request Lifecycle → GET (§19)](electronic_forms_SPEC.md#sec-request-lifecycle-get).
 \t- Log and optionally surface the `max_input_vars` advisory per [Request lifecycle → GET (§19)](#sec-request-lifecycle-get).
-\t- Honor `html5.client_validation`: renderer never adds `novalidate`; when `true`, retain HTML5 validation hints so browsers run native checks, and when `false`, still omit `novalidate` and leave suppression of native UI to template overrides while server-side validation remains authoritative.
+\t- Honor `html5.client_validation`: omit `novalidate` when the flag is `true` so browsers run native validation, and add `novalidate` when the flag is `false` to suppress native checks while server-side validation remains authoritative.
 - WordPress shortcode and template tag entry points bootstrap through the frozen configuration snapshot and document caching guidance, including `Vary: Cookie` scoped to `eforms_s_{form_id}`.
 - **SubmitHandler (POST)**
 	- Orchestrates Security → Normalize → Validate → Coerce → Ledger before any side effects.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -193,7 +193,7 @@
 \t- Forms emit `<form method="post">` and add `enctype="multipart/form-data"` whenever upload fields are present (TemplateContext `has_uploads`), per [Request Lifecycle → GET (§19)](#sec-request-lifecycle-get).
 \t- Shortcode `[eform id="…"]` `cacheable=true|false` switch controls hidden-mode vs. cookie-mode rendering per [Request Lifecycle → GET (§19)](electronic_forms_SPEC.md#sec-request-lifecycle-get).
 \t- Log and optionally surface the `max_input_vars` advisory per [Request lifecycle → GET (§19)](#sec-request-lifecycle-get).
-\t- Honor `html5.client_validation`: when `true`, omit `novalidate` and retain required/pattern attributes so browsers run native checks; when `false`, add `novalidate` and suppress native validation UI so server-side errors remain authoritative.
+\t- Honor `html5.client_validation`: renderer never adds `novalidate`; when `true`, retain HTML5 validation hints so browsers run native checks, and when `false`, still omit `novalidate` and leave suppression of native UI to template overrides while server-side validation remains authoritative.
 - WordPress shortcode and template tag entry points bootstrap through the frozen configuration snapshot and document caching guidance, including `Vary: Cookie` scoped to `eforms_s_{form_id}`.
 - **SubmitHandler (POST)**
 	- Orchestrates Security → Normalize → Validate → Coerce → Ledger before any side effects.


### PR DESCRIPTION
## Summary
- clarify the spec and roadmap so the renderer never adds `novalidate` and `html5.client_validation` only preserves native hints while leaving any suppression to template overrides

## Testing
- python scripts/spec_lint.py *(fails: sections referencing #sec-cookie-header-actions must include generated/security/cookie_headers.md)*

------
https://chatgpt.com/codex/tasks/task_e_68dafff0e654832dbcf5a87e39098efd