### PR TITLE
Add documentation guide for spec resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Lightweight PHP form handler for WordPress.
 
+## Documentation
+
+- See [Documentation Guide](docs/README.md) for an overview of the spec, roadmap, and generated excerpts.
+
 ## Architecture
 
 - `eforms.php` boots the plugin, sets up rewrite rules, autoloads `src/`, and registers the `[eform]` shortcode.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Documentation Guide {#sec-documentation-guide}
+
+This guide orients contributors to the eForms documentation set so you can quickly find the right reference for any task. It also explains how to regenerate the generated spec excerpts that live alongside the canonical narrative.
+
+## Structure overview {#sec-docs-structure}
+
+- `docs/electronic_forms_SPEC.md` — The canonical product specification. Start here for authoritative behaviour, security, and integration details.
+- `docs/roadmap.md` — High-level planning notes, upcoming milestones, and sequencing context.
+- `docs/generated/` — Machine-generated excerpts that keep long tables and helper summaries in sync with the YAML sources under `tools/spec_sources/`.
+
+	- `docs/generated/security/` collects derived security tables (such as cookie policies and NCID rerender flows) that should never be hand-edited.
+
+## Regenerating spec excerpts {#sec-regenerating-spec-excerpts}
+
+Files under `docs/generated/security/` are generated from the YAML inputs in `tools/spec_sources/` using `tools/generate_spec_sections.py`. To refresh them:
+
+1. Ensure you have Python 3 available and install the `PyYAML` dependency if it is not already present: `pip install PyYAML`.
+2. From the repository root, run:
+
+	```sh
+	python tools/generate_spec_sections.py
+	```
+
+The script validates the YAML schema before rewriting the generated Markdown files. Commit both the updated generated files and any source YAML edits together to avoid drift between the canonical data and the published excerpts.


### PR DESCRIPTION
## Summary
- add a documentation guide under docs/ that maps the spec, roadmap, and generated excerpts
- explain how to regenerate the generated security spec excerpts and list prerequisites
- link the new guide from the root README so contributors can find it quickly

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dda047eea4832db27688e2ce0c6595