### PR TITLE
Document minimum platform requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Lightweight PHP form handler for WordPress.
 
 ## Installation
 
+Requirements: PHP 8.0+ and WordPress 5.8+, as detailed in [Electronic Forms Spec → Compatibility and Updates](docs/electronic_forms_SPEC.md#sec-compatibility).
+
 1. Place the plugin directory inside `wp-content/plugins/` so WordPress can discover it.
 2. (Optional for contributors) Run `composer install` within the plugin directory to set up the development-only tooling used for local testing; the packaged plugin ships with no runtime Composer dependencies.
 3. Activate the plugin from the WordPress admin Plugins screen once the files are in place.


### PR DESCRIPTION
## Summary
- add an installation note highlighting the PHP 8.0+ and WordPress 5.8+ minimums
- link the new requirements sentence to the spec's compatibility section for the authoritative source

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda819b930832db7c05a0e86093ef4