### PR TITLE
Add spec contracts link to documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Lightweight PHP form handler for WordPress.
 ## Documentation
 
 - [Electronic Forms Spec](docs/electronic_forms_SPEC.md) details the end-to-end submission, security, and rendering requirements the plugin must meet.
+- [Spec Contracts](docs/SPEC_CONTRACTS.md) defines the canonicality hierarchy and helper contract rules the rest of the docs rely on.
 - [Roadmap](docs/roadmap.md) highlights upcoming milestones, outstanding work, and longer-term ideas.
 - [Documentation Guide](docs/README.md) explains how the documentation set is organized and where to find generated excerpts.
 


### PR DESCRIPTION
## Summary
- add a documentation bullet that links to docs/SPEC_CONTRACTS.md and describes its focus on canonicality and helper contracts
- keep the documentation list order consistent from core spec through supporting references

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda82bc23c832d8a82e65c7e6cc02e