### PR TITLE
Add installation guidance and expanded documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Lightweight PHP form handler for WordPress.
 ## Installation
 
 1. Place the plugin directory inside `wp-content/plugins/` so WordPress can discover it.
-2. Run `composer install` within the plugin directory to install PHP dependencies.
-3. Activate the plugin from the WordPress admin Plugins screen once the files and dependencies are in place.
+2. (Optional for contributors) Run `composer install` within the plugin directory to set up the development-only tooling used for local testing; the packaged plugin ships with no runtime Composer dependencies.
+3. Activate the plugin from the WordPress admin Plugins screen once the files are in place.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 Lightweight PHP form handler for WordPress.
 
+## Installation
+
+1. Place the plugin directory inside `wp-content/plugins/` so WordPress can discover it.
+2. Run `composer install` within the plugin directory to install PHP dependencies.
+3. Activate the plugin from the WordPress admin Plugins screen once the files and dependencies are in place.
+
 ## Documentation
 
-- See [Documentation Guide](docs/README.md) for an overview of the spec, roadmap, and generated excerpts.
+- [Electronic Forms Spec](docs/electronic_forms_SPEC.md) details the end-to-end submission, security, and rendering requirements the plugin must meet.
+- [Roadmap](docs/roadmap.md) highlights upcoming milestones, outstanding work, and longer-term ideas.
+- [Documentation Guide](docs/README.md) explains how the documentation set is organized and where to find generated excerpts.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- add an installation section explaining how to place the plugin, install dependencies, and activate it
- expand the documentation section to link directly to the spec, roadmap, and documentation guide

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dda39ddeb8832d84e8227791e96265