### PR TITLE
Update CI scaffolding citations

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -386,11 +386,11 @@
 - **Security invariants:** Regex guards before disk; tamper paths hard-fail; error rerenders reuse persisted records; NCID fallbacks preserve dedupe semantics; enforce origin-only CSRF boundary; audit cookie attributes (Path=/, SameSite=Lax, Secure on HTTPS, HttpOnly).
 - **CI scaffolding checks:**
 	- Config defaults parity test: CI loads the §17 configuration table and diffs it against `Config::DEFAULTS` (key coverage plus clamp/enum metadata) so spec/implementation drift fails fast; wire this parity check into phpunit/spec-lint as part of the build.【F:docs/electronic_forms_SPEC.md†L922-L992】
-	- Descriptor resolution test proves every handler surfaced by `Spec::typeDescriptors()` is callable, preventing drift between matrices and helper implementations.【F:docs/electronic_forms_SPEC.md†L1116-L1117】
-	- Schema parity diff regenerates JSON Schema from `TEMPLATE_SPEC` (or vice versa) and fails when enums, required fields, or shapes diverge from the canonical manifest.【F:docs/electronic_forms_SPEC.md†L1117-L1118】
-	- Determinism validation replays a fixed template + inputs and asserts identical error ordering, canonical values, and rendered attribute sets for every run.【F:docs/electronic_forms_SPEC.md†L1117-L1118】
-	- TTL alignment asserts minted records respect `security.token_ttl_seconds` and success tickets honor `security.success_ticket_ttl_seconds`.【F:docs/electronic_forms_SPEC.md†L1118-L1119】
-- **WP-CLI smoke coverage:** Enumerate the commands required to exercise the Origin policy and RuntimeCap checks so CI can invoke them directly, matching the §23 CI scaffolding guidance for WP-CLI smoke tests.【F:docs/electronic_forms_SPEC.md†L1117-L1119】
+- Descriptor resolution test proves every handler surfaced by `Spec::typeDescriptors()` is callable, preventing drift between matrices and helper implementations.【F:docs/electronic_forms_SPEC.md†L1142-L1144】
+- Schema parity diff regenerates JSON Schema from `TEMPLATE_SPEC` (or vice versa) and fails when enums, required fields, or shapes diverge from the canonical manifest.【F:docs/electronic_forms_SPEC.md†L1144-L1145】
+- Determinism validation replays a fixed template + inputs and asserts identical error ordering, canonical values, and rendered attribute sets for every run.【F:docs/electronic_forms_SPEC.md†L1145-L1145】
+- TTL alignment asserts minted records respect `security.token_ttl_seconds` and success tickets honor `security.success_ticket_ttl_seconds`.【F:docs/electronic_forms_SPEC.md†L1146-L1146】
+- **WP-CLI smoke coverage:** Enumerate the commands required to exercise the Origin policy and RuntimeCap checks so CI can invoke them directly, matching the §23 CI scaffolding guidance for WP-CLI smoke tests.【F:docs/electronic_forms_SPEC.md†L1147-L1149】
 
 **Acceptance**
 


### PR DESCRIPTION
## Summary
- retarget roadmap CI scaffolding citations to the updated spec ranges covering descriptor, schema, determinism, and TTL checks
- align the WP-CLI smoke coverage citation with the spec’s CI scaffolding subsection

## Testing
- python -m markdown docs/roadmap.md > /tmp/roadmap.html

------
https://chatgpt.com/codex/tasks/task_e_68db08793804832d98d094bb25631f37